### PR TITLE
WIP Add external symbols for typechecking

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -23,6 +23,7 @@ import { Documentation } from '../documentation/Documentation';
 import { Links } from '../utils/Constants';
 import AceRange from './EditorAceRange';
 import { Position } from './EditorTypes';
+import { externalLibraries } from '../application/types/ExternalTypes';
 
 /**
  * @property editorValue - The string content of the react-ace editor
@@ -424,6 +425,10 @@ class Editor extends React.PureComponent<EditorProps, {}> {
   private handleTypeInferenceDisplay = (): void => {
     const chapter = this.props.sourceChapter;
     const code = this.props.editorValue;
+    const externals =
+      this.props.externalLibraryName === undefined
+        ? []
+        : externalLibraries.get(this.props.externalLibraryName);
     const editor = this.AceEditor.current!.editor;
     const pos = editor.getCursorPosition();
     const token = editor.session.getTokenAt(pos.row, pos.column);
@@ -448,7 +453,7 @@ class Editor extends React.PureComponent<EditorProps, {}> {
         }
         const str = getTypeInformation(
           code,
-          createContext(chapter),
+          createContext(chapter, 'default', externals),
           { line: pos.row + 1, column: pos.column },
           token.value
         );


### PR DESCRIPTION
### for testing, needs a js-slang push first

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to Test

Load a library using the dropdown (and not by `import`), type a constant from that library and ctrl shift m to typecheck. There should not be an error saying that it is undefined.

### Checklist

- [x] I have tested this code
