### PR TITLE
SICPJS: Fix minor bugs

### DIFF
--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -1,5 +1,6 @@
 import { Blockquote, Code, H1, OL, Pre, UL } from '@blueprintjs/core';
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Constants from 'src/commons/utils/Constants';
 import SicpExercise from 'src/pages/sicp/subcomponents/SicpExercise';
 import SicpLatex from 'src/pages/sicp/subcomponents/SicpLatex';
@@ -53,9 +54,9 @@ const handleFootnote = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
 
 const handleRef = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
   return (
-    <a ref={ref => (refs.current[obj['id']!] = ref)} href={obj['href']}>
+    <Link ref={ref => (refs.current[obj['id']!] = ref)} to={obj['href']!}>
       {obj['body']}
-    </a>
+    </Link>
   );
 };
 
@@ -216,7 +217,9 @@ export const processingFunctions = {
 
   LI: (obj: JsonType, refs: React.MutableRefObject<{}>) => <li>{parseArr(obj['child']!, refs)}</li>,
 
-  LINK: handleRef,
+  LINK: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
+    <a href={obj['href']}>{obj['body']}</a>
+  ),
 
   META: (obj: JsonType, _refs: React.MutableRefObject<{}>) => <em>{obj['body']}</em>,
 

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -174,7 +174,7 @@ const handleContainer = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
 };
 
 const handleReference = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
-  return <div>{parseArr(obj['child']!, refs)}</div>;
+  return <div className="sicp-reference">{parseArr(obj['child']!, refs)}</div>;
 };
 
 const handleText = (text: string) => {

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -220,7 +220,7 @@ export const processingFunctions = {
 
   LINK: handleRef,
 
-  LaTeX: (_obj: JsonType, _refs: React.MutableRefObject<{}>) => handleText('LaTeX'),
+  LaTeX: (_obj: JsonType, _refs: React.MutableRefObject<{}>) => handleLatex('$\\LaTeX$'),
 
   META: (obj: JsonType, _refs: React.MutableRefObject<{}>) => <em>{obj['body']}</em>,
 
@@ -267,7 +267,7 @@ export const processingFunctions = {
     <Code>{parseArr(obj['child']!, refs)}</Code>
   ),
 
-  TeX: (_obj: JsonType, _refs: React.MutableRefObject<{}>) => handleText('TeX'),
+  TeX: (_obj: JsonType, _refs: React.MutableRefObject<{}>) => handleLatex('$\\TeX$'),
 
   UL: (obj: JsonType, refs: React.MutableRefObject<{}>) => <UL>{parseArr(obj['child']!, refs)}</UL>
 };

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -214,13 +214,9 @@ export const processingFunctions = {
 
   LATEX: (obj: JsonType, _refs: React.MutableRefObject<{}>) => handleLatex(obj['body']!),
 
-  LATEXINLINE: (obj: JsonType, _refs: React.MutableRefObject<{}>) => handleLatex(obj['body']!),
-
   LI: (obj: JsonType, refs: React.MutableRefObject<{}>) => <li>{parseArr(obj['child']!, refs)}</li>,
 
   LINK: handleRef,
-
-  LaTeX: (_obj: JsonType, _refs: React.MutableRefObject<{}>) => handleLatex('$\\LaTeX$'),
 
   META: (obj: JsonType, _refs: React.MutableRefObject<{}>) => <em>{obj['body']}</em>,
 
@@ -266,8 +262,6 @@ export const processingFunctions = {
   TT: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
     <Code>{parseArr(obj['child']!, refs)}</Code>
   ),
-
-  TeX: (_obj: JsonType, _refs: React.MutableRefObject<{}>) => handleLatex('$\\TeX$'),
 
   UL: (obj: JsonType, refs: React.MutableRefObject<{}>) => <UL>{parseArr(obj['child']!, refs)}</UL>
 };

--- a/src/features/sicp/parser/__tests__/ParseJson.tsx
+++ b/src/features/sicp/parser/__tests__/ParseJson.tsx
@@ -7,9 +7,8 @@ import { JsonType, parseArr, ParseJsonError, parseObj, processingFunctions } fro
 // Tags to process
 const headingTags = ['SUBHEADING', 'SUBSUBHEADING'];
 const listTags = ['OL', 'UL'];
-const symbolTags = ['BR', 'LaTeX', 'TeX'];
+const symbolTags = ['BR'];
 const stylingTags = ['B', 'EM', 'JAVASCRIPTINLINE', 'TT', 'META'];
-const latexTags = ['LATEX', 'LATEXINLINE'];
 const linkTags = ['LINK', 'REF', 'FOOTNOTE_REF'];
 
 const epigraphTag = 'EPIGRAPH';
@@ -21,6 +20,7 @@ const figureTag = 'FIGURE';
 const displayFootnoteTag = 'DISPLAYFOOTNOTE';
 const referenceTag = 'REFERENCE';
 const textTag = '#text';
+const latexTag = 'LATEX';
 const unknownTag = 'unknown';
 
 jest.mock('src/commons/utils/Constants', () => ({
@@ -287,13 +287,16 @@ describe('Parse footnote', () => {
 });
 
 describe('Parse latex', () => {
-  const tag = latexTags;
-  const math = '$test$';
-  const obj = {
-    body: math
+  const tag = latexTag;
+  const inline = {
+    body: '$test$'
+  };
+  const block = {
+    body: '\\[test\\]'
   };
 
-  tag.forEach(tag => testTagSuccessful(obj, tag, ''));
+  testTagSuccessful(inline, tag, 'inline');
+  testTagSuccessful(block, tag, 'block');
 });
 
 describe('Parse links', () => {

--- a/src/features/sicp/parser/__tests__/ParseJson.tsx
+++ b/src/features/sicp/parser/__tests__/ParseJson.tsx
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import lzString from 'lz-string';
+import { BrowserRouter } from 'react-router-dom';
 import { CodeSnippetProps } from 'src/pages/sicp/subcomponents/CodeSnippet';
 
 import { JsonType, parseArr, ParseJsonError, parseObj, processingFunctions } from '../ParseJson';
@@ -309,7 +310,13 @@ describe('Parse links', () => {
     href: href
   };
 
-  tag.forEach(tag => testTagSuccessful(obj, tag));
+  tag.forEach(tag => {
+    test(tag + ' successful', () => {
+      const tree = mount(<BrowserRouter>{processTag(tag, obj)}</BrowserRouter>);
+
+      expect(tree.debug()).toMatchSnapshot();
+    });
+  });
 });
 
 describe('Parse reference', () => {

--- a/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
+++ b/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
@@ -301,7 +301,7 @@ exports[`Parse object no tag 1`] = `"Mock Text"`;
 exports[`Parse object successful 1`] = `"Mock Text"`;
 
 exports[`Parse reference REFERENCE  successful 1`] = `
-"<div>
+"<div className=\\"sicp-reference\\">
   Mock Text
 </div>"
 `;

--- a/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
+++ b/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
@@ -405,9 +405,21 @@ exports[`Parse styling TT  successful 1`] = `
 
 exports[`Parse symbol BR  successful 1`] = `"<br />"`;
 
-exports[`Parse symbol LaTeX  successful 1`] = `"LaTeX"`;
+exports[`Parse symbol LaTeX  successful 1`] = `
+"<SicpLatex math=\\"$\\\\\\\\LaTeX$\\">
+  <Latex delimiters={{...}} strict={false}>
+    <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
+  </Latex>
+</SicpLatex>"
+`;
 
-exports[`Parse symbol TeX  successful 1`] = `"TeX"`;
+exports[`Parse symbol TeX  successful 1`] = `
+"<SicpLatex math=\\"$\\\\\\\\TeX$\\">
+  <Latex delimiters={{...}} strict={false}>
+    <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
+  </Latex>
+</SicpLatex>"
+`;
 
 exports[`Parse table TABLE  successful 1`] = `
 "<table>

--- a/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
+++ b/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
@@ -240,15 +240,15 @@ exports[`Parse heading SUBSUBHEADING  successful 1`] = `
 </h4>"
 `;
 
-exports[`Parse latex LATEX  successful 1`] = `
-"<SicpLatex math=\\"$test$\\">
+exports[`Parse latex LATEX block successful 1`] = `
+"<SicpLatex math=\\"\\\\\\\\[test\\\\\\\\]\\">
   <Latex delimiters={{...}} strict={false}>
     <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
   </Latex>
 </SicpLatex>"
 `;
 
-exports[`Parse latex LATEXINLINE  successful 1`] = `
+exports[`Parse latex LATEX inline successful 1`] = `
 "<SicpLatex math=\\"$test$\\">
   <Latex delimiters={{...}} strict={false}>
     <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
@@ -404,22 +404,6 @@ exports[`Parse styling TT  successful 1`] = `
 `;
 
 exports[`Parse symbol BR  successful 1`] = `"<br />"`;
-
-exports[`Parse symbol LaTeX  successful 1`] = `
-"<SicpLatex math=\\"$\\\\\\\\LaTeX$\\">
-  <Latex delimiters={{...}} strict={false}>
-    <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
-  </Latex>
-</SicpLatex>"
-`;
-
-exports[`Parse symbol TeX  successful 1`] = `
-"<SicpLatex math=\\"$\\\\\\\\TeX$\\">
-  <Latex delimiters={{...}} strict={false}>
-    <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
-  </Latex>
-</SicpLatex>"
-`;
 
 exports[`Parse table TABLE  successful 1`] = `
 "<table>

--- a/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
+++ b/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
@@ -256,24 +256,44 @@ exports[`Parse latex LATEX inline successful 1`] = `
 </SicpLatex>"
 `;
 
-exports[`Parse links FOOTNOTE_REF  successful 1`] = `
-"<sup>
-  <a href=\\"bad-link\\">
-    link
-  </a>
-</sup>"
+exports[`Parse links FOOTNOTE_REF successful 1`] = `
+"<BrowserRouter>
+  <Router history={{...}}>
+    <sup>
+      <Link to=\\"bad-link\\">
+        <LinkAnchor href=\\"/bad-link\\" navigate={[Function: navigate]}>
+          <a href=\\"/bad-link\\" onClick={[Function: onClick]}>
+            link
+          </a>
+        </LinkAnchor>
+      </Link>
+    </sup>
+  </Router>
+</BrowserRouter>"
 `;
 
-exports[`Parse links LINK  successful 1`] = `
-"<a href=\\"bad-link\\">
-  link
-</a>"
+exports[`Parse links LINK successful 1`] = `
+"<BrowserRouter>
+  <Router history={{...}}>
+    <a href=\\"bad-link\\">
+      link
+    </a>
+  </Router>
+</BrowserRouter>"
 `;
 
-exports[`Parse links REF  successful 1`] = `
-"<a href=\\"bad-link\\">
-  link
-</a>"
+exports[`Parse links REF successful 1`] = `
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Link to=\\"bad-link\\">
+      <LinkAnchor href=\\"/bad-link\\" navigate={[Function: navigate]}>
+        <a href=\\"/bad-link\\" onClick={[Function: onClick]}>
+          link
+        </a>
+      </LinkAnchor>
+    </Link>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse list OL  successful 1`] = `

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -272,6 +272,10 @@ $sicp-content-lr-padding: 6em;
       }
     }
   }
+
+  .sicp-reference {
+    margin-bottom: 1.5rem;
+  }
 }
 
 // Styles for sicp table of contents


### PR DESCRIPTION
### Description
Do not merge before source-academy/sicp#552.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Add spacing between references, fixes source-academy/sicp#551. 
<img width="912" alt="Screenshot 2021-07-01 at 8 07 33 PM" src="https://user-images.githubusercontent.com/60355570/124121853-fb926100-daa7-11eb-8345-cf79da48ef5e.png">

- Change internal links to use react router link instead of `a` tag.
- Code quality improvements - Simplify parsing of latex tags.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Check references have better spacing now.
- Internal links still work. (e.g. links to footnote, ex, section)
- Latex is parsed correctly.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
