### PR TITLE
SICP-JS: Add anchor links feature

### DIFF
--- a/src/features/sicp/TableOfContentsButton.tsx
+++ b/src/features/sicp/TableOfContentsButton.tsx
@@ -1,5 +1,3 @@
-import { IconNames } from '@blueprintjs/icons';
-
 import controlButton from '../../commons/ControlButton';
 
 type TableOfContentsButtonProps = OwnProps;
@@ -10,5 +8,5 @@ type OwnProps = {
 };
 
 export function TableOfContentsButton(props: TableOfContentsButtonProps) {
-  return controlButton('Table of Contents', IconNames.MENU, props.handleOpenToc);
+  return controlButton('Table of Contents', null, props.handleOpenToc);
 }

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -50,7 +50,7 @@ type AnchorLinkType = {
 const AnchorLink: React.FC<AnchorLinkType> = props => {
   const { refs, id, children, top } = props;
   return (
-    <>
+    <div className="sicp-anchor-link-container">
       {id && (
         <Link
           className="sicp-anchor-link"
@@ -62,7 +62,7 @@ const AnchorLink: React.FC<AnchorLinkType> = props => {
         </Link>
       )}
       {children}
-    </>
+    </div>
   );
 };
 

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -44,14 +44,20 @@ type AnchorLinkType = {
   children: React.ReactNode;
   id: string | undefined;
   refs: React.MutableRefObject<{}>;
+  top: number;
 };
 
 const AnchorLink: React.FC<AnchorLinkType> = props => {
-  const { refs, id, children } = props;
+  const { refs, id, children, top } = props;
   return (
     <>
       {id && (
-        <Link className="sicp-anchor-link" ref={ref => (refs.current[id] = ref)} to={id}>
+        <Link
+          className="sicp-anchor-link"
+          style={{ top: top }}
+          ref={ref => (refs.current[id] = ref)}
+          to={id}
+        >
           <Icon icon={IconNames.LINK} />
         </Link>
       )}
@@ -135,16 +141,17 @@ const handleSnippet = (obj: JsonType) => {
 };
 
 const handleFigure = (obj: JsonType, refs: React.MutableRefObject<{}>) => (
-  <div className="sicp-figure">
-    <div ref={ref => (refs.current[obj['id']!] = ref)} />
-    {handleImage(obj, refs)}
-    {obj['captionName'] && (
-      <h5 className="sicp-caption">
-        {obj['captionName']}
-        {parseArr(obj['captionBody']!, refs)}
-      </h5>
-    )}
-  </div>
+  <AnchorLink id={obj['id']} refs={refs} top={36}>
+    <div className="sicp-figure">
+      {handleImage(obj, refs)}
+      {obj['captionName'] && (
+        <h5 className="sicp-caption">
+          {obj['captionName']}
+          {parseArr(obj['captionBody']!, refs)}
+        </h5>
+      )}
+    </div>
+  </AnchorLink>
 );
 
 const handleImage = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
@@ -274,7 +281,7 @@ export const processingFunctions = {
   ),
 
   TEXT: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
-    <AnchorLink id={obj['id']} refs={refs}>
+    <AnchorLink id={obj['id']} refs={refs} top={-3}>
       <div className="sicp-text">{parseArr(obj['child']!, refs)}</div>
       <br />
     </AnchorLink>

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -230,7 +230,7 @@ export const processingFunctions = {
   FIGURE: handleFigure,
 
   FOOTNOTE_REF: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
-    <sup>{handleRef(obj, refs)}</sup>
+    <sup ref={ref => (refs.current[obj['id']!] = ref)}>{handleRef(obj, refs)}</sup>
   ),
 
   JAVASCRIPTINLINE: (obj: JsonType, _refs: React.MutableRefObject<{}>) => (

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -192,12 +192,11 @@ const handleExercise = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
   );
 };
 
-const handleContainer = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
+const handleTitle = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
   return (
-    <div>
-      {obj['body'] && <H1>{obj['body']!}</H1>}
-      <div>{parseArr(obj['child']!, refs)}</div>
-    </div>
+    <AnchorLink id={obj['id']} refs={refs} top={6}>
+      <H1>{obj['body']!}</H1>
+    </AnchorLink>
   );
 };
 
@@ -219,8 +218,6 @@ export const processingFunctions = {
   B: (obj: JsonType, refs: React.MutableRefObject<{}>) => <b>{parseArr(obj['child']!, refs)}</b>,
 
   BR: (_obj: JsonType, _refs: React.MutableRefObject<{}>) => <br />,
-
-  CHAPTER: handleContainer,
 
   DISPLAYFOOTNOTE: handleFootnote,
 
@@ -256,21 +253,21 @@ export const processingFunctions = {
 
   REFERENCE: handleReference,
 
-  SECTION: handleContainer,
-
   SNIPPET: (obj: JsonType, _refs: React.MutableRefObject<{}>) => handleSnippet(obj),
 
   SUBHEADING: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
-    <h2 className="bp3-heading" ref={ref => (refs.current[obj['id']!] = ref)}>
-      {parseArr(obj['child']!, refs)}
-    </h2>
+    <AnchorLink id={obj['id']} refs={refs} top={2}>
+      <h2 className="bp3-heading">{parseArr(obj['child']!, refs)}</h2>
+    </AnchorLink>
   ),
 
   SUBSUBHEADING: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
-    <h4 className="bp3-heading" ref={ref => (refs.current[obj['id']!] = ref)}>
-      <br />
-      {parseArr(obj['child']!, refs)}
-    </h4>
+    <AnchorLink id={obj['id']} refs={refs} top={16}>
+      <h4 className="bp3-heading">
+        <br />
+        {parseArr(obj['child']!, refs)}
+      </h4>
+    </AnchorLink>
   ),
 
   TABLE: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
@@ -285,6 +282,8 @@ export const processingFunctions = {
       <br />
     </AnchorLink>
   ),
+
+  TITLE: handleTitle,
 
   TT: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
     <Code>{parseArr(obj['child']!, refs)}</Code>

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -1,4 +1,5 @@
-import { Blockquote, Code, H1, OL, Pre, UL } from '@blueprintjs/core';
+import { Blockquote, Code, H1, Icon, OL, Pre, UL } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import Constants from 'src/commons/utils/Constants';
@@ -37,6 +38,26 @@ export type JsonType = {
   count?: integer;
   eval?: boolean;
   prependLength?: number;
+};
+
+type AnchorLinkType = {
+  children: React.ReactNode;
+  id: string | undefined;
+  refs: React.MutableRefObject<{}>;
+};
+
+const AnchorLink: React.FC<AnchorLinkType> = props => {
+  const { refs, id, children } = props;
+  return (
+    <>
+      {id && (
+        <Link className="sicp-anchor-link" ref={ref => (refs.current[id] = ref)} to={id}>
+          <Icon icon={IconNames.LINK} />
+        </Link>
+      )}
+      {children}
+    </>
+  );
 };
 
 const handleFootnote = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
@@ -253,13 +274,10 @@ export const processingFunctions = {
   ),
 
   TEXT: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
-    <>
-      <div className="sicp-text">
-        <div ref={ref => (refs.current[obj['id']!] = ref)} />
-        {parseArr(obj['child']!, refs)}
-      </div>
+    <AnchorLink id={obj['id']} refs={refs}>
+      <div className="sicp-text">{parseArr(obj['child']!, refs)}</div>
       <br />
-    </>
+    </AnchorLink>
   ),
 
   TT: (obj: JsonType, refs: React.MutableRefObject<{}>) => (

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -182,14 +182,13 @@ const handleTD = (obj: JsonType, refs: React.MutableRefObject<{}>, index: intege
 
 const handleExercise = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
   return (
-    <div>
-      <div ref={ref => (refs.current[obj['id']!] = ref)} />
+    <AnchorLink id={obj['id']} refs={refs} top={5}>
       <SicpExercise
         title={obj['title']!}
         body={parseArr(obj['child']!, refs)}
         solution={obj['solution'] && parseArr(obj['solution'], refs)}
       />
-    </div>
+    </AnchorLink>
   );
 };
 

--- a/src/features/sicp/parser/__tests__/ParseJson.tsx
+++ b/src/features/sicp/parser/__tests__/ParseJson.tsx
@@ -15,7 +15,7 @@ const linkTags = ['LINK', 'REF', 'FOOTNOTE_REF'];
 const epigraphTag = 'EPIGRAPH';
 const tableTag = 'TABLE';
 const exerciseTag = 'EXERCISE';
-const sectionTag = 'SECTION';
+const titleTag = 'TITLE';
 const snippetTag = 'SNIPPET';
 const figureTag = 'FIGURE';
 const displayFootnoteTag = 'DISPLAYFOOTNOTE';
@@ -56,7 +56,7 @@ const processTag = (tag: string, obj: JsonType) => {
 
 const testTagSuccessful = (obj: JsonType, tag: string, text: string = '') => {
   test(tag + ' ' + text + ' successful', () => {
-    const tree = mount(processTag(tag, obj));
+    const tree = mount(<BrowserRouter>{processTag(tag, obj)}</BrowserRouter>);
 
     expect(tree.debug()).toMatchSnapshot();
   });
@@ -76,11 +76,9 @@ describe('Parse heading', () => {
   tags.forEach(x => testTagSuccessful(obj, x));
 });
 
-describe('Parse section', () => {
-  const tag = sectionTag;
-  const text = { tag: 'TEXT', child: [mockData['text'], mockData['text']] };
-  const content = [text, text];
-  const obj = { body: 'Title', child: content };
+describe('Parse title', () => {
+  const tag = titleTag;
+  const obj = { body: 'Title' };
 
   testTagSuccessful(obj, tag);
 });
@@ -311,11 +309,7 @@ describe('Parse links', () => {
   };
 
   tag.forEach(tag => {
-    test(tag + ' successful', () => {
-      const tree = mount(<BrowserRouter>{processTag(tag, obj)}</BrowserRouter>);
-
-      expect(tree.debug()).toMatchSnapshot();
-    });
+    testTagSuccessful(obj, tag);
   });
 });
 

--- a/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
+++ b/src/features/sicp/parser/__tests__/__snapshots__/ParseJson.tsx.snap
@@ -12,251 +12,403 @@ Mock Text"
 `;
 
 exports[`Parse epigraph EPIGRAPH with all successful 1`] = `
-"<Component className=\\"sicp-epigraph\\">
-  <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
-    Mock Text
-    <div className=\\"sicp-attribution\\">
-      -
-      Author
-      <i>
-        Title
-      </i>
-      2021
-    </div>
-  </blockquote>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component className=\\"sicp-epigraph\\">
+      <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
+        Mock Text
+        <div className=\\"sicp-attribution\\">
+          -
+          Author
+          <i>
+            Title
+          </i>
+          2021
+        </div>
+      </blockquote>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse epigraph EPIGRAPH with author successful 1`] = `
-"<Component className=\\"sicp-epigraph\\">
-  <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
-    Mock Text
-    <div className=\\"sicp-attribution\\">
-      -
-      Author
-    </div>
-  </blockquote>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component className=\\"sicp-epigraph\\">
+      <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
+        Mock Text
+        <div className=\\"sicp-attribution\\">
+          -
+          Author
+        </div>
+      </blockquote>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse epigraph EPIGRAPH with date successful 1`] = `
-"<Component className=\\"sicp-epigraph\\">
-  <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
-    Mock Text
-    <div className=\\"sicp-attribution\\">
-      -
-      2021
-    </div>
-  </blockquote>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component className=\\"sicp-epigraph\\">
+      <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
+        Mock Text
+        <div className=\\"sicp-attribution\\">
+          -
+          2021
+        </div>
+      </blockquote>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse epigraph EPIGRAPH with none successful 1`] = `
-"<Component className=\\"sicp-epigraph\\">
-  <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
-    Mock Text
-  </blockquote>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component className=\\"sicp-epigraph\\">
+      <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
+        Mock Text
+      </blockquote>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse epigraph EPIGRAPH with title successful 1`] = `
-"<Component className=\\"sicp-epigraph\\">
-  <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
-    Mock Text
-    <div className=\\"sicp-attribution\\">
-      -
-      <i>
-        Title
-      </i>
-    </div>
-  </blockquote>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component className=\\"sicp-epigraph\\">
+      <blockquote className=\\"bp3-blockquote sicp-epigraph\\">
+        Mock Text
+        <div className=\\"sicp-attribution\\">
+          -
+          <i>
+            Title
+          </i>
+        </div>
+      </blockquote>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse exercise EXERCISE with solution successful 1`] = `
-"<div>
-  <div />
-  <SicpExercise title={[undefined]} body={{...}} solution={{...}}>
-    <Blueprint3.Card className=\\"sicp-exercise\\" interactive={false} elevation={1}>
-      <div className=\\"bp3-card bp3-elevation-1 sicp-exercise\\">
-        <b />
-        <div />
-        <div className=\\"sicp-button-container\\">
-          <Blueprint3.Button onClick={[Function: onClick]} large={true} className=\\"sicp-show-solution-button\\">
-            <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-large sicp-show-solution-button\\" disabled={[undefined]} onBlur={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-              <Blueprint3.Icon icon={[undefined]} />
-              <span className=\\"bp3-button-text\\">
-                Show Solution
-              </span>
-              <Blueprint3.Icon icon={[undefined]} />
-            </button>
-          </Blueprint3.Button>
-        </div>
-        <Blueprint3.Collapse className=\\"sicp-solution\\" isOpen={false} component=\\"div\\" keepChildrenMounted={false} transitionDuration={200}>
-          <div className=\\"bp3-collapse sicp-solution\\" style={{...}}>
-            <div className=\\"bp3-collapse-body\\" style={{...}} aria-hidden={false} />
-          </div>
-        </Blueprint3.Collapse>
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id={[undefined]} refs={{...}} top={5}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <SicpExercise title={[undefined]} body={{...}} solution={{...}}>
+          <Blueprint3.Card className=\\"sicp-exercise\\" interactive={false} elevation={1}>
+            <div className=\\"bp3-card bp3-elevation-1 sicp-exercise\\">
+              <b />
+              <div />
+              <div className=\\"sicp-button-container\\">
+                <Blueprint3.Button onClick={[Function: onClick]} large={true} className=\\"sicp-show-solution-button\\">
+                  <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-large sicp-show-solution-button\\" disabled={[undefined]} onBlur={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
+                    <Blueprint3.Icon icon={[undefined]} />
+                    <span className=\\"bp3-button-text\\">
+                      Show Solution
+                    </span>
+                    <Blueprint3.Icon icon={[undefined]} />
+                  </button>
+                </Blueprint3.Button>
+              </div>
+              <Blueprint3.Collapse className=\\"sicp-solution\\" isOpen={false} component=\\"div\\" keepChildrenMounted={false} transitionDuration={200}>
+                <div className=\\"bp3-collapse sicp-solution\\" style={{...}}>
+                  <div className=\\"bp3-collapse-body\\" style={{...}} aria-hidden={false} />
+                </div>
+              </Blueprint3.Collapse>
+            </div>
+          </Blueprint3.Card>
+        </SicpExercise>
       </div>
-    </Blueprint3.Card>
-  </SicpExercise>
-</div>"
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse exercise EXERCISE without solution successful 1`] = `
-"<div>
-  <div />
-  <SicpExercise title=\\"Title\\" body={{...}} solution={[undefined]}>
-    <Blueprint3.Card className=\\"sicp-exercise\\" interactive={false} elevation={1}>
-      <div className=\\"bp3-card bp3-elevation-1 sicp-exercise\\">
-        <b>
-          Title
-        </b>
-        <div>
-          Mock Text
-        </div>
-        <div className=\\"sicp-button-container\\">
-          <Blueprint3.Button onClick={[Function: onClick]} large={true} className=\\"sicp-show-solution-button\\">
-            <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-large sicp-show-solution-button\\" disabled={[undefined]} onBlur={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
-              <Blueprint3.Icon icon={[undefined]} />
-              <span className=\\"bp3-button-text\\">
-                Show Solution
-              </span>
-              <Blueprint3.Icon icon={[undefined]} />
-            </button>
-          </Blueprint3.Button>
-        </div>
-        <Blueprint3.Collapse className=\\"sicp-solution\\" isOpen={false} component=\\"div\\" keepChildrenMounted={false} transitionDuration={200}>
-          <div className=\\"bp3-collapse sicp-solution\\" style={{...}}>
-            <div className=\\"bp3-collapse-body\\" style={{...}} aria-hidden={false} />
-          </div>
-        </Blueprint3.Collapse>
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id={[undefined]} refs={{...}} top={5}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <SicpExercise title=\\"Title\\" body={{...}} solution={[undefined]}>
+          <Blueprint3.Card className=\\"sicp-exercise\\" interactive={false} elevation={1}>
+            <div className=\\"bp3-card bp3-elevation-1 sicp-exercise\\">
+              <b>
+                Title
+              </b>
+              <div>
+                Mock Text
+              </div>
+              <div className=\\"sicp-button-container\\">
+                <Blueprint3.Button onClick={[Function: onClick]} large={true} className=\\"sicp-show-solution-button\\">
+                  <button type=\\"button\\" onClick={[Function: onClick]} className=\\"bp3-button bp3-large sicp-show-solution-button\\" disabled={[undefined]} onBlur={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
+                    <Blueprint3.Icon icon={[undefined]} />
+                    <span className=\\"bp3-button-text\\">
+                      Show Solution
+                    </span>
+                    <Blueprint3.Icon icon={[undefined]} />
+                  </button>
+                </Blueprint3.Button>
+              </div>
+              <Blueprint3.Collapse className=\\"sicp-solution\\" isOpen={false} component=\\"div\\" keepChildrenMounted={false} transitionDuration={200}>
+                <div className=\\"bp3-collapse sicp-solution\\" style={{...}}>
+                  <div className=\\"bp3-collapse-body\\" style={{...}} aria-hidden={false} />
+                </div>
+              </Blueprint3.Collapse>
+            </div>
+          </Blueprint3.Card>
+        </SicpExercise>
       </div>
-    </Blueprint3.Card>
-  </SicpExercise>
-</div>"
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse figures FIGURE with image and scale successful 1`] = `
-"<div className=\\"sicp-figure\\">
-  <div />
-  <img src=\\"https://source-academy.github.io/sicp/sicp.png\\" alt=\\"id\\" width=\\"50%\\" />
-  <h5 className=\\"sicp-caption\\">
-    name
-    Mock Text
-  </h5>
-</div>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id=\\"id\\" refs={{...}} top={36}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <Link className=\\"sicp-anchor-link\\" style={{...}} to=\\"id\\">
+          <LinkAnchor className=\\"sicp-anchor-link\\" style={{...}} href=\\"/id\\" navigate={[Function: navigate]}>
+            <a className=\\"sicp-anchor-link\\" style={{...}} href=\\"/id\\" onClick={[Function: onClick]}>
+              <Blueprint3.Icon icon=\\"link\\">
+                <span icon=\\"link\\" className=\\"bp3-icon bp3-icon-link\\" title={[undefined]}>
+                  <svg fill={[undefined]} data-icon=\\"link\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                    <desc>
+                      link
+                    </desc>
+                    <path d=\\"M4.99 11.99c.28 0 .53-.11.71-.29l6-6a1.003 1.003 0 00-1.42-1.42l-6 6a1.003 1.003 0 00.71 1.71zm3.85-2.02L6.4 12.41l-1 1-.01-.01c-.36.36-.85.6-1.4.6-1.1 0-2-.9-2-2 0-.55.24-1.04.6-1.4l-.01-.01 1-1 2.44-2.44c-.33-.1-.67-.16-1.03-.16-1.1 0-2.09.46-2.81 1.19l-.02-.02-1 1 .02.02c-.73.72-1.19 1.71-1.19 2.81 0 2.21 1.79 4 4 4 1.1 0 2.09-.46 2.81-1.19l.02.02 1-1-.02-.02c.73-.72 1.19-1.71 1.19-2.81 0-.35-.06-.69-.15-1.02zm7.15-5.98c0-2.21-1.79-4-4-4-1.1 0-2.09.46-2.81 1.19l-.02-.02-1 1 .02.02c-.72.72-1.19 1.71-1.19 2.81 0 .36.06.69.15 1.02l2.44-2.44 1-1 .01.01c.36-.36.85-.6 1.4-.6 1.1 0 2 .9 2 2 0 .55-.24 1.04-.6 1.4l.01.01-1 1-2.43 2.45c.33.09.67.15 1.02.15 1.1 0 2.09-.46 2.81-1.19l.02.02 1-1-.02-.02a3.92 3.92 0 001.19-2.81z\\" fillRule=\\"evenodd\\" />
+                  </svg>
+                </span>
+              </Blueprint3.Icon>
+            </a>
+          </LinkAnchor>
+        </Link>
+        <div className=\\"sicp-figure\\">
+          <img src=\\"https://source-academy.github.io/sicp/sicp.png\\" alt=\\"id\\" width=\\"50%\\" />
+          <h5 className=\\"sicp-caption\\">
+            name
+            Mock Text
+          </h5>
+        </div>
+      </div>
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse figures FIGURE with image successful 1`] = `
-"<div className=\\"sicp-figure\\">
-  <div />
-  <img src=\\"https://source-academy.github.io/sicp/sicp.png\\" alt=\\"id\\" width=\\"100%\\" />
-  <h5 className=\\"sicp-caption\\">
-    name
-    Mock Text
-  </h5>
-</div>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id=\\"id\\" refs={{...}} top={36}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <Link className=\\"sicp-anchor-link\\" style={{...}} to=\\"id\\">
+          <LinkAnchor className=\\"sicp-anchor-link\\" style={{...}} href=\\"/id\\" navigate={[Function: navigate]}>
+            <a className=\\"sicp-anchor-link\\" style={{...}} href=\\"/id\\" onClick={[Function: onClick]}>
+              <Blueprint3.Icon icon=\\"link\\">
+                <span icon=\\"link\\" className=\\"bp3-icon bp3-icon-link\\" title={[undefined]}>
+                  <svg fill={[undefined]} data-icon=\\"link\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                    <desc>
+                      link
+                    </desc>
+                    <path d=\\"M4.99 11.99c.28 0 .53-.11.71-.29l6-6a1.003 1.003 0 00-1.42-1.42l-6 6a1.003 1.003 0 00.71 1.71zm3.85-2.02L6.4 12.41l-1 1-.01-.01c-.36.36-.85.6-1.4.6-1.1 0-2-.9-2-2 0-.55.24-1.04.6-1.4l-.01-.01 1-1 2.44-2.44c-.33-.1-.67-.16-1.03-.16-1.1 0-2.09.46-2.81 1.19l-.02-.02-1 1 .02.02c-.73.72-1.19 1.71-1.19 2.81 0 2.21 1.79 4 4 4 1.1 0 2.09-.46 2.81-1.19l.02.02 1-1-.02-.02c.73-.72 1.19-1.71 1.19-2.81 0-.35-.06-.69-.15-1.02zm7.15-5.98c0-2.21-1.79-4-4-4-1.1 0-2.09.46-2.81 1.19l-.02-.02-1 1 .02.02c-.72.72-1.19 1.71-1.19 2.81 0 .36.06.69.15 1.02l2.44-2.44 1-1 .01.01c.36-.36.85-.6 1.4-.6 1.1 0 2 .9 2 2 0 .55-.24 1.04-.6 1.4l.01.01-1 1-2.43 2.45c.33.09.67.15 1.02.15 1.1 0 2.09-.46 2.81-1.19l.02.02 1-1-.02-.02a3.92 3.92 0 001.19-2.81z\\" fillRule=\\"evenodd\\" />
+                  </svg>
+                </span>
+              </Blueprint3.Icon>
+            </a>
+          </LinkAnchor>
+        </Link>
+        <div className=\\"sicp-figure\\">
+          <img src=\\"https://source-academy.github.io/sicp/sicp.png\\" alt=\\"id\\" width=\\"100%\\" />
+          <h5 className=\\"sicp-caption\\">
+            name
+            Mock Text
+          </h5>
+        </div>
+      </div>
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse figures FIGURE with snippet successful 1`] = `
-"<div className=\\"sicp-figure\\">
-  <div />
-  <Component body=\\"1 + 1;\\" id={[undefined]} initialEditorValueHash={[undefined]} prependLength={[undefined]} output={[undefined]}>
-    <div>
-      Code Snippet
-    </div>
-  </Component>
-  <h5 className=\\"sicp-caption\\">
-    name
-    Mock Text
-  </h5>
-</div>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id=\\"id\\" refs={{...}} top={36}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <Link className=\\"sicp-anchor-link\\" style={{...}} to=\\"id\\">
+          <LinkAnchor className=\\"sicp-anchor-link\\" style={{...}} href=\\"/id\\" navigate={[Function: navigate]}>
+            <a className=\\"sicp-anchor-link\\" style={{...}} href=\\"/id\\" onClick={[Function: onClick]}>
+              <Blueprint3.Icon icon=\\"link\\">
+                <span icon=\\"link\\" className=\\"bp3-icon bp3-icon-link\\" title={[undefined]}>
+                  <svg fill={[undefined]} data-icon=\\"link\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                    <desc>
+                      link
+                    </desc>
+                    <path d=\\"M4.99 11.99c.28 0 .53-.11.71-.29l6-6a1.003 1.003 0 00-1.42-1.42l-6 6a1.003 1.003 0 00.71 1.71zm3.85-2.02L6.4 12.41l-1 1-.01-.01c-.36.36-.85.6-1.4.6-1.1 0-2-.9-2-2 0-.55.24-1.04.6-1.4l-.01-.01 1-1 2.44-2.44c-.33-.1-.67-.16-1.03-.16-1.1 0-2.09.46-2.81 1.19l-.02-.02-1 1 .02.02c-.73.72-1.19 1.71-1.19 2.81 0 2.21 1.79 4 4 4 1.1 0 2.09-.46 2.81-1.19l.02.02 1-1-.02-.02c.73-.72 1.19-1.71 1.19-2.81 0-.35-.06-.69-.15-1.02zm7.15-5.98c0-2.21-1.79-4-4-4-1.1 0-2.09.46-2.81 1.19l-.02-.02-1 1 .02.02c-.72.72-1.19 1.71-1.19 2.81 0 .36.06.69.15 1.02l2.44-2.44 1-1 .01.01c.36-.36.85-.6 1.4-.6 1.1 0 2 .9 2 2 0 .55-.24 1.04-.6 1.4l.01.01-1 1-2.43 2.45c.33.09.67.15 1.02.15 1.1 0 2.09-.46 2.81-1.19l.02.02 1-1-.02-.02a3.92 3.92 0 001.19-2.81z\\" fillRule=\\"evenodd\\" />
+                  </svg>
+                </span>
+              </Blueprint3.Icon>
+            </a>
+          </LinkAnchor>
+        </Link>
+        <div className=\\"sicp-figure\\">
+          <Component body=\\"1 + 1;\\" id={[undefined]} initialEditorValueHash={[undefined]} prependLength={[undefined]} output={[undefined]}>
+            <div>
+              Code Snippet
+            </div>
+          </Component>
+          <h5 className=\\"sicp-caption\\">
+            name
+            Mock Text
+          </h5>
+        </div>
+      </div>
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse figures FIGURE with table successful 1`] = `
-"<div className=\\"sicp-figure\\">
-  <div />
-  <table>
-    <tbody>
-      <tr>
-        <td>
-          Mock Text
-        </td>
-        <td>
-          Mock Text
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Mock Text
-        </td>
-        <td>
-          Mock Text
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <h5 className=\\"sicp-caption\\">
-    name
-    Mock Text
-  </h5>
-</div>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id=\\"id\\" refs={{...}} top={36}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <Link className=\\"sicp-anchor-link\\" style={{...}} to=\\"id\\">
+          <LinkAnchor className=\\"sicp-anchor-link\\" style={{...}} href=\\"/id\\" navigate={[Function: navigate]}>
+            <a className=\\"sicp-anchor-link\\" style={{...}} href=\\"/id\\" onClick={[Function: onClick]}>
+              <Blueprint3.Icon icon=\\"link\\">
+                <span icon=\\"link\\" className=\\"bp3-icon bp3-icon-link\\" title={[undefined]}>
+                  <svg fill={[undefined]} data-icon=\\"link\\" width={16} height={16} viewBox=\\"0 0 16 16\\">
+                    <desc>
+                      link
+                    </desc>
+                    <path d=\\"M4.99 11.99c.28 0 .53-.11.71-.29l6-6a1.003 1.003 0 00-1.42-1.42l-6 6a1.003 1.003 0 00.71 1.71zm3.85-2.02L6.4 12.41l-1 1-.01-.01c-.36.36-.85.6-1.4.6-1.1 0-2-.9-2-2 0-.55.24-1.04.6-1.4l-.01-.01 1-1 2.44-2.44c-.33-.1-.67-.16-1.03-.16-1.1 0-2.09.46-2.81 1.19l-.02-.02-1 1 .02.02c-.73.72-1.19 1.71-1.19 2.81 0 2.21 1.79 4 4 4 1.1 0 2.09-.46 2.81-1.19l.02.02 1-1-.02-.02c.73-.72 1.19-1.71 1.19-2.81 0-.35-.06-.69-.15-1.02zm7.15-5.98c0-2.21-1.79-4-4-4-1.1 0-2.09.46-2.81 1.19l-.02-.02-1 1 .02.02c-.72.72-1.19 1.71-1.19 2.81 0 .36.06.69.15 1.02l2.44-2.44 1-1 .01.01c.36-.36.85-.6 1.4-.6 1.1 0 2 .9 2 2 0 .55-.24 1.04-.6 1.4l.01.01-1 1-2.43 2.45c.33.09.67.15 1.02.15 1.1 0 2.09-.46 2.81-1.19l.02.02 1-1-.02-.02a3.92 3.92 0 001.19-2.81z\\" fillRule=\\"evenodd\\" />
+                  </svg>
+                </span>
+              </Blueprint3.Icon>
+            </a>
+          </LinkAnchor>
+        </Link>
+        <div className=\\"sicp-figure\\">
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  Mock Text
+                </td>
+                <td>
+                  Mock Text
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Mock Text
+                </td>
+                <td>
+                  Mock Text
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h5 className=\\"sicp-caption\\">
+            name
+            Mock Text
+          </h5>
+        </div>
+      </div>
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse footnote DISPLAYFOOTNOTE count is 1 successful 1`] = `
-"<hr />
-
-
-<div className=\\"sicp-footnote\\">
-  <div />
-  <a href=\\"\\">
-    [1] 
-  </a>
-  Mock Text
-</div>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <hr />
+    <div className=\\"sicp-footnote\\">
+      <div />
+      <a href=\\"\\">
+        [1] 
+      </a>
+      Mock Text
+    </div>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse footnote DISPLAYFOOTNOTE count is 2 successful 1`] = `
-"<div className=\\"sicp-footnote\\">
-  <div />
-  <a href=\\"\\">
-    [2] 
-  </a>
-  Mock Text
-</div>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <div className=\\"sicp-footnote\\">
+      <div />
+      <a href=\\"\\">
+        [2] 
+      </a>
+      Mock Text
+    </div>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse heading SUBHEADING  successful 1`] = `
-"<h2 className=\\"bp3-heading\\">
-  Mock Text
-</h2>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id={[undefined]} refs={{...}} top={2}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <h2 className=\\"bp3-heading\\">
+          Mock Text
+        </h2>
+      </div>
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse heading SUBSUBHEADING  successful 1`] = `
-"<h4 className=\\"bp3-heading\\">
-  <br />
-  Mock Text
-</h4>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id={[undefined]} refs={{...}} top={16}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <h4 className=\\"bp3-heading\\">
+          <br />
+          Mock Text
+        </h4>
+      </div>
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse latex LATEX block successful 1`] = `
-"<SicpLatex math=\\"\\\\\\\\[test\\\\\\\\]\\">
-  <Latex delimiters={{...}} strict={false}>
-    <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
-  </Latex>
-</SicpLatex>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <SicpLatex math=\\"\\\\\\\\[test\\\\\\\\]\\">
+      <Latex delimiters={{...}} strict={false}>
+        <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
+      </Latex>
+    </SicpLatex>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse latex LATEX inline successful 1`] = `
-"<SicpLatex math=\\"$test$\\">
-  <Latex delimiters={{...}} strict={false}>
-    <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
-  </Latex>
-</SicpLatex>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <SicpLatex math=\\"$test$\\">
+      <Latex delimiters={{...}} strict={false}>
+        <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
+      </Latex>
+    </SicpLatex>
+  </Router>
+</BrowserRouter>"
 `;
 
-exports[`Parse links FOOTNOTE_REF successful 1`] = `
+exports[`Parse links FOOTNOTE_REF  successful 1`] = `
 "<BrowserRouter>
   <Router history={{...}}>
     <sup>
@@ -272,7 +424,7 @@ exports[`Parse links FOOTNOTE_REF successful 1`] = `
 </BrowserRouter>"
 `;
 
-exports[`Parse links LINK successful 1`] = `
+exports[`Parse links LINK  successful 1`] = `
 "<BrowserRouter>
   <Router history={{...}}>
     <a href=\\"bad-link\\">
@@ -282,7 +434,7 @@ exports[`Parse links LINK successful 1`] = `
 </BrowserRouter>"
 `;
 
-exports[`Parse links REF successful 1`] = `
+exports[`Parse links REF  successful 1`] = `
 "<BrowserRouter>
   <Router history={{...}}>
     <Link to=\\"bad-link\\">
@@ -297,23 +449,31 @@ exports[`Parse links REF successful 1`] = `
 `;
 
 exports[`Parse list OL  successful 1`] = `
-"<Component>
-  <ol className=\\"bp3-list\\">
-    <li>
-      Mock Text
-    </li>
-  </ol>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component>
+      <ol className=\\"bp3-list\\">
+        <li>
+          Mock Text
+        </li>
+      </ol>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse list UL  successful 1`] = `
-"<Component>
-  <ul className=\\"bp3-list\\">
-    <li>
-      Mock Text
-    </li>
-  </ul>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component>
+      <ul className=\\"bp3-list\\">
+        <li>
+          Mock Text
+        </li>
+      </ul>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse object no tag 1`] = `"Mock Text"`;
@@ -321,129 +481,177 @@ exports[`Parse object no tag 1`] = `"Mock Text"`;
 exports[`Parse object successful 1`] = `"Mock Text"`;
 
 exports[`Parse reference REFERENCE  successful 1`] = `
-"<div className=\\"sicp-reference\\">
-  Mock Text
-</div>"
-`;
-
-exports[`Parse section SECTION  successful 1`] = `
-"<div>
-  <Component>
-    <h1 className=\\"bp3-heading\\">
-      Title
-    </h1>
-  </Component>
-  <div>
-    <div className=\\"sicp-text\\">
-      <div />
-      Mock Text
+"<BrowserRouter>
+  <Router history={{...}}>
+    <div className=\\"sicp-reference\\">
       Mock Text
     </div>
-    <br />
-    <div className=\\"sicp-text\\">
-      <div />
-      Mock Text
-      Mock Text
-    </div>
-    <br />
-  </div>
-</div>"
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse snippet SNIPPET no eval successful 1`] = `
-"<Component>
-  <pre className=\\"bp3-code-block\\">
-    const a = 1;
-    a+1;
-  </pre>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component>
+      <pre className=\\"bp3-code-block\\">
+        const a = 1;
+        a+1;
+      </pre>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse snippet SNIPPET with latex successful 1`] = `
-"<Component>
-  <pre className=\\"bp3-code-block\\">
-    <SicpLatex math=\\"const a = 1;\\\\na+1;\\">
-      <Latex delimiters={{...}} strict={false}>
-        <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
-      </Latex>
-    </SicpLatex>
-  </pre>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component>
+      <pre className=\\"bp3-code-block\\">
+        <SicpLatex math=\\"const a = 1;\\\\na+1;\\">
+          <Latex delimiters={{...}} strict={false}>
+            <span className=\\"__Latex__\\" dangerouslySetInnerHTML={{...}} />
+          </Latex>
+        </SicpLatex>
+      </pre>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse snippet SNIPPET with prepend successful 1`] = `
-"<Component body=\\"const a = 1;\\\\na+1;\\" id=\\"id\\" initialEditorValueHash=\\"MYewdgzgLgBAhjAvDAjAbgFBwNTqA\\" prependLength={1} output={[undefined]}>
-  <div>
-    Code Snippet
-  </div>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component body=\\"const a = 1;\\\\na+1;\\" id=\\"id\\" initialEditorValueHash=\\"MYewdgzgLgBAhjAvDAjAbgFBwNTqA\\" prependLength={1} output={[undefined]}>
+      <div>
+        Code Snippet
+      </div>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse snippet SNIPPET without prepend successful 1`] = `
-"<Component body=\\"const a = 1;\\\\na+1;\\" id=\\"id\\" initialEditorValueHash=\\"MYewdgzgLgBAhjAvDAjAbgFBwNTqA\\" prependLength={[undefined]} output={[undefined]}>
-  <div>
-    Code Snippet
-  </div>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component body=\\"const a = 1;\\\\na+1;\\" id=\\"id\\" initialEditorValueHash=\\"MYewdgzgLgBAhjAvDAjAbgFBwNTqA\\" prependLength={[undefined]} output={[undefined]}>
+      <div>
+        Code Snippet
+      </div>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse snippet SNIPPET without prepend with output successful 1`] = `
-"<Component body=\\"const a = 1;\\\\na+1;\\" id=\\"id\\" initialEditorValueHash=\\"MYewdgzgLgBAhjAvDAjAbgFBwNTqA\\" prependLength={[undefined]} output=\\"2\\">
-  <div>
-    Code Snippet
-  </div>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component body=\\"const a = 1;\\\\na+1;\\" id=\\"id\\" initialEditorValueHash=\\"MYewdgzgLgBAhjAvDAjAbgFBwNTqA\\" prependLength={[undefined]} output=\\"2\\">
+      <div>
+        Code Snippet
+      </div>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse styling B  successful 1`] = `
-"<b>
-  Mock Text
-</b>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <b>
+      Mock Text
+    </b>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse styling EM  successful 1`] = `
-"<em>
-  Mock Text
-</em>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <em>
+      Mock Text
+    </em>
+  </Router>
+</BrowserRouter>"
 `;
 
 exports[`Parse styling JAVASCRIPTINLINE  successful 1`] = `
-"<Component>
-  <code className=\\"bp3-code\\" />
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component>
+      <code className=\\"bp3-code\\" />
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
-exports[`Parse styling META  successful 1`] = `"<em />"`;
+exports[`Parse styling META  successful 1`] = `
+"<BrowserRouter>
+  <Router history={{...}}>
+    <em />
+  </Router>
+</BrowserRouter>"
+`;
 
 exports[`Parse styling TT  successful 1`] = `
-"<Component>
-  <code className=\\"bp3-code\\">
-    Mock Text
-  </code>
-</Component>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <Component>
+      <code className=\\"bp3-code\\">
+        Mock Text
+      </code>
+    </Component>
+  </Router>
+</BrowserRouter>"
 `;
 
-exports[`Parse symbol BR  successful 1`] = `"<br />"`;
+exports[`Parse symbol BR  successful 1`] = `
+"<BrowserRouter>
+  <Router history={{...}}>
+    <br />
+  </Router>
+</BrowserRouter>"
+`;
 
 exports[`Parse table TABLE  successful 1`] = `
-"<table>
-  <tbody>
-    <tr>
-      <td>
-        Mock Text
-      </td>
-      <td>
-        Mock Text
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Mock Text
-      </td>
-      <td>
-        Mock Text
-      </td>
-    </tr>
-  </tbody>
-</table>"
+"<BrowserRouter>
+  <Router history={{...}}>
+    <table>
+      <tbody>
+        <tr>
+          <td>
+            Mock Text
+          </td>
+          <td>
+            Mock Text
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Mock Text
+          </td>
+          <td>
+            Mock Text
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Router>
+</BrowserRouter>"
+`;
+
+exports[`Parse title TITLE  successful 1`] = `
+"<BrowserRouter>
+  <Router history={{...}}>
+    <AnchorLink id={[undefined]} refs={{...}} top={6}>
+      <div className=\\"sicp-anchor-link-container\\">
+        <Component>
+          <h1 className=\\"bp3-heading\\">
+            Title
+          </h1>
+        </Component>
+      </div>
+    </AnchorLink>
+  </Router>
+</BrowserRouter>"
 `;

--- a/src/pages/sicp/Sicp.tsx
+++ b/src/pages/sicp/Sicp.tsx
@@ -82,7 +82,7 @@ const Sicp: React.FC<SicpProps> = props => {
           // page not found
           setData(getSicpError(SicpErrorType.PAGE_NOT_FOUND_ERROR));
         } else if (error instanceof ParseJsonError) {
-          // error occured while parsing JSON
+          // error occurred while parsing JSON
           setData(getSicpError(SicpErrorType.PARSING_ERROR));
         } else {
           setData(getSicpError(SicpErrorType.UNEXPECTED_ERROR));

--- a/src/pages/sicp/Sicp.tsx
+++ b/src/pages/sicp/Sicp.tsx
@@ -32,23 +32,22 @@ const Sicp: React.FC<SicpProps> = props => {
   const [loading, setLoading] = React.useState(true);
   const [active, setActive] = React.useState('0');
   const { section } = useParams<{ section: string }>();
-  const topRef = React.useRef<HTMLDivElement>(null);
-  const bottomRef = React.useRef<HTMLDivElement>(null);
+  const parentRef = React.useRef<HTMLDivElement>(null);
   const refs = React.useRef({});
   const history = useHistory();
 
   const scrollRefIntoView = (ref: HTMLDivElement | null) => {
-    if (!ref) {
+    if (!ref || !parentRef?.current) {
       return;
     }
 
-    // Hack to get scrolling to work properly.
-    // When 'block: start' option is used with scrollIntoView, the whole page scrolls with it.
-    // This issue does not occur when the option 'block: nearest' is used.
-    // To get `block: nearest` to mimic `block: start` behaviour, we first scroll to the bottom of
-    // the page before scrolling to the desired ref using the `block: nearest` option.
-    bottomRef.current!.scrollIntoView({ block: 'end' });
-    ref.scrollIntoView({ block: 'nearest' });
+    const parent = parentRef.current!;
+    const relativeTop = window.scrollY > parent.offsetTop ? window.scrollY : parent.offsetTop;
+
+    parent.scrollTo({
+      behavior: 'smooth',
+      top: ref.offsetTop - relativeTop
+    });
   };
 
   // Fetch json data
@@ -130,10 +129,12 @@ const Sicp: React.FC<SicpProps> = props => {
   );
 
   return (
-    <div className={classNames('Sicp', Classes.RUNNING_TEXT, Classes.TEXT_LARGE, Classes.DARK)}>
+    <div
+      className={classNames('Sicp', Classes.RUNNING_TEXT, Classes.TEXT_LARGE, Classes.DARK)}
+      ref={parentRef}
+    >
       <SicpErrorBoundary>
         <CodeSnippetContext.Provider value={{ active: active, setActive: handleSnippetEditorOpen }}>
-          <div ref={topRef} />
           {loading ? (
             <div className="sicp-content">{loadingComponent}</div>
           ) : section === 'index' ? (
@@ -144,7 +145,6 @@ const Sicp: React.FC<SicpProps> = props => {
               {navigationButtons}
             </div>
           )}
-          <div ref={bottomRef} />
         </CodeSnippetContext.Provider>
       </SicpErrorBoundary>
     </div>

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -71,7 +71,6 @@ $sicp-content-lr-padding: 6em;
       overflow: visible;
       width: 16px;
       height: 0px;
-      top: -3px;
       left: -22px;
       color: #dddddd;
     }

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -106,7 +106,7 @@ $sicp-content-lr-padding: 6em;
     }
 
     @media only screen and (max-width: 768px) {
-      padding: 0 1.2em;
+      padding: 0 1.4em;
     }
   }
 

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -65,6 +65,10 @@ $sicp-content-lr-padding: 6em;
     height: fit-content;
     background-color: $sicp-background-color;
 
+    .sicp-anchor-link-container:hover > .sicp-anchor-link {
+      color: #cccccc;
+    }
+
     .sicp-anchor-link {
       position: relative;
       display: block;
@@ -72,7 +76,7 @@ $sicp-content-lr-padding: 6em;
       width: 16px;
       height: 0px;
       left: -22px;
-      color: #dddddd;
+      color: transparent;
     }
 
     .sicp-anchor-link:hover {

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -65,6 +65,26 @@ $sicp-content-lr-padding: 6em;
     height: fit-content;
     background-color: $sicp-background-color;
 
+    .sicp-anchor-link {
+      position: relative;
+      display: block;
+      overflow: visible;
+      width: 16px;
+      height: 0px;
+      top: -3px;
+      left: -22px;
+      color: #dddddd;
+    }
+
+    .sicp-anchor-link:hover {
+      color: $sicp-text-color;
+    }
+
+    .sicp-anchor-link:hover + div {
+      background-color: #dddddd;
+      border-radius: 5px;
+    }
+
     .sicp-navigation-buttons {
       margin: 25px 0;
       display: flex;

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -41,7 +41,7 @@ $sicp-content-lr-padding: 6em;
 
   .bp3-code {
     color: $sicp-text-color;
-    background-color: $sicp-background-color;
+    background-color: inherit;
     box-shadow: none;
   }
 
@@ -51,7 +51,7 @@ $sicp-content-lr-padding: 6em;
     margin: 0;
     box-shadow: none;
     color: $sicp-text-color;
-    background-color: $sicp-background-color;
+    background-color: inherit;
   }
 
   .katex {


### PR DESCRIPTION
### Description
Breaking changes, merge together with source-academy/sicp#556.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added anchor links to each section. Expected behaviour:
- Link icon visible on the top right of each section when you hover over the section.
- Hovering over the link highlights the relevant section in light-grey, to show which section is being linked to.
- Clicking of the link icon adds the link to the address bar, similar to GitHub wiki pages.


https://user-images.githubusercontent.com/60355570/124362149-e8c58b00-dc65-11eb-9337-c7e7aa5a808e.mov

Also fixed:
- Footnote links not working
- Anchor links not working on Safari

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Behaviour should be as described in description section.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
