### PR TITLE
SICPJS: Change spacing between paragraphs

### DIFF
--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -279,7 +279,6 @@ export const processingFunctions = {
   TEXT: (obj: JsonType, refs: React.MutableRefObject<{}>) => (
     <AnchorLink id={obj['id']} refs={refs} top={-3}>
       <div className="sicp-text">{parseArr(obj['child']!, refs)}</div>
-      <br />
     </AnchorLink>
   ),
 

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -58,6 +58,10 @@ $sicp-content-lr-padding: 6em;
     font-size: 1.3rem;
   }
 
+  .sicp-text {
+    margin-bottom: 32px;
+  }
+
   .sicp-content {
     margin: 1em auto;
     padding: 0 $sicp-content-lr-padding;


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Change spacing between paragraphs to 32px, same as comparison edition. 
- Changing from line breaks to using margins to control spacing between paragraphs. This gives us more control over how large the spacing will be.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
