### PR TITLE
Fix formatting of contributors page on Safari

### DIFF
--- a/src/pages/contributors/subcomponents/ContributorsDetails.tsx
+++ b/src/pages/contributors/subcomponents/ContributorsDetails.tsx
@@ -12,7 +12,7 @@ class ContributorsDetails extends React.Component {
       <div className="outsideDetails">
         <Card className="contributorsDetails" elevation={Elevation.ONE}>
           <H3>The Team behind the Source Academy</H3>
-          <p>
+          <p className="description">
             The <i>Source Academy</i> is designed and developed by a team of students, most of who
             have used the system to learn the fundamentals of computing and enjoyed it. This page
             includes all developers who contributed to the Source Academy <i>Rook</i> (2022) and its

--- a/src/styles/_contributors.scss
+++ b/src/styles/_contributors.scss
@@ -46,6 +46,11 @@
       margin-left: 0.5%;
     }
 
+    p.description {
+      text-align: justify;
+      text-align-last: center;
+    }
+
     span.dot {
       padding: 0 0.2rem 0 0.2rem;
     }

--- a/src/styles/_contributors.scss
+++ b/src/styles/_contributors.scss
@@ -42,8 +42,6 @@
     }
 
     p {
-      text-align: justify;
-      text-align-last: center;
       margin-right: 0.5%;
       margin-left: 0.5%;
     }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
`text-align-last` property is not supported in safari, resulting in hall of fame section not being centrally aligned.

<img width="1110" alt="Screenshot 2021-07-20 at 1 02 00 AM" src="https://user-images.githubusercontent.com/60355570/126198838-78bf05c6-df98-4c84-ae93-e328d963323d.png">

I've fixed the issue by removing the `text-align-last` property on the `p` tags, although I have kept it on the description section. This means that the last line of the description will be justified on safari but centered on other browsers.

**After screenshots**
Chrome:
<img width="1114" alt="Screenshot 2021-07-20 at 1 14 35 AM" src="https://user-images.githubusercontent.com/60355570/126200082-2462c14b-bb91-4ee3-a117-a6731b4e5da1.png">

Safari:
<img width="1104" alt="Screenshot 2021-07-20 at 1 14 59 AM" src="https://user-images.githubusercontent.com/60355570/126200165-2169f452-d521-4601-b61d-81df47bd96c0.png">

 
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
