### PR TITLE
Fix AssessmentWorkspace syntax highlighting bug

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -757,6 +757,9 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
       ? {
           editorSessionId: '',
           editorValue: props.editorValue!,
+          sourceChapter: question.library.chapter || 4,
+          sourceVariant: 'default' as Variant,
+          externalLibrary: question.library.external.name || 'NONE',
           handleDeclarationNavigate: props.handleDeclarationNavigate,
           handleEditorEval: handleEval,
           handleEditorValueChange: props.handleEditorValueChange,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The Source chapter, variant and external library props were not passed into the editor component of AssessmentWorkspace. Probably accidentally left out in the previous refactor a year ago.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
