### PR TITLE
bumping js-slang

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "connected-react-router": "^6.9.1",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.5.10",
+    "js-slang": "^0.5.11",
     "konva": "^7.2.5",
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",


### PR DESCRIPTION
Bumping js-slang;

WIP: Joey is looking into issue:

```
henz@r-175-123-25-172 frontend % yarn install
yarn install v1.22.10
warning ../../../package.json: No license field
[1/4] 🔍  Resolving packages...
error Package "alt-ergo-modified" refers to a non-existing file '"/Users/henz/Documents/source-academy/frontend/alt-ergo-modified"'.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
