### PR TITLE
Bump js-slang and update infinite loop detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "connected-react-router": "^6.9.1",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.5.10",
+    "js-slang": "^0.5.12",
     "konva": "^7.2.5",
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -287,6 +287,8 @@ export const defaultSession: SessionState = {
   accessToken: undefined,
   assessments: new Map<number, Assessment>(),
   assessmentOverviews: undefined,
+  experimentApproval: false, // TODO: get this from backend or sth
+  experimentCoinflip: Math.random() < 0.5,
   githubOctokitObject: { octokit: undefined },
   grade: 0,
   gradingOverviews: undefined,

--- a/src/commons/application/types/SessionTypes.ts
+++ b/src/commons/application/types/SessionTypes.ts
@@ -48,6 +48,8 @@ export type SessionState = {
   readonly accessToken?: string;
   readonly assessmentOverviews?: AssessmentOverview[];
   readonly assessments: Map<number, Assessment>;
+  readonly experimentApproval: boolean;
+  readonly experimentCoinflip: boolean;
   readonly grade: number;
   readonly gradingOverviews?: GradingOverview[];
   readonly gradings: Map<number, Grading>;

--- a/src/commons/utils/InfiniteLoopReporter.ts
+++ b/src/commons/utils/InfiniteLoopReporter.ts
@@ -1,104 +1,5 @@
 import * as Sentry from '@sentry/browser';
-import { infiniteLoopErrorType } from 'js-slang/dist/infiniteLoops/errorMessages';
-import { Context, SourceError } from 'js-slang/dist/types';
-
-function getInfiniteLoopErrors(errors: SourceError[]) {
-  for (const error of errors) {
-    const errorType = infiniteLoopErrorType(error.explain());
-    if (errorType) return errorType;
-  }
-  return '';
-}
-
-/**
- * stringifies an array, similar to JSON.stringify, but is able to
- * 'stringify' functions in arrays (e.g. [(x=>x)]) -> "[(x=>x)]"
- * JSON.stringify will return [null]). Also written iteratively as
- * stringifying long (lispy) lists are likely to cause stack
- * overflows. Has a depth limit in case of circular references.
- *
- */
-function stringifyArray(arr: any[]) {
-  let result = '';
-  const stack: [any[], integer][] = [[arr, 0]];
-  while (stack.length > 0) {
-    // arbitrary depth limit: 1000
-    if (stack.length > 1000) return result + ' ...REDACTED]';
-    const top = stack.pop() as [any[], integer];
-    const topArr = top[0];
-    let idx = top[1];
-    if (idx === 0) result += '[';
-    while (idx < topArr.length) {
-      const elem = topArr[idx];
-      if (Array.isArray(elem)) {
-        stack.push([topArr, idx + 1]);
-        stack.push([elem, 0]);
-        break;
-      } else if (typeof elem === 'function') {
-        result += elem.toString();
-      } else {
-        result += JSON.stringify(elem);
-      }
-      if (idx !== topArr.length - 1) result += ',';
-      idx++;
-    }
-    if (idx >= topArr.length) {
-      const top = stack[stack.length - 1];
-      result += ']';
-      if (top && top[1] !== top[0].length) result += ',';
-    }
-  }
-  return result;
-}
-
-/**
- * After running code in the REPL, the code from previous invocations/runs
- * are stored as native javascript objects in the Context's NativeStorage object.
- * This function turns these native objects back into string (transpiled code) form.
- * NOTE: variables trapped in closures can not be saved/recovered, e.g.
- * function f(x) {return (y)=>(x+y)}; //f(2).tostring() = "(y)=>(x+y)", 2 is gone forever
- *
- * @param {Globals} previousIdentifiers - Globals object from context.nativeStorage
- *
- * @returns {string} code
- */
-function getPreviousCode(context: Context): string {
-  let code = '';
-  for (const key of context.nativeStorage.previousProgramsIdentifiers) {
-    const theVar = context.nativeStorage.evaller!(key);
-    //add newline for readability
-    if (code !== '') code += '\n';
-    if (typeof theVar === 'function') {
-      code += `${theVar.toString()}`;
-    } else if (Array.isArray(theVar)) {
-      code += `const ${key}=${stringifyArray(theVar)};`;
-    } else {
-      code += `const ${key}=${JSON.stringify(theVar)};`;
-    }
-  }
-  return code;
-}
-
-/**
- * Determines whether the error is an infinite loop, and returns a pair of [error type, code].
- * Constants (including functions) created from previous executions in the editor/REPL
- * will be stored as native Javascript objects. We will convert these objects
- * back into Source code and prepend it to the code that is being run.
- *
- * @param {Globals} scope - Globals object from context.nativeStorage
- * @param {string} code - last block of code that was executed
- *
- * @returns {[string, string]} [error type, code] if the error was an infinite loop
- * @returns {null} otherwise
- */
-export function getInfiniteLoopData(context: Context, code: string) {
-  const errors = getInfiniteLoopErrors(context.errors);
-  if (errors) {
-    return [errors, getPreviousCode(context)];
-  } else {
-    return null;
-  }
-}
+import { getInfiniteLoopData, InfiniteLoopErrorType } from 'js-slang/dist/infiniteLoops/errors';
 
 /**
  * Sends the infinite loop data to Sentry. Uses a unique Sentry
@@ -108,16 +9,25 @@ export function getInfiniteLoopData(context: Context, code: string) {
  * @param {string} errors - infinite loop error classification
  * @param {string} code - code to be sent along with the error
  */
-export function reportInfiniteLoopError(errors: string, code: string) {
+function reportInfiniteLoopError(
+  errorType: InfiniteLoopErrorType,
+  isStream: boolean,
+  message: string,
+  code: string[]
+) {
   Sentry.withScope(function (scope) {
     scope.clearBreadcrumbs();
     scope.setLevel(Sentry.Severity.Info);
-    scope.setTag('code-type', errors);
-    scope.setExtra('code', code);
-    scope.setFingerprint(['INFINITE_LOOP_LOGGING_FINGERPRINT']);
+    scope.setTag('error-type', InfiniteLoopErrorType[errorType]);
+    scope.setTag('is-stream', isStream ? 'yes' : 'no');
+    scope.setTag('message', message);
+    scope.setExtra('code', JSON.stringify(code));
+    scope.setFingerprint(['INFINITE_LOOP_LOGGING_FINGERPRINT_2022']);
     const err = new Error('Infinite Loop');
     // remove stack trace whenever we can to save space
     err.stack = '';
     Sentry.captureException(err);
   });
 }
+
+export { getInfiniteLoopData, reportInfiniteLoopError, InfiniteLoopErrorType };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,6 +1529,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@joeychenofficial/alt-ergo-modified@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@joeychenofficial/alt-ergo-modified/-/alt-ergo-modified-2.4.0.tgz#27aec0cbed8ab4e2f0dad6feb4f0c9766ac3132f"
+  integrity sha512-58b0K8pNUVZXGbua4IJQ+1K+E+jz3MkhDazZaaeKlD+sOLYR9iTHIbicV/I5K16ivYW6R9lONiT3dz8rMeFJ1w==
+
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
@@ -8181,11 +8186,12 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
-js-slang@^0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.10.tgz#c65a3043fa87d5206c65c85d4c3773922cc6eba9"
-  integrity sha512-ToWrQ7E/UDOEFwgh3zst0VT9cuISYi4EijYynAcHwXRPu0XLQlZEtW4OjALX7eK+sfDoKeW6IWnJBDMAPVF8MQ==
+js-slang@^0.5.12:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.12.tgz#63c77476bc8445dfc06691fb83c4cb6af683d072"
+  integrity sha512-P7246r6CO/mLr42q8pp9y5ILSs6WzF/2zyFAzhhIlUR5/jmS66nqk3Gw+qn/KSDbOhPWeimslJ1dc/azmzBo4w==
   dependencies:
+    "@joeychenofficial/alt-ergo-modified" "^2.4.0"
     "@types/estree" "0.0.47"
     acorn "^8.0.3"
     acorn-loose "^8.0.0"


### PR DESCRIPTION
### Description

Bump js-slang to 0.5.12.

The new version of js-slang implements an overhauled infinite loop detector which breaks certain features depending on the old implementation (namely the reporting infinite loop to sentry feature).

The new reporting feature can be turned on/off depending on whether the user has given approval or not.
This approval flag (state.session.experimentApproval in the state) is set to 'false' as default.
A future change should check for the user's given approval status and set this flag accordingly.

Also, as discussed in the meeting, we will only show the 'enhanced' infinite loop errors 50% of the time.

### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How to test

Run an infinite loop into the playground. The new error should show up 50% of the time. Refresh the page to 'reroll' for different results.

![image](https://user-images.githubusercontent.com/5654470/126958836-d80e248f-eb67-4567-9447-f6e894dd1d9f.png)


### Checklist

- [x] I have tested this code
