### PR TITLE
Fix output not appearing in snippets which are not evaluated

### DIFF
--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -123,7 +123,12 @@ const handleSnippet = (obj: JsonType) => {
   if (obj['latex']) {
     return <Pre>{handleLatex(obj['body']!)}</Pre>;
   } else if (typeof obj['eval'] === 'boolean' && !obj['eval']) {
-    return <Pre>{obj['body']}</Pre>;
+    return (
+      <>
+        {obj['body'] && <Pre>{obj['body']}</Pre>}
+        {obj['output'] && <Pre>{obj['output']}</Pre>}
+      </>
+    );
   } else {
     if (!obj['body']) {
       return;

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -126,7 +126,11 @@ const handleSnippet = (obj: JsonType) => {
     return (
       <>
         {obj['body'] && <Pre>{obj['body']}</Pre>}
-        {obj['output'] && <Pre>{obj['output']}</Pre>}
+        {obj['output'] && (
+          <Pre>
+            <em>{obj['output']}</em>
+          </Pre>
+        )}
       </>
     );
   } else {

--- a/src/pages/sicp/subcomponents/CodeSnippet.tsx
+++ b/src/pages/sicp/subcomponents/CodeSnippet.tsx
@@ -101,7 +101,11 @@ const CodeSnippet: React.FC<CodeSnippetProps> = props => {
           </SyntaxHighlighter>
         </Card>
       )}
-      {output && <Pre>{output}</Pre>}
+      {output && (
+        <Pre>
+          <em>{output}</em>
+        </Pre>
+      )}
     </div>
   );
 };

--- a/src/pages/sicp/subcomponents/__tests__/__snapshots__/CodeSnippet.tsx.snap
+++ b/src/pages/sicp/subcomponents/__tests__/__snapshots__/CodeSnippet.tsx.snap
@@ -9,7 +9,9 @@ exports[`Sicp Code Snippet renders correctly with prepend 1`] = `
     </SyntaxHighlighter>
   </Blueprint3.Card>
   <Component>
-    2
+    <em>
+      2
+    </em>
   </Component>
 </div>"
 `;
@@ -23,7 +25,9 @@ exports[`Sicp Code Snippet renders correctly without prepend 1`] = `
     </SyntaxHighlighter>
   </Blueprint3.Card>
   <Component>
-    2
+    <em>
+      2
+    </em>
   </Component>
 </div>"
 `;

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -42,9 +42,9 @@ $sicp-content-lr-padding: 6em;
   }
 
   .bp3-code-block {
-    font-size: 15pt;
-    padding: 0 15px;
-    margin: 0;
+    font-size: 14pt;
+    padding: 0;
+    margin: 10px 0;
     box-shadow: none;
     color: $sicp-text-color;
     background-color: inherit;


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1876 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

For snippets which are not evaluated, output should be visible (if present). For example, the chapter 4.4.1, `lives_near(list, "Reasoner"...` should be visible, as seen in the screenshot below.

<img width="933" alt="Screenshot 2021-07-28 at 12 58 00 PM" src="https://user-images.githubusercontent.com/60355570/127267007-93f3b2c8-8fb5-4750-a86b-d965e9f0f087.png">


### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
