### PR TITLE
Fix various issues with snippets

### DIFF
--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -152,7 +152,9 @@ const handleSnippet = (obj: JsonType) => {
 const handleFigure = (obj: JsonType, refs: React.MutableRefObject<{}>) => (
   <AnchorLink id={obj['id']} refs={refs} top={36}>
     <div className="sicp-figure">
-      {handleImage(obj, refs)}
+      {obj['src'] && handleImage(obj, refs)}
+      {obj['snippet'] && processingFunctions['SNIPPET'](obj['snippet'], refs)}
+      {obj['table'] && processingFunctions['TABLE'](obj['table'], refs)}
       {obj['captionName'] && (
         <h5 className="sicp-caption">
           {obj['captionName']}
@@ -164,21 +166,13 @@ const handleFigure = (obj: JsonType, refs: React.MutableRefObject<{}>) => (
 );
 
 const handleImage = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
-  if (obj['src']) {
-    return (
-      <img
-        src={Constants.interactiveSicpDataUrl + obj['src']}
-        alt={obj['id']}
-        width={obj['scale'] || '100%'}
-      />
-    );
-  } else if (obj['snippet']) {
-    return processingFunctions['SNIPPET'](obj['snippet'], refs);
-  } else if (obj['table']) {
-    return processingFunctions['TABLE'](obj['table'], refs);
-  } else {
-    throw new ParseJsonError('Figure has no image');
-  }
+  return (
+    <img
+      src={Constants.interactiveSicpDataUrl + obj['src']}
+      alt={obj['id']}
+      width={obj['scale'] || '100%'}
+    />
+  );
 };
 
 const handleTR = (obj: JsonType, refs: React.MutableRefObject<{}>, index: integer) => {

--- a/src/styles/_sicp.scss
+++ b/src/styles/_sicp.scss
@@ -191,6 +191,7 @@ $sicp-content-lr-padding: 6em;
   .sicp-code-snippet {
     margin: 10px 0;
     line-height: 1;
+    width: 100%;
 
     .sicp-code-snippet-open {
       width: 100vw;


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1882 
Fixes source-academy/sicp#585

Made changes to ensure snippets are always displayed in figures for cases where there is both an image and a snippet.



### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
