### PR TITLE
Game sounds and anims fixes

### DIFF
--- a/src/features/game/animations/GameAnimationManager.ts
+++ b/src/features/game/animations/GameAnimationManager.ts
@@ -67,7 +67,7 @@ export default class GameAnimationManager {
         GameGlobalAPI.getInstance().addItem(GameItemType.objects, currLoc, image.key);
         break;
       case AnimType.Background:
-        GameGlobalAPI.getInstance().renderBackgroundLayerContainer(image.path);
+        GameGlobalAPI.getInstance().renderBackgroundLayerContainer(image.key);
         break;
     }
   }
@@ -114,7 +114,9 @@ export default class GameAnimationManager {
    */
   public startAnimation(image: ImageAsset) {
     if (this.isSprite(image)) {
-      this.getAnimation(image).play(image.path);
+      const sprite = this.getAnimation(image);
+      sprite.play(image.path, false);
+      this.game.add.existing(sprite);
     }
   }
 

--- a/src/features/game/sound/GameSoundManager.ts
+++ b/src/features/game/sound/GameSoundManager.ts
@@ -187,13 +187,9 @@ class GameSoundManager {
       duration: fadeDuration
     });
 
-    const befScene = this.getCurrentScene().scene.key;
-    setTimeout(() => {
-      const aftScene = this.getCurrentScene().scene.key;
-      if (this.getBaseSoundManager().game && befScene === aftScene) {
-        sound.destroy();
-      }
-    }, fadeDuration * 2);
+    // TODO: fix `TypeError: Cannot read property 'disconnect' of null` error
+    // when user navigates away from game scene before fadeDuration * 2
+    setTimeout(() => sound.destroy(), fadeDuration * 2);
   }
 
   /**

--- a/src/features/game/sound/GameSoundManager.ts
+++ b/src/features/game/sound/GameSoundManager.ts
@@ -187,7 +187,13 @@ class GameSoundManager {
       duration: fadeDuration
     });
 
-    setTimeout(() => sound.destroy(), fadeDuration * 2);
+    const befScene = this.getCurrentScene().scene.key;
+    setTimeout(() => {
+      const aftScene = this.getCurrentScene().scene.key;
+      if (this.getBaseSoundManager().game && befScene === aftScene) {
+        sound.destroy();
+      }
+    }, fadeDuration * 2);
   }
 
   /**


### PR DESCRIPTION
### Description

**NOTE: Please do not merge this till the Rook PR #1878  has been reviewed and merged**

This PR also fixes an issue with the handling of animations that prevents them from being played.

It also adds a TODO in the sound manager for fixing the `TypeError: Cannot read property 'disconnect' of null` error when a user navigates out of the game scene before the sound is destroyed.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

Anims fix:
- Run any animation checkpoint txt like [this one](https://github.com/source-academy/frontend/files/6913310/settling-in-animations.txt) in the story simulator and check that animations play.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code