### PR TITLE
Rename SICP-JS backend environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ REACT_APP_OAUTH2_PROVIDER3_ENDPOINT=http://localhost:8000/login?provider=test&co
 
 REACT_APP_MODULE_BACKEND_URL=https://source-academy.github.io/modules
 REACT_APP_SHAREDB_BACKEND_URL=
+REACT_APP_SICPJS_BACKEND_URL="http://127.0.0.1:8080/"
 
 # API keys for Google Drive integration
 REACT_APP_GOOGLE_CLIENT_ID=
@@ -51,6 +52,3 @@ REACT_APP_GITHUB_OAUTH_PROXY_URL=
 # Keystroke logging
 REACT_APP_CADET_LOGGER=
 REACT_APP_CADET_LOGGER_INTERVAL=10000
-
-# Link to interative-sicp
-REACT_APP_INTERACTIVE_SICP_DATA_URL="http://127.0.0.1:8080/"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The project requires some environment variables to be set to work properly. In t
 1. `REACT_APP_USE_BACKEND`: Set to false if not running together with the [backend](https://github.com/source-academy/backend).
 1. `REACT_APP_MODULE_BACKEND_URL`: The base URL from which Source modules are loaded. (This is a js-slang feature, but of course it has to be configured here.) You can just use the default value in development.
 1. `REACT_APP_SHAREDB_BACKEND_URL`: The base URL of the [ShareDB collaborative editor backend](https://github.com/source-academy/sharedb-ace-backend). The protocol must be HTTP or HTTPS (it will automatically be set to WS/WSS as appropriate). **Must end in a trailing `/`.**
+1. `REACT_APP_SICPJS_BACKEND_URL`: The base URL from which [SICP JS](https://github.com/source-academy/sicp) content is loaded.
 
 #### URL shortener configuration
 

--- a/src/commons/utils/Constants.ts
+++ b/src/commons/utils/Constants.ts
@@ -31,8 +31,8 @@ const googleApiKey = process.env.REACT_APP_GOOGLE_API_KEY;
 const googleAppId = process.env.REACT_APP_GOOGLE_APP_ID;
 const githubClientId = process.env.REACT_APP_GITHUB_CLIENT_ID || '';
 const githubOAuthProxyUrl = process.env.REACT_APP_GITHUB_OAUTH_PROXY_URL || '';
-const interactiveSicpDataUrl =
-  process.env.REACT_APP_INTERACTIVE_SICP_DATA_URL || 'https://sicp.sourceacademy.org/'; // data for sicpjs (images and json files)
+const sicpBackendUrl =
+  process.env.REACT_APP_SICPJS_BACKEND_URL || 'https://sicp.sourceacademy.org/';
 
 const authProviders: Map<string, { name: string; endpoint: string; isDefault: boolean }> =
   new Map();
@@ -127,7 +127,7 @@ const Constants = {
   sharedbBackendUrl,
   disablePeriods,
   cadetLoggerInterval,
-  interactiveSicpDataUrl
+  sicpBackendUrl: sicpBackendUrl
 };
 
 export default Constants;

--- a/src/features/sicp/parser/ParseJson.tsx
+++ b/src/features/sicp/parser/ParseJson.tsx
@@ -168,7 +168,7 @@ const handleFigure = (obj: JsonType, refs: React.MutableRefObject<{}>) => (
 const handleImage = (obj: JsonType, refs: React.MutableRefObject<{}>) => {
   return (
     <img
-      src={Constants.interactiveSicpDataUrl + obj['src']}
+      src={Constants.sicpBackendUrl + obj['src']}
       alt={obj['id']}
       width={obj['scale'] || '100%'}
     />

--- a/src/features/sicp/parser/__tests__/ParseJson.tsx
+++ b/src/features/sicp/parser/__tests__/ParseJson.tsx
@@ -28,7 +28,7 @@ jest.mock('src/commons/utils/Constants', () => ({
   Links: {
     sourceDocs: ''
   },
-  interactiveSicpDataUrl: 'https://source-academy.github.io/sicp/'
+  sicpBackendUrl: 'https://source-academy.github.io/sicp/'
 }));
 
 jest.mock('src/pages/sicp/subcomponents/CodeSnippet', () => (props: CodeSnippetProps) => {

--- a/src/pages/sicp/Sicp.tsx
+++ b/src/pages/sicp/Sicp.tsx
@@ -16,7 +16,7 @@ import SicpIndexPage from './subcomponents/SicpIndexPage';
 
 type SicpProps = RouteComponentProps<{}>;
 
-const baseUrl = Constants.interactiveSicpDataUrl + 'json/';
+const baseUrl = Constants.sicpBackendUrl + 'json/';
 const extension = '.json';
 
 // Context to determine which code snippet is active


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Renamed SICP-JS environment variable to `REACT_APP_SICPJS_BACKEND_URL` and updated the README.

The previously badly named `REACT_APP_INTERACTIVE_SICP_DATA_URL` is not consistent with the URLS for other backends, and has caused confusion in the past. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Check if pages can still be loaded. No functionality changes here, just a change in variable name.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [x] I have updated the documentation
