### PR TITLE
Fix logout routing bug

### DIFF
--- a/src/commons/application/Application.tsx
+++ b/src/commons/application/Application.tsx
@@ -18,6 +18,7 @@ import Welcome from '../../pages/welcome/Welcome';
 import { AssessmentType } from '../assessment/AssessmentTypes';
 import NavigationBar from '../navigationBar/NavigationBar';
 import Constants from '../utils/Constants';
+import { history } from '../utils/HistoryHelper';
 import { parseQuery } from '../utils/QueryHelper';
 import { Role } from './ApplicationTypes';
 import { UpdateCourseConfiguration, UserCourse } from './types/SessionTypes';
@@ -194,7 +195,16 @@ const Application: React.FC<ApplicationProps> = props => {
   return (
     <div className="Application">
       <NavigationBar
-        handleLogOut={props.handleLogOut}
+        handleLogOut={() => {
+          props.handleLogOut();
+          /**
+           * Ensures that the user is redirected back to /login when logging
+           * out in /achievements or /sourcecast as these routes no longer exist.
+           * The other routes are ok due to `ensureUserAndRoleAndRouteTo` and
+           * `ensureUserAndRouteTo`
+           */
+          history.push('/login');
+        }}
         handleGitHubLogIn={props.handleGitHubLogIn}
         handleGitHubLogOut={props.handleGitHubLogOut}
         updateLatestViewedCourse={props.updateLatestViewedCourse}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Since the `/achievements` and `/sourcecast` routes are conditionally rendered by course, upon logout, these routes no longer exist and will 404 instead of bringing the user to the login page.

Using `history.push('/login')` for good measure

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Logout in `/achievements` or `/sourcecast`. You should be redirected to `/login` instead of `/404`

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
