### PR TITLE
Fix game location preview asset keys

### DIFF
--- a/src/features/game/parser/LocationParser.ts
+++ b/src/features/game/parser/LocationParser.ts
@@ -65,12 +65,13 @@ export default class LocationParser {
         location.talkTopics = new Set(talkTopics);
         break;
       case 'preview':
-        const [previewKey] = configValues;
-        if (previewKey) {
+        const [previewPath] = configValues;
+        if (previewPath) {
+          const previewKey = '/preview' + previewPath;
           Parser.checkpoint.map.addMapAsset(previewKey, {
             type: AssetType.Image,
             key: location.id + 'Preview',
-            path: previewKey
+            path: previewPath
           });
           location.previewKey = previewKey;
         }


### PR DESCRIPTION
### Description

Fixes an issue with #1904 when the location asset config is overwritten by the preview asset

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

Use location previews with the same assets as declared locations, and check that locations render correctly

### Checklist

- [x] I have tested this code