### PR TITLE
Properly fix handling of null name in AchievementUser

### DIFF
--- a/src/commons/achievement/AchievementManualEditor.tsx
+++ b/src/commons/achievement/AchievementManualEditor.tsx
@@ -101,7 +101,7 @@ function AchievementManualEditor(props: AchievementManualEditorProps) {
       >
         <Button
           outlined={true}
-          text={selectedUser ? selectedUser.name : 'No User Selected'}
+          text={selectedUser ? selectedUser.name || selectedUser.username : 'No User Selected'}
           color="White"
         />
       </UserSelect>

--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -314,12 +314,12 @@ export const getAllUsers = async (tokens: Tokens): Promise<AchievementUser[] | n
   const users = await resp.json();
 
   return users.map(
-    (user: any) =>
-      ({
-        name: user.name,
-        courseRegId: user.courseRegId,
-        group: user.group
-      } as AchievementUser)
+    (user: any): AchievementUser => ({
+      name: user.name,
+      courseRegId: user.courseRegId,
+      group: user.group,
+      username: user.username
+    })
   );
 };
 


### PR DESCRIPTION
### Description

Properly fix handling of null name in AchievementUser

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

Add a new user to a course. Before that user first logs in, try to access the achievements page (as a staff user).

### Checklist

- [x] I have tested this code
