### PR TITLE
No longer creates graded goal for excluded assessments

### DIFF
--- a/src/commons/XMLParser/XMLParserHelper.ts
+++ b/src/commons/XMLParser/XMLParserHelper.ts
@@ -69,6 +69,7 @@ const makeAssessmentOverview = (result: any, maxXpVal: number): AssessmentOvervi
   const rawOverview: XmlParseStrOverview = task.$;
   return {
     type: capitalizeFirstLetter(rawOverview.kind) as AssessmentType,
+    isManuallyGraded: true, // TODO: This is temporarily hardcoded to true. To be redone when overhauling MissionControl
     closeAt: rawOverview.duedate,
     coverImage: rawOverview.coverimage,
     id: EDITING_ID,

--- a/src/commons/achievement/utils/InsertFakeAchievements.ts
+++ b/src/commons/achievement/utils/InsertFakeAchievements.ts
@@ -16,7 +16,6 @@ function insertFakeAchievements(
     return;
   }
   const idString = assessmentOverview.id.toString();
-  const gradingExcluded = assessmentOverview.gradingStatus === 'excluded';
 
   if (!inferencer.hasAchievement(idString)) {
     // Goal for assessment submission
@@ -35,7 +34,7 @@ function insertFakeAchievements(
     );
 
     // goal for assessment grading
-    if (!gradingExcluded) {
+    if (assessmentOverview.isManuallyGraded) {
       inferencer.insertFakeGoalDefinition(
         {
           uuid: idString + '1',
@@ -64,7 +63,9 @@ function insertFakeAchievements(
       isTask: assessmentOverview.isPublished === undefined ? true : assessmentOverview.isPublished,
       position: -1, // always appears on top
       prerequisiteUuids: [],
-      goalUuids: gradingExcluded ? [idString + '0'] : [idString + '0', idString + '1'], // need to create a mock completed goal to reference to be considered complete
+      goalUuids: !assessmentOverview.isManuallyGraded
+        ? [idString + '0']
+        : [idString + '0', idString + '1'], // need to create a mock completed goal to reference to be considered complete
       cardBackground: `${cardBackgroundUrl}/default.png`,
       view: {
         coverImage: assessmentOverview.coverImage,

--- a/src/commons/achievement/utils/InsertFakeAchievements.ts
+++ b/src/commons/achievement/utils/InsertFakeAchievements.ts
@@ -16,6 +16,8 @@ function insertFakeAchievements(
     return;
   }
   const idString = assessmentOverview.id.toString();
+  const gradingExcluded = assessmentOverview.gradingStatus === 'excluded';
+
   if (!inferencer.hasAchievement(idString)) {
     // Goal for assessment submission
     inferencer.insertFakeGoalDefinition(
@@ -31,20 +33,23 @@ function insertFakeAchievements(
       },
       assessmentOverview.status === 'submitted'
     );
-    // Goal for assessment grading
-    inferencer.insertFakeGoalDefinition(
-      {
-        uuid: idString + '1',
-        text: `Graded ${assessmentOverview.title}`,
-        achievementUuids: [idString],
-        meta: {
-          type: GoalType.ASSESSMENT,
-          assessmentNumber: assessmentOverview.id,
-          requiredCompletionFrac: 0
-        }
-      },
-      assessmentOverview.gradingStatus === 'graded'
-    );
+
+    // goal for assessment grading
+    if (!gradingExcluded) {
+      inferencer.insertFakeGoalDefinition(
+        {
+          uuid: idString + '1',
+          text: `Graded ${assessmentOverview.title}`,
+          achievementUuids: [idString],
+          meta: {
+            type: GoalType.ASSESSMENT,
+            assessmentNumber: assessmentOverview.id,
+            requiredCompletionFrac: 0
+          }
+        },
+        assessmentOverview.gradingStatus === 'graded'
+      );
+    }
     // Would like a goal for early submission, but that seems to be hard to get from the overview
     inferencer.insertFakeAchievement({
       uuid: idString,
@@ -59,7 +64,7 @@ function insertFakeAchievements(
       isTask: assessmentOverview.isPublished === undefined ? true : assessmentOverview.isPublished,
       position: -1, // always appears on top
       prerequisiteUuids: [],
-      goalUuids: [idString + '0', idString + '1'], // need to create a mock completed goal to reference to be considered complete
+      goalUuids: gradingExcluded ? [idString + '0'] : [idString + '0', idString + '1'], // need to create a mock completed goal to reference to be considered complete
       cardBackground: `${cardBackgroundUrl}/default.png`,
       view: {
         coverImage: assessmentOverview.coverImage,

--- a/src/commons/achievement/utils/InsertFakeAchievements.ts
+++ b/src/commons/achievement/utils/InsertFakeAchievements.ts
@@ -54,7 +54,7 @@ function insertFakeAchievements(
       uuid: idString,
       title: assessmentOverview.title,
       xp:
-        assessmentOverview.gradingStatus === 'graded'
+        assessmentOverview.gradingStatus === 'graded' || !assessmentOverview.isManuallyGraded
           ? assessmentOverview.xp
           : assessmentOverview.maxXp,
       isVariableXp: false,

--- a/src/commons/application/actions/__tests__/SessionActions.ts
+++ b/src/commons/application/actions/__tests__/SessionActions.ts
@@ -465,6 +465,7 @@ test('updateAssessmentOverviews generates correct action object', () => {
   const overviews: AssessmentOverview[] = [
     {
       type: 'Missions',
+      isManuallyGraded: true,
       closeAt: 'test_string',
       coverImage: 'test_string',
       id: 0,

--- a/src/commons/application/reducers/__tests__/SessionReducer.ts
+++ b/src/commons/application/reducers/__tests__/SessionReducer.ts
@@ -312,6 +312,7 @@ test('UPDATE_ASSESSMENT works correctly in updating assessment', () => {
 const assessmentOverviewsTest1: AssessmentOverview[] = [
   {
     type: 'Missions',
+    isManuallyGraded: true,
     closeAt: 'test_string',
     coverImage: 'test_string',
     id: 0,
@@ -329,6 +330,7 @@ const assessmentOverviewsTest1: AssessmentOverview[] = [
 const assessmentOverviewsTest2: AssessmentOverview[] = [
   {
     type: 'Contests',
+    isManuallyGraded: true,
     closeAt: 'test_string_0',
     coverImage: 'test_string_0',
     fileName: 'test_sting_0',

--- a/src/commons/assessment/AssessmentTypes.ts
+++ b/src/commons/assessment/AssessmentTypes.ts
@@ -55,6 +55,7 @@ W* Used to display information regarding an assessment in the UI.
  */
 export type AssessmentOverview = {
   type: AssessmentType;
+  isManuallyGraded: boolean;
   closeAt: string;
   coverImage: string;
   fileName?: string; // For mission control
@@ -224,6 +225,7 @@ export const normalLibrary = (): Library => {
 export const overviewTemplate = (): AssessmentOverview => {
   return {
     type: 'Missions',
+    isManuallyGraded: true,
     closeAt: '2100-12-01T00:00+08',
     coverImage: 'https://fakeimg.pl/300/',
     id: -1,

--- a/src/commons/mocks/AssessmentMocks.ts
+++ b/src/commons/mocks/AssessmentMocks.ts
@@ -86,6 +86,7 @@ export const mockAssessmentConfigurations: AssessmentConfiguration[][] = [
 const mockUnopenedAssessmentsOverviews: AssessmentOverview[] = [
   {
     type: 'Missions',
+    isManuallyGraded: true,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/300/',
     id: 1,
@@ -104,6 +105,7 @@ const mockUnopenedAssessmentsOverviews: AssessmentOverview[] = [
 const mockOpenedAssessmentsOverviews: AssessmentOverview[] = [
   {
     type: 'Missions',
+    isManuallyGraded: true,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/300/',
     id: 1,
@@ -131,6 +133,7 @@ const mockOpenedAssessmentsOverviews: AssessmentOverview[] = [
   },
   {
     type: 'Missions',
+    isManuallyGraded: true,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/?text=World&font=lobster',
     id: 2,
@@ -146,6 +149,7 @@ const mockOpenedAssessmentsOverviews: AssessmentOverview[] = [
   },
   {
     type: 'Quests',
+    isManuallyGraded: true,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/?text=Hello',
     id: 3,
@@ -161,6 +165,7 @@ const mockOpenedAssessmentsOverviews: AssessmentOverview[] = [
   },
   {
     type: 'Paths',
+    isManuallyGraded: true,
     closeAt: '2069-04-20T01:23:45.111Z',
     coverImage: 'https://fakeimg.pl/700x400/417678,64/?text=%E3%83%91%E3%82%B9&font=noto',
     id: 6,
@@ -176,6 +181,7 @@ const mockOpenedAssessmentsOverviews: AssessmentOverview[] = [
   },
   {
     type: 'Others',
+    isManuallyGraded: false,
     closeAt: '2048-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/?text=Hello',
     id: 5,
@@ -195,6 +201,7 @@ const mockOpenedAssessmentsOverviews: AssessmentOverview[] = [
 const mockClosedAssessmentOverviews: AssessmentOverview[] = [
   {
     type: 'Missions',
+    isManuallyGraded: true,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000/000',
     id: 4,
@@ -210,6 +217,7 @@ const mockClosedAssessmentOverviews: AssessmentOverview[] = [
   },
   {
     type: 'Quests',
+    isManuallyGraded: true,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000,128/000,255',
     id: 5,
@@ -225,6 +233,7 @@ const mockClosedAssessmentOverviews: AssessmentOverview[] = [
   },
   {
     type: 'Quests',
+    isManuallyGraded: true,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000,128/000,255',
     id: 5,
@@ -240,6 +249,7 @@ const mockClosedAssessmentOverviews: AssessmentOverview[] = [
   },
   {
     type: 'Quests',
+    isManuallyGraded: true,
     closeAt: '2008-06-18T05:24:26.026Z',
     coverImage: 'https://fakeimg.pl/350x200/ff0000/000',
     id: 5,

--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -457,7 +457,6 @@ export const getAssessmentOverviews = async (
       overview.gradedCount,
       overview.questionCount
     );
-    delete overview.isManuallyGraded;
     delete overview.gradedCount;
     delete overview.questionCount;
 
@@ -487,7 +486,6 @@ export const getUserAssessmentOverviews = async (
       overview.gradedCount,
       overview.questionCount
     );
-    delete overview.isManuallyGraded;
     delete overview.gradedCount;
     delete overview.questionCount;
 


### PR DESCRIPTION
### Description

Assessments excluded from grading will now not have the graded goal generated.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Upload an autograded assessment, and check that it doesn't have the graded goal

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
