### PR TITLE
Recompute achievement completion status and other achievement UI updates

### DIFF
--- a/src/commons/achievement/AchievementView.tsx
+++ b/src/commons/achievement/AchievementView.tsx
@@ -53,8 +53,8 @@ function AchievementView(props: AchievementViewProps) {
         <h1>{title.toUpperCase()}</h1>
         {deadline && <p>{`Deadline: ${prettifyDate(deadline)}`}</p>}
         <span className="description">
-          {descriptionParagraphs.map(para => (
-            <p>
+          {descriptionParagraphs.map((para, idx) => (
+            <p key={idx}>
               {para}
               <br />
             </p>

--- a/src/commons/achievement/AchievementView.tsx
+++ b/src/commons/achievement/AchievementView.tsx
@@ -39,6 +39,8 @@ function AchievementView(props: AchievementViewProps) {
   const prereqGoals = inferencer.listPrerequisiteGoals(focusUuid);
   const status = inferencer.getStatus(focusUuid);
 
+  const descriptionParagraphs = description.split('\n');
+
   return (
     <div className="view" style={{ ...getAbilityGlow(), ...getAbilityBackground() }}>
       <div
@@ -51,7 +53,7 @@ function AchievementView(props: AchievementViewProps) {
         <h1>{title.toUpperCase()}</h1>
         {deadline && <p>{`Deadline: ${prettifyDate(deadline)}`}</p>}
         <span className="description">
-          <p>{description}</p>
+          {descriptionParagraphs.map(para => <p>{para}<br /></p>)}
         </span>
       </div>
       <AchievementViewGoal goals={goals} />

--- a/src/commons/achievement/AchievementView.tsx
+++ b/src/commons/achievement/AchievementView.tsx
@@ -53,7 +53,12 @@ function AchievementView(props: AchievementViewProps) {
         <h1>{title.toUpperCase()}</h1>
         {deadline && <p>{`Deadline: ${prettifyDate(deadline)}`}</p>}
         <span className="description">
-          {descriptionParagraphs.map(para => <p>{para}<br /></p>)}
+          {descriptionParagraphs.map(para => (
+            <p>
+              {para}
+              <br />
+            </p>
+          ))}
         </span>
       </div>
       <AchievementViewGoal goals={goals} />

--- a/src/commons/achievement/overview/AchievementLevel.tsx
+++ b/src/commons/achievement/overview/AchievementLevel.tsx
@@ -15,8 +15,8 @@ function AchievementLevel(props: AchievementLevelProps) {
   const displayMilestone = () => setShowMilestone(true);
   const hideMilestone = () => setShowMilestone(false);
 
-  // start at level 0
-  const level = Math.floor(studentXp / xpPerLevel);
+  // start at level 1
+  const level = Math.floor(studentXp / xpPerLevel) + 1;
   const progress = studentXp % xpPerLevel;
   const progressFrac = progress / xpPerLevel;
 

--- a/src/commons/achievement/overview/AchievementLevel.tsx
+++ b/src/commons/achievement/overview/AchievementLevel.tsx
@@ -15,7 +15,8 @@ function AchievementLevel(props: AchievementLevelProps) {
   const displayMilestone = () => setShowMilestone(true);
   const hideMilestone = () => setShowMilestone(false);
 
-  const level = Math.floor(studentXp / xpPerLevel) + 1;
+  // start at level 0
+  const level = Math.floor(studentXp / xpPerLevel);
   const progress = studentXp % xpPerLevel;
   const progressFrac = progress / xpPerLevel;
 

--- a/src/commons/achievement/overview/AchievementMilestone.tsx
+++ b/src/commons/achievement/overview/AchievementMilestone.tsx
@@ -18,9 +18,9 @@ function AchievementMilestone(props: AchievementMilestoneProps) {
       <div className="details">
         <div className="level-badge">
           <span className="level-icon" />
-          <p>41</p>
+          <p>37+</p>
         </div>
-        <p className="description">Earn extra 1 MC from CS1010R</p>
+        <p className="description">Counts towards CS1010R</p>
       </div>
       <div className="footer">
         <p>Total XP: {studentXp}</p>

--- a/src/commons/achievement/overview/AchievementMilestone.tsx
+++ b/src/commons/achievement/overview/AchievementMilestone.tsx
@@ -2,7 +2,6 @@ type AchievementMilestoneProps = {
   studentXp: number;
 };
 
-
 // 36k XP = Level 37
 function AchievementMilestone(props: AchievementMilestoneProps) {
   const { studentXp } = props;

--- a/src/commons/achievement/overview/AchievementMilestone.tsx
+++ b/src/commons/achievement/overview/AchievementMilestone.tsx
@@ -2,6 +2,8 @@ type AchievementMilestoneProps = {
   studentXp: number;
 };
 
+
+// 36k XP = Level 37
 function AchievementMilestone(props: AchievementMilestoneProps) {
   const { studentXp } = props;
   return (
@@ -10,14 +12,14 @@ function AchievementMilestone(props: AchievementMilestoneProps) {
       <div className="details">
         <div className="level-badge">
           <span className="level-icon" />
-          <p>36</p>
+          <p>37</p>
         </div>
         <p className="description">Complete CS1101S CA Component</p>
       </div>
       <div className="details">
         <div className="level-badge">
           <span className="level-icon" />
-          <p>40</p>
+          <p>41</p>
         </div>
         <p className="description">Earn extra 1 MC from CS1010R</p>
       </div>

--- a/src/commons/achievement/utils/AchievementBackender.ts
+++ b/src/commons/achievement/utils/AchievementBackender.ts
@@ -30,7 +30,7 @@ export const frontendifyAchievementGoal = (goal: any) =>
       : goal.meta) as GoalMeta,
     count: goal.count,
     targetCount: goal.targetCount,
-    completed: goal.completed
+    completed: goal.count >= goal.targetCount
   } as AchievementGoal);
 
 export const frontendifyAchievementItem = (achievement: any) =>

--- a/src/commons/achievement/view/AchievementViewCompletion.tsx
+++ b/src/commons/achievement/view/AchievementViewCompletion.tsx
@@ -11,8 +11,8 @@ function AchievementViewCompletion(props: AchievementViewCompletionProps) {
   return (
     <div className="completion">
       <h1>{`AWARDED ${awardedXp}XP`}</h1>
-      {paragraphs.map(para => (
-        <p>
+      {paragraphs.map((para, idx) => (
+        <p key={idx}>
           {para}
           <br />
         </p>

--- a/src/commons/achievement/view/AchievementViewCompletion.tsx
+++ b/src/commons/achievement/view/AchievementViewCompletion.tsx
@@ -6,10 +6,12 @@ type AchievementViewCompletionProps = {
 function AchievementViewCompletion(props: AchievementViewCompletionProps) {
   const { awardedXp, completionText } = props;
 
+  const paragraphs = completionText.split('\n');
+
   return (
     <div className="completion">
       <h1>{`AWARDED ${awardedXp}XP`}</h1>
-      <p>{completionText}</p>
+      {paragraphs.map(para => <p>{para}<br /></p>)}
     </div>
   );
 }

--- a/src/commons/achievement/view/AchievementViewCompletion.tsx
+++ b/src/commons/achievement/view/AchievementViewCompletion.tsx
@@ -11,7 +11,12 @@ function AchievementViewCompletion(props: AchievementViewCompletionProps) {
   return (
     <div className="completion">
       <h1>{`AWARDED ${awardedXp}XP`}</h1>
-      {paragraphs.map(para => <p>{para}<br /></p>)}
+      {paragraphs.map(para => (
+        <p>
+          {para}
+          <br />
+        </p>
+      ))}
     </div>
   );
 }

--- a/src/styles/_achievementdashboard.scss
+++ b/src/styles/_achievementdashboard.scss
@@ -90,7 +90,7 @@
           margin: $default-spacing;
 
           .description {
-            margin: 0;
+            margin: 10;
             padding: 0 0 0 $default-spacing;
           }
         }

--- a/src/styles/_achievementdashboard.scss
+++ b/src/styles/_achievementdashboard.scss
@@ -400,6 +400,15 @@
             }
           }
 
+          .goal-progress {
+            width: 100%;
+            padding-right: 2.5em;
+
+            .progress {
+              margin-top: 5px;
+            }
+          }
+
           p {
             margin: 0;
             padding: 0;


### PR DESCRIPTION
### Description

goalProgress.completed is now recomputed when fetching the goal progress from the backend to avoid the goal from being incorrectly completed when goal was previously completed but target count is increased.

Also allows completion text and description of achievements to be multi-lined.

Achievement milestone levels are increased by 1, to reflect that 36k xp (level 37) is full credit

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Create a goal and an achievement that uses that goal. 
Complete the goal.
Increase the goal's target count so that you would not complete the goal.
Return the the achievement dashboard and verify that the achievement and goal are not completed.

Check that your level starts at 1, and goes up by 1 every 1000 xp

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
