### PR TITLE
Fix mcq button highlight when no solution is sent from backend

### DIFF
--- a/src/commons/assessment/AssessmentTypes.ts
+++ b/src/commons/assessment/AssessmentTypes.ts
@@ -112,7 +112,7 @@ export interface IProgrammingQuestion extends BaseQuestion {
 export interface IMCQQuestion extends BaseQuestion {
   answer: number | null;
   choices: MCQChoice[];
-  solution: number | null;
+  solution?: number;
   type: 'mcq';
 }
 

--- a/src/commons/mcqChooser/McqChooser.tsx
+++ b/src/commons/mcqChooser/McqChooser.tsx
@@ -72,11 +72,11 @@ class McqChooser extends React.PureComponent<McqChooserProps, {}> {
   private getButtonIntent = (
     currentOption: number,
     chosenOption: number | null,
-    solution: number | null
+    solution?: number
   ): Intent => {
     const active = currentOption === chosenOption;
-    const correctOptionSelected = active && solution !== null && currentOption === solution;
-    if (solution === null) {
+    const correctOptionSelected = active && solution !== undefined && currentOption === solution;
+    if (solution === undefined) {
       return Intent.NONE;
     } else if (active && correctOptionSelected) {
       return Intent.SUCCESS;

--- a/src/commons/mocks/AssessmentMocks.ts
+++ b/src/commons/mocks/AssessmentMocks.ts
@@ -461,7 +461,7 @@ export const mockAssessmentQuestions: Array<IProgrammingQuestion | IMCQQuestion>
     id: 3,
     library: mockBinaryTreeLibrary,
     type: 'mcq',
-    solution: null,
+    solution: undefined,
     xp: 0,
     maxXp: 2,
     blocking: false


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously, when no solution was sent from the backend, any selection will be highlighted red.

Now, they are highlighted in a neutral grey colour:

![image](https://user-images.githubusercontent.com/53928333/129931986-8cebc8bf-6ab0-49ed-8a69-f87a492020f7.png)


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Test against an MCQ question with 'showsolution' = false. Selecting any option should highlight it grey instead of red.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
