### PR TITLE
Fix bug where split was applied on undefined strings

### DIFF
--- a/src/commons/achievement/AchievementView.tsx
+++ b/src/commons/achievement/AchievementView.tsx
@@ -39,7 +39,7 @@ function AchievementView(props: AchievementViewProps) {
   const prereqGoals = inferencer.listPrerequisiteGoals(focusUuid);
   const status = inferencer.getStatus(focusUuid);
 
-  const descriptionParagraphs = description.split('\n');
+  const descriptionParagraphs = description ? description.split('\n') : [''];
 
   return (
     <div className="view" style={{ ...getAbilityGlow(), ...getAbilityBackground() }}>

--- a/src/commons/achievement/view/AchievementViewCompletion.tsx
+++ b/src/commons/achievement/view/AchievementViewCompletion.tsx
@@ -6,7 +6,7 @@ type AchievementViewCompletionProps = {
 function AchievementViewCompletion(props: AchievementViewCompletionProps) {
   const { awardedXp, completionText } = props;
 
-  const paragraphs = completionText.split('\n');
+  const paragraphs = completionText ? completionText.split('\n') : [''];
 
   return (
     <div className="completion">


### PR DESCRIPTION
### Description

split is causing an error to occur when the contest's automatically generated achievement is clicked on. Probably due to the contest not having a shortDescription.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
