### PR TITLE
Fix misclassification of incomplete assessments

### DIFF
--- a/src/commons/achievement/utils/InsertFakeAchievements.ts
+++ b/src/commons/achievement/utils/InsertFakeAchievements.ts
@@ -9,6 +9,13 @@ import { AssessmentConfiguration, AssessmentOverview } from '../../assessment/As
 import AchievementInferencer from './AchievementInferencer';
 import { isExpired, isReleased } from './DateHelper';
 
+function assessmentCompleted(assessmentOverview: AssessmentOverview): boolean {
+  return (
+    assessmentOverview.gradingStatus === 'graded' ||
+    (!assessmentOverview.isManuallyGraded && assessmentOverview.status === 'submitted')
+  );
+}
+
 function insertFakeAchievements(
   assessmentOverviews: AssessmentOverview[],
   assessmentConfigs: AssessmentConfiguration[],
@@ -69,10 +76,9 @@ function insertFakeAchievements(
       inferencer.insertFakeAchievement({
         uuid: idString,
         title: assessmentOverview.title,
-        xp:
-          assessmentOverview.gradingStatus === 'graded' || !assessmentOverview.isManuallyGraded
-            ? assessmentOverview.xp
-            : assessmentOverview.maxXp,
+        xp: assessmentCompleted(assessmentOverview)
+          ? assessmentOverview.xp
+          : assessmentOverview.maxXp,
         isVariableXp: false,
         deadline: new Date(assessmentOverview.closeAt),
         release: new Date(assessmentOverview.openAt),
@@ -92,7 +98,7 @@ function insertFakeAchievements(
       });
 
       // if completed, add the uuid into the appropriate array
-      if (assessmentOverview.gradingStatus === 'graded' || !assessmentOverview.isManuallyGraded) {
+      if (assessmentCompleted(assessmentOverview)) {
         assessmentTypes.forEach((type, idx) => {
           if (type === assessmentOverview.type) {
             categorisedUuids[idx].push(idString);


### PR DESCRIPTION
### Description

Assessments that were not manually graded were being put under the completed assessment dropdown

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
