### PR TITLE
Send infinite loop related programs to Sentry

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -301,6 +301,8 @@ export const defaultSession: SessionState = {
   assessmentOverviews: undefined,
   agreedToResearch: undefined,
   experimentCoinflip: Math.random() < 0.5,
+  hadPreviousInfiniteLoop: false,
+  sessionId: Date.now(),
   githubOctokitObject: { octokit: undefined },
   gradingOverviews: undefined,
   gradings: new Map<number, Grading>(),

--- a/src/commons/application/actions/SessionActions.ts
+++ b/src/commons/application/actions/SessionActions.ts
@@ -60,6 +60,7 @@ import {
   UPDATE_COURSE_RESEARCH_AGREEMENT,
   UPDATE_GRADING,
   UPDATE_GRADING_OVERVIEWS,
+  UPDATE_INFINITE_LOOP_ENCOUNTERED,
   UPDATE_LATEST_VIEWED_COURSE,
   UPDATE_NOTIFICATIONS,
   UPDATE_USER_ROLE,
@@ -232,3 +233,5 @@ export const deleteUserCourseRegistration = (courseRegId: number) =>
 
 export const updateCourseResearchAgreement = (agreedToResearch: boolean) =>
   action(UPDATE_COURSE_RESEARCH_AGREEMENT, { agreedToResearch });
+
+export const updateInfiniteLoopEncountered = () => action(UPDATE_INFINITE_LOOP_ENCOUNTERED);

--- a/src/commons/application/actions/SessionActions.ts
+++ b/src/commons/application/actions/SessionActions.ts
@@ -234,5 +234,4 @@ export const deleteUserCourseRegistration = (courseRegId: number) =>
 export const updateCourseResearchAgreement = (agreedToResearch: boolean) =>
   action(UPDATE_COURSE_RESEARCH_AGREEMENT, { agreedToResearch });
 
-export const updateInfiniteLoopEncountered = (hadPreviousInfiniteLoop: boolean) =>
-  action(UPDATE_INFINITE_LOOP_ENCOUNTERED, { hadPreviousInfiniteLoop });
+export const updateInfiniteLoopEncountered = () => action(UPDATE_INFINITE_LOOP_ENCOUNTERED);

--- a/src/commons/application/actions/SessionActions.ts
+++ b/src/commons/application/actions/SessionActions.ts
@@ -234,4 +234,5 @@ export const deleteUserCourseRegistration = (courseRegId: number) =>
 export const updateCourseResearchAgreement = (agreedToResearch: boolean) =>
   action(UPDATE_COURSE_RESEARCH_AGREEMENT, { agreedToResearch });
 
-export const updateInfiniteLoopEncountered = () => action(UPDATE_INFINITE_LOOP_ENCOUNTERED);
+export const updateInfiniteLoopEncountered = (hadPreviousInfiniteLoop: boolean) =>
+  action(UPDATE_INFINITE_LOOP_ENCOUNTERED, { hadPreviousInfiniteLoop });

--- a/src/commons/application/actions/__tests__/SessionActions.ts
+++ b/src/commons/application/actions/__tests__/SessionActions.ts
@@ -41,6 +41,7 @@ import {
   UPDATE_COURSE_RESEARCH_AGREEMENT,
   UPDATE_GRADING,
   UPDATE_GRADING_OVERVIEWS,
+  UPDATE_INFINITE_LOOP_ENCOUNTERED,
   UPDATE_LATEST_VIEWED_COURSE,
   UPDATE_NOTIFICATIONS,
   UPDATE_USER_ROLE
@@ -82,6 +83,7 @@ import {
   updateCourseResearchAgreement,
   updateGrading,
   updateGradingOverviews,
+  updateInfiniteLoopEncountered,
   updateLatestViewedCourse,
   updateNotifications,
   updateUserRole
@@ -717,6 +719,13 @@ test('updateCourseResearchAgreement generates correct action object', () => {
   expect(action).toEqual({
     type: UPDATE_COURSE_RESEARCH_AGREEMENT,
     payload: { agreedToResearch }
+  });
+});
+
+test('updateInfiniteLoopEncountered generates correct action object', () => {
+  const action = updateInfiniteLoopEncountered();
+  expect(action).toEqual({
+    type: UPDATE_INFINITE_LOOP_ENCOUNTERED
   });
 });
 

--- a/src/commons/application/actions/__tests__/SessionActions.ts
+++ b/src/commons/application/actions/__tests__/SessionActions.ts
@@ -723,9 +723,10 @@ test('updateCourseResearchAgreement generates correct action object', () => {
 });
 
 test('updateInfiniteLoopEncountered generates correct action object', () => {
-  const action = updateInfiniteLoopEncountered();
+  const action = updateInfiniteLoopEncountered(true);
   expect(action).toEqual({
-    type: UPDATE_INFINITE_LOOP_ENCOUNTERED
+    type: UPDATE_INFINITE_LOOP_ENCOUNTERED,
+    payload: { hadPreviousInfiniteLoop: true }
   });
 });
 

--- a/src/commons/application/actions/__tests__/SessionActions.ts
+++ b/src/commons/application/actions/__tests__/SessionActions.ts
@@ -723,10 +723,9 @@ test('updateCourseResearchAgreement generates correct action object', () => {
 });
 
 test('updateInfiniteLoopEncountered generates correct action object', () => {
-  const action = updateInfiniteLoopEncountered(true);
+  const action = updateInfiniteLoopEncountered();
   expect(action).toEqual({
-    type: UPDATE_INFINITE_LOOP_ENCOUNTERED,
-    payload: { hadPreviousInfiniteLoop: true }
+    type: UPDATE_INFINITE_LOOP_ENCOUNTERED
   });
 });
 

--- a/src/commons/application/reducers/SessionsReducer.ts
+++ b/src/commons/application/reducers/SessionsReducer.ts
@@ -112,7 +112,7 @@ export const SessionsReducer: Reducer<SessionState> = (
     case UPDATE_INFINITE_LOOP_ENCOUNTERED:
       return {
         ...state,
-        hadPreviousInfiniteLoop: action.payload.hadPreviousInfiniteLoop
+        hadPreviousInfiniteLoop: true
       };
     case UPDATE_NOTIFICATIONS:
       return {

--- a/src/commons/application/reducers/SessionsReducer.ts
+++ b/src/commons/application/reducers/SessionsReducer.ts
@@ -112,7 +112,7 @@ export const SessionsReducer: Reducer<SessionState> = (
     case UPDATE_INFINITE_LOOP_ENCOUNTERED:
       return {
         ...state,
-        hadPreviousInfiniteLoop: true
+        hadPreviousInfiniteLoop: action.payload.hadPreviousInfiniteLoop
       };
     case UPDATE_NOTIFICATIONS:
       return {

--- a/src/commons/application/reducers/SessionsReducer.ts
+++ b/src/commons/application/reducers/SessionsReducer.ts
@@ -24,6 +24,7 @@ import {
   UPDATE_ASSESSMENT_OVERVIEWS,
   UPDATE_GRADING,
   UPDATE_GRADING_OVERVIEWS,
+  UPDATE_INFINITE_LOOP_ENCOUNTERED,
   UPDATE_NOTIFICATIONS
 } from '../types/SessionTypes';
 
@@ -107,6 +108,11 @@ export const SessionsReducer: Reducer<SessionState> = (
       return {
         ...state,
         gradingOverviews: action.payload
+      };
+    case UPDATE_INFINITE_LOOP_ENCOUNTERED:
+      return {
+        ...state,
+        hadPreviousInfiniteLoop: true
       };
     case UPDATE_NOTIFICATIONS:
       return {

--- a/src/commons/application/reducers/__tests__/SessionReducer.ts
+++ b/src/commons/application/reducers/__tests__/SessionReducer.ts
@@ -544,8 +544,7 @@ test('UPDATE_INFINITE_LOOP_ENCOUNTERED works correctly in updating had infinite 
     hadPreviousInfiniteLoop: false
   };
   const action = {
-    type: UPDATE_INFINITE_LOOP_ENCOUNTERED,
-    payload: { hadPreviousInfiniteLoop: true }
+    type: UPDATE_INFINITE_LOOP_ENCOUNTERED
   };
   const result: SessionState = SessionsReducer(newDefaultSession, action);
 

--- a/src/commons/application/reducers/__tests__/SessionReducer.ts
+++ b/src/commons/application/reducers/__tests__/SessionReducer.ts
@@ -544,7 +544,8 @@ test('UPDATE_INFINITE_LOOP_ENCOUNTERED works correctly in updating had infinite 
     hadPreviousInfiniteLoop: false
   };
   const action = {
-    type: UPDATE_INFINITE_LOOP_ENCOUNTERED
+    type: UPDATE_INFINITE_LOOP_ENCOUNTERED,
+    payload: { hadPreviousInfiniteLoop: true }
   };
   const result: SessionState = SessionsReducer(newDefaultSession, action);
 

--- a/src/commons/application/reducers/__tests__/SessionReducer.ts
+++ b/src/commons/application/reducers/__tests__/SessionReducer.ts
@@ -23,6 +23,7 @@ import {
   UPDATE_ASSESSMENT_OVERVIEWS,
   UPDATE_GRADING,
   UPDATE_GRADING_OVERVIEWS,
+  UPDATE_INFINITE_LOOP_ENCOUNTERED,
   UPDATE_NOTIFICATIONS
 } from '../../types/SessionTypes';
 import { SessionsReducer } from '../SessionsReducer';
@@ -535,6 +536,19 @@ test('UPDATE_GRADING_OVERVIEWS works correctly in updating grading overviews', (
   const result: SessionState = SessionsReducer(newDefaultSession, action);
 
   expect(result.gradingOverviews).toEqual(gradingOverviewsPayload);
+});
+
+test('UPDATE_INFINITE_LOOP_ENCOUNTERED works correctly in updating had infinite loop flag', () => {
+  const newDefaultSession = {
+    ...defaultSession,
+    hadPreviousInfiniteLoop: false
+  };
+  const action = {
+    type: UPDATE_INFINITE_LOOP_ENCOUNTERED
+  };
+  const result: SessionState = SessionsReducer(newDefaultSession, action);
+
+  expect(result.hadPreviousInfiniteLoop).toEqual(true);
 });
 
 test('UPDATE_NOTIFICATIONS works correctly in updating notifications', () => {

--- a/src/commons/application/types/SessionTypes.ts
+++ b/src/commons/application/types/SessionTypes.ts
@@ -57,6 +57,7 @@ export const DELETE_ASSESSMENT_CONFIG = 'DELETE_ASSESSMENT_CONFIG';
 export const FETCH_ADMIN_PANEL_COURSE_REGISTRATIONS = 'FETCH_ADMIN_PANEL_COURSE_REGISTRATIONS';
 export const UPDATE_USER_ROLE = 'UPDATE_USER_ROLE';
 export const UPDATE_COURSE_RESEARCH_AGREEMENT = 'UPDATE_COURSE_RESEARCH_AGREEMENT';
+export const UPDATE_INFINITE_LOOP_ENCOUNTERED = 'UPDATE_INFINITE_LOOP_ENCOUNTERED';
 export const DELETE_USER_COURSE_REGISTRATION = 'DELETE_USER_COURSE_REGISTRATION';
 
 export const UPLOAD_KEYSTROKE_LOGS = 'UPLOAD_KEYSTROKE_LOGS';
@@ -99,6 +100,8 @@ export type SessionState = {
   // For infinite loop research data collection
   readonly agreedToResearch?: boolean | null;
   readonly experimentCoinflip: boolean;
+  readonly hadPreviousInfiniteLoop: boolean;
+  readonly sessionId: number;
 
   readonly assessmentOverviews?: AssessmentOverview[];
   readonly assessments: Map<number, Assessment>;

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -817,7 +817,7 @@ export function* evalCode(
         const lastError = context.errors[context.errors.length - 1];
         if (infiniteLoopData) {
           events.push(EventType.INFINITE_LOOP);
-          yield put(actions.updateInfiniteLoopEncountered());
+          yield put(actions.updateInfiniteLoopEncountered(true));
           yield call(reportInfiniteLoopError, sessionId, coinflip, ...infiniteLoopData);
         } else if (isPotentialInfiniteLoop(lastError)) {
           events.push(EventType.INFINITE_LOOP);
@@ -858,6 +858,7 @@ export function* evalCode(
     ]);
     if (approval && previousInfiniteLoop) {
       yield call(reportNonErrorProgram, sessionId, context.previousCode);
+      yield put(actions.updateInfiniteLoopEncountered(false));
     }
   }
 

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -817,7 +817,7 @@ export function* evalCode(
         const lastError = context.errors[context.errors.length - 1];
         if (infiniteLoopData) {
           events.push(EventType.INFINITE_LOOP);
-          yield put(actions.updateInfiniteLoopEncountered(true));
+          yield put(actions.updateInfiniteLoopEncountered());
           yield call(reportInfiniteLoopError, sessionId, coinflip, ...infiniteLoopData);
         } else if (isPotentialInfiniteLoop(lastError)) {
           events.push(EventType.INFINITE_LOOP);
@@ -858,7 +858,6 @@ export function* evalCode(
     ]);
     if (approval && previousInfiniteLoop) {
       yield call(reportNonErrorProgram, sessionId, context.previousCode);
-      yield put(actions.updateInfiniteLoopEncountered(false));
     }
   }
 

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -803,11 +803,11 @@ describe('evalCode', () => {
 
       return expectSaga(evalCode, theCode, context, execTime, workspaceLocation, actionType)
         .withState(state)
-        .put(updateInfiniteLoopEncountered())
+        .put(updateInfiniteLoopEncountered(true))
         .silentRun();
     });
 
-    test('reports non error code to sentry after infinite loop', () => {
+    test('reports non error code to sentry after infinite loop and resets flag', () => {
       state = {
         ...state,
         session: {
@@ -824,6 +824,7 @@ describe('evalCode', () => {
       return expectSaga(evalCode, theCode, context, execTime, workspaceLocation, actionType)
         .withState(state)
         .call(reportNonErrorProgram, defaultSessionId, [theCode])
+        .put(updateInfiniteLoopEncountered(false))
         .silentRun();
     });
 

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -803,11 +803,11 @@ describe('evalCode', () => {
 
       return expectSaga(evalCode, theCode, context, execTime, workspaceLocation, actionType)
         .withState(state)
-        .put(updateInfiniteLoopEncountered(true))
+        .put(updateInfiniteLoopEncountered())
         .silentRun();
     });
 
-    test('reports non error code to sentry after infinite loop and resets flag', () => {
+    test('reports non error code to sentry after infinite loop', () => {
       state = {
         ...state,
         session: {
@@ -824,7 +824,6 @@ describe('evalCode', () => {
       return expectSaga(evalCode, theCode, context, execTime, workspaceLocation, actionType)
         .withState(state)
         .call(reportNonErrorProgram, defaultSessionId, [theCode])
-        .put(updateInfiniteLoopEncountered(false))
         .silentRun();
     });
 

--- a/src/commons/utils/InfiniteLoopReporter.ts
+++ b/src/commons/utils/InfiniteLoopReporter.ts
@@ -11,6 +11,7 @@ import {
  * single issue in Sentry.
  */
 function reportInfiniteLoopError(
+  sessionId: number,
   coinflip: boolean,
   errorType: InfiniteLoopErrorType,
   isStream: boolean,
@@ -23,6 +24,7 @@ function reportInfiniteLoopError(
     scope.setTag('error-type', InfiniteLoopErrorType[errorType]);
     scope.setTag('coinflip', coinflip ? 'yes' : 'no');
     scope.setTag('is-stream', isStream ? 'yes' : 'no');
+    scope.setExtra('sessionId', sessionId.toString());
     scope.setExtra('message', message);
     scope.setExtra('code', JSON.stringify(code));
     scope.setFingerprint(['INFINITE_LOOP_LOGGING_FINGERPRINT_2022']);
@@ -42,16 +44,45 @@ function reportInfiniteLoopError(
  * @param {string} message - the error's message
  * @param {string} code - code to be sent along with the error
  */
-function reportPotentialInfiniteLoop(coinflip: boolean, message: string, code: string[]) {
+function reportPotentialInfiniteLoop(
+  sessionId: number,
+  coinflip: boolean,
+  message: string,
+  code: string[]
+) {
   Sentry.withScope(function (scope) {
     scope.clearBreadcrumbs();
     scope.setLevel(Sentry.Severity.Info);
     scope.setTag('coinflip', coinflip ? 'yes' : 'no');
     scope.setTag('error-type', 'Undetected');
+    scope.setExtra('sessionId', sessionId.toString());
     scope.setExtra('message', message);
     scope.setExtra('code', JSON.stringify(code));
     scope.setFingerprint(['INFINITE_LOOP_LOGGING_FINGERPRINT_2022']);
     const err = new Error('Infinite Loop');
+    // remove stack trace whenever we can to save space
+    err.stack = '';
+    Sentry.captureException(err);
+  });
+}
+
+/**
+ * Sends a program with no errors to Sentry.
+ *
+ * Uses a unique Sentry fingerprint so all 'errors' reported
+ * here are grouped under a single issue in Sentry.
+ *
+ * @param {string} message - the error's message
+ * @param {string} code - code to be sent along with the error
+ */
+function reportNonErrorProgram(sessionId: number, code: string[]) {
+  Sentry.withScope(function (scope) {
+    scope.clearBreadcrumbs();
+    scope.setLevel(Sentry.Severity.Info);
+    scope.setExtra('sessionId', sessionId.toString());
+    scope.setExtra('code', JSON.stringify(code));
+    scope.setFingerprint(['INFINITE_LOOP_LOGGING_FINGERPRINT_2022_NONERROR']);
+    const err = new Error('Non Infinite Loop');
     // remove stack trace whenever we can to save space
     err.stack = '';
     Sentry.captureException(err);
@@ -63,5 +94,6 @@ export {
   reportInfiniteLoopError,
   InfiniteLoopErrorType,
   isPotentialInfiniteLoop,
-  reportPotentialInfiniteLoop
+  reportPotentialInfiniteLoop,
+  reportNonErrorProgram
 };


### PR DESCRIPTION
### Description

We would like to know whether a student has successfully 'fixed' their infinite loop.
To find out, after an infinite loop is encountered, we will send all programs the student runs to Sentry.
Created a flag in `state.session` called `hadPreviousInfiniteLoop` to keep track of this.

Also created another flag `state.session.sessionId` which will be set to the system time when it is initialized.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How to test

1. Ensure REACT_APP_SENTRY_DSN is set to the correct url in the environment variables (.env file)
1. Set approval to true in the infinite loop reporting part of WorkspaceSaga.ts (~line793)
1. Run any program that will cause an infinite loop. Example: `function f(x){f(x);}f(1);`
1. Run any non-infinite looping program. Example: `1+1;`
1. Check that the issue "Error: Non Infinite Loop" is added on the Sentry dashboard

### Checklist

- [x] I have tested this code