### PR TITLE
Update step size in grading editor

### DIFF
--- a/src/pages/academy/grading/subcomponents/GradingEditor.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingEditor.tsx
@@ -167,6 +167,9 @@ class GradingEditor extends React.Component<GradingEditorProps, State> {
                       ? this.props.maxXp - this.props.initialXp
                       : undefined
                   }
+                  stepSize={50}
+                  minorStepSize={25}
+                  majorStepSize={100}
                 />
               </div>
             </div>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Use `50` as step size in grading editor, since most marking schemes have `50` as the minimum breakdown, so it is easier to grade by clicking.
- This does not affect manual entering, so xps that are not multiples of `50` can still be given.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
