### PR TITLE
Fix Ctrl+B (open docs) for remote execution libraries

### DIFF
--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -179,6 +179,11 @@ const Playground: React.FC<PlaygroundProps> = props => {
 
   const usingRemoteExecution =
     useSelector((state: OverallState) => !!state.session.remoteExecutionSession) && !isSicpEditor;
+  // this is still used by remote execution (EV3)
+  // specifically, for the editor Ctrl+B to work
+  const externalLibraryName = useSelector(
+    (state: OverallState) => state.workspaces.playground.externalLibrary
+  );
 
   React.useEffect(() => {
     // When the editor session Id changes, then treat it as a new session.
@@ -668,7 +673,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     onSelectionChange: onSelectionChangeMethod,
     onLoad: isSicpEditor && props.prependLength ? onLoadMethod : undefined,
     sourceChapter: props.playgroundSourceChapter,
-    externalLibraryName: ExternalLibraryName.NONE, // temporary placeholder as we phase out libraries
+    externalLibraryName,
     sourceVariant: props.playgroundSourceVariant,
     editorValue: props.editorValue,
     editorSessionId: props.editorSessionId,


### PR DESCRIPTION
### Description

Fix Ctrl+B to open documentation for functions in remote execution libraries.

Unfortunately this is actually a use of external libraries that can't be removed.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

Test that Ctrl+B opens documentation for EV3 functions like `ev3_colorSensor` when the EV3 library is enabled (when connected to an EV3 device).

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
