### PR TITLE
Fix autocomplete in AssessmentWorkspace

### DIFF
--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -538,6 +538,7 @@ export const getAssessment = async (id: number, tokens: Tokens): Promise<Assessm
       question.prepend = question.prepend || '';
       question.postpend = question.postpend || '';
       question.testcases = question.testcases || [];
+      question.library.variant = question.library.variant || 'default';
       q = question;
     }
 

--- a/src/commons/utils/CastBackend.ts
+++ b/src/commons/utils/CastBackend.ts
@@ -13,7 +13,7 @@ export const castLibrary = (lib: any): Library => ({
     symbols: lib.external.symbols
   },
   execTimeMs: lib.execTimeMs,
-  variant: lib.variant,
+  variant: lib.variant || 'default',
   /** globals are passed as an object, mapping symbol name -> value */
   globals: Object.entries(lib.globals as object).map(entry => {
     /** The value that is passed is evaluated into an actual JS value */


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously, the AssessmentWorkspace and GradingWorkspace autocomplete were broken as the Variant received from the backend was `null` instead of `default`. As a result, `chapterName` became something like `3_null` and the `builtinSuggestions` became an empty array as seen below:

```
      // line 135 WorkspaceSaga.ts
      let chapterName = context.chapter.toString();
      if (context.variant !== 'default') {
        chapterName += '_' + context.variant;
      }

      const builtinSuggestions = Documentation.builtins[chapterName] || [];
```

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Test that the default chapter builtins show up in the autocomplete in AssessmentWorkspace and GradingWorkspace

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code

