### PR TITLE
Fix display of autograder runtime errors

### DIFF
--- a/src/commons/sideContent/SideContentResultCard.tsx
+++ b/src/commons/sideContent/SideContentResultCard.tsx
@@ -18,9 +18,11 @@ const buildErrorString = (errors: AutogradingError[]) =>
         case 'timeout':
           return '[TIMEOUT] Submission exceeded time limit for this test case.';
         case 'syntax':
-          return `[SYNTAX] Line ${error.line}: Error: ${error.errorExplanation}`;
+          return `[SYNTAX] Line ${error.line}: ${error.errorExplanation}`;
+        case 'runtime':
+          return `[RUNTIME] Line ${error.line}: ${error.errorExplanation}`;
         case 'systemError':
-          return `[RUNTIME] ${error.errorMessage}`;
+          return `[SYSTEM] ${error.errorMessage}`;
         default:
           return `[UNKNOWN] Autograder error: type ${error.errorType}`;
       }

--- a/src/commons/sideContent/__tests__/SideContentAutograder.tsx
+++ b/src/commons/sideContent/__tests__/SideContentAutograder.tsx
@@ -267,13 +267,13 @@ test('Autograder renders autograder results with different statuses correctly', 
     ['1', 'PASS', '', ''],
     ['2', 'FAIL', '8', '5'],
     ['3', 'ERROR', '', '[UNKNOWN] Autograder error: type dummyErrorType'],
-    ['4', 'ERROR', '', "[RUNTIME] Cannot read property 'getUniformLocation' of null"],
+    ['4', 'ERROR', '', "[SYSTEM] Cannot read property 'getUniformLocation' of null"],
     [
       '5',
       'ERROR',
       '',
       '[TIMEOUT] Submission exceeded time limit for this test case.\n\n' +
-        '[SYNTAX] Line 2: Error: Missing semicolon at the end of statement'
+        '[SYNTAX] Line 2: Missing semicolon at the end of statement'
     ]
   ]);
 });

--- a/src/commons/sideContent/__tests__/__snapshots__/SideContentAutograder.tsx.snap
+++ b/src/commons/sideContent/__tests__/__snapshots__/SideContentAutograder.tsx.snap
@@ -228,7 +228,7 @@ exports[`Autograder renders autograder results with different statuses correctly
                     </Component>
                     <Component className=\\"result-actual\\">
                       <pre className=\\"bp3-code-block result-actual\\">
-                        [RUNTIME] Cannot read property &#39;getUniformLocation&#39; of null
+                        [SYSTEM] Cannot read property &#39;getUniformLocation&#39; of null
                       </pre>
                     </Component>
                   </div>
@@ -254,7 +254,7 @@ exports[`Autograder renders autograder results with different statuses correctly
                       <pre className=\\"bp3-code-block result-actual\\">
                         [TIMEOUT] Submission exceeded time limit for this test case.
                         
-                        [SYNTAX] Line 2: Error: Missing semicolon at the end of statement
+                        [SYNTAX] Line 2: Missing semicolon at the end of statement
                       </pre>
                     </Component>
                   </div>


### PR DESCRIPTION
### Description

Fix display of autograder runtime errors.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

See that runtime errors that happen during autograding are shown correctly.

### Checklist

- [x] I have tested this code
