### PR TITLE
fullJS security enhancements 

### DIFF
--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -12,6 +12,7 @@ import {
   styliseSublanguage,
   variantLanguages
 } from '../application/ApplicationTypes';
+import Constants from '../utils/Constants';
 
 type ControlBarChapterSelectProps = DispatchProps & StateProps;
 
@@ -41,7 +42,7 @@ export function ControlBarChapterSelect(props: ControlBarChapterSelectProps) {
     return (
       <Menu ulRef={itemsParentRef}>
         {defaultChoices}
-        {nativeJSChoice}
+        {Constants.playgroundOnly && nativeJSChoice}
         <MenuItem key="variant-menu" text="Variants" icon="cog">
           {variantChoices}
         </MenuItem>

--- a/src/commons/nativeJS/NativeJSUtils.tsx
+++ b/src/commons/nativeJS/NativeJSUtils.tsx
@@ -1,4 +1,5 @@
 import { showSimpleConfirmDialog, SimpleConfirmDialogProps } from '../utils/DialogHelper';
+import { showWarningMessage } from '../utils/NotificationsHelper';
 
 const DISCLAIMER_DIALOG_PROPS: SimpleConfirmDialogProps = {
   icon: 'warning-sign',
@@ -20,6 +21,13 @@ const DISCLAIMER_DIALOG_PROPS: SimpleConfirmDialogProps = {
   negativeLabel: 'Cancel'
 };
 
+const ULR_LOAD_INFO: string =
+  'For security concerns, users are not allowed to load full JavaScript code from shared links';
+
 export function showNativeJSDisclaimer(): Promise<boolean> {
   return showSimpleConfirmDialog(DISCLAIMER_DIALOG_PROPS);
+}
+
+export function showNativeJSWarningOnUrlLoad(): void {
+  showWarningMessage(ULR_LOAD_INFO);
 }

--- a/src/commons/nativeJS/NativeJSUtils.tsx
+++ b/src/commons/nativeJS/NativeJSUtils.tsx
@@ -6,7 +6,7 @@ const DISCLAIMER_DIALOG_PROPS: SimpleConfirmDialogProps = {
   title: 'You are switching to a unsafe feature!',
   contents: (
     <p>
-      <code>full Javascript</code> allows you to run arbitrary JS code beyond source.
+      <code>full JavaScript</code> allows you to run arbitrary JS code beyond source.
       <br />
       <br />
       This might pose a security concern if you are not careful and fully aware of what program you
@@ -21,7 +21,7 @@ const DISCLAIMER_DIALOG_PROPS: SimpleConfirmDialogProps = {
   negativeLabel: 'Cancel'
 };
 
-const ULR_LOAD_INFO: string =
+const URL_LOAD_INFO: string =
   'For security concerns, users are not allowed to load full JavaScript code from shared links';
 
 export function showNativeJSDisclaimer(): Promise<boolean> {
@@ -29,5 +29,5 @@ export function showNativeJSDisclaimer(): Promise<boolean> {
 }
 
 export function showNativeJSWarningOnUrlLoad(): void {
-  showWarningMessage(ULR_LOAD_INFO);
+  showWarningMessage(URL_LOAD_INFO);
 }

--- a/src/commons/nativeJS/NativeJSUtils.tsx
+++ b/src/commons/nativeJS/NativeJSUtils.tsx
@@ -1,4 +1,4 @@
-import { showSimpleConfirmDialog, SimpleConfirmDialogProps } from "../utils/DialogHelper"
+import { showSimpleConfirmDialog, SimpleConfirmDialogProps } from '../utils/DialogHelper';
 
 const DISCLAIMER_DIALOG_PROPS: SimpleConfirmDialogProps = {
   icon: 'warning-sign',
@@ -6,15 +6,19 @@ const DISCLAIMER_DIALOG_PROPS: SimpleConfirmDialogProps = {
   contents: (
     <p>
       <code>full Javascript</code> allows you to run arbitrary JS code beyond source.
-      <br/><br/>This might pose a security concern if you are not careful and fully aware of what program you are running!
-      <br/><br/><strong>Do you still want to proceed?</strong>
+      <br />
+      <br />
+      This might pose a security concern if you are not careful and fully aware of what program you
+      are running!
+      <br />
+      <br />
+      <strong>Do you still want to proceed?</strong>
     </p>
   ),
   positiveIntent: 'danger',
   positiveLabel: 'Proceed',
   negativeLabel: 'Cancel'
 };
-
 
 export function showNativeJSDisclaimer(): Promise<boolean> {
   return showSimpleConfirmDialog(DISCLAIMER_DIALOG_PROPS);

--- a/src/commons/nativeJS/NativeJSUtils.tsx
+++ b/src/commons/nativeJS/NativeJSUtils.tsx
@@ -1,0 +1,21 @@
+import { showSimpleConfirmDialog, SimpleConfirmDialogProps } from "../utils/DialogHelper"
+
+const DISCLAIMER_DIALOG_PROPS: SimpleConfirmDialogProps = {
+  icon: 'warning-sign',
+  title: 'You are switching to a unsafe feature!',
+  contents: (
+    <p>
+      <code>full Javascript</code> allows you to run arbitrary JS code beyond source.
+      <br/><br/>This might pose a security concern if you are not careful and fully aware of what program you are running!
+      <br/><br/><strong>Do you still want to proceed?</strong>
+    </p>
+  ),
+  positiveIntent: 'danger',
+  positiveLabel: 'Proceed',
+  negativeLabel: 'Cancel'
+};
+
+
+export function showNativeJSDisclaimer(): Promise<boolean> {
+  return showSimpleConfirmDialog(DISCLAIMER_DIALOG_PROPS);
+}

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -252,11 +252,11 @@ export default function* WorkspaceSaga(): SagaIterator {
     ]);
 
     const chapterChanged: boolean = newChapter !== oldChapter || newVariant !== oldVariant;
-    const changeChapter: boolean = isNativeJSChapter(newChapter)
+    const toChangeChapter: boolean = isNativeJSChapter(newChapter)
       ? chapterChanged && (yield call(showNativeJSDisclaimer))
       : chapterChanged;
 
-    if (changeChapter) {
+    if (toChangeChapter) {
       const library = {
         chapter: newChapter,
         variant: newVariant,

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -43,6 +43,7 @@ import { Testcase, TestcaseType, TestcaseTypes } from '../assessment/AssessmentT
 import { Documentation } from '../documentation/Documentation';
 import { SideContentType } from '../sideContent/SideContentTypes';
 import { actions } from '../utils/ActionsHelper';
+import { showSimpleConfirmDialog } from '../utils/DialogHelper';
 import {
   getInfiniteLoopData,
   isPotentialInfiniteLoop,
@@ -251,23 +252,37 @@ export default function* WorkspaceSaga(): SagaIterator {
     ]);
 
     if (newChapter !== oldChapter || newVariant !== oldVariant) {
-      const library = {
-        chapter: newChapter,
-        variant: newVariant,
-        external: {
-          name: externalLibraryName,
-          symbols
-        },
-        globals
-      };
-      yield put(actions.beginClearContext(workspaceLocation, library, false));
-      yield put(actions.clearReplOutput(workspaceLocation));
-      yield put(actions.debuggerReset(workspaceLocation));
-      yield call(
-        showSuccessMessage,
-        `Switched to ${styliseSublanguage(newChapter, newVariant)}`,
-        1000
-      );
+      // When full JavaScript is chosen, put on a disclaimer
+      if (
+        !isNativeJSChapter(newChapter) ||
+        (yield call(showSimpleConfirmDialog, {
+          icon: 'warning-sign',
+          title: 'You are entering danger zone!',
+          contents:
+            '"full JavaScript" allows you to run any JavaScript code beyond Source. Note that malignant programs might stole your tokens. Are you sure to proceed?',
+          positiveIntent: 'danger',
+          positiveLabel: 'At my own risk!',
+          negativeLabel: 'Keep me safe then.'
+        }))
+      ) {
+        const library = {
+          chapter: newChapter,
+          variant: newVariant,
+          external: {
+            name: externalLibraryName,
+            symbols
+          },
+          globals
+        };
+        yield put(actions.beginClearContext(workspaceLocation, library, false));
+        yield put(actions.clearReplOutput(workspaceLocation));
+        yield put(actions.debuggerReset(workspaceLocation));
+        yield call(
+          showSuccessMessage,
+          `Switched to ${styliseSublanguage(newChapter, newVariant)}`,
+          1000
+        );
+      }
     }
   });
 

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -251,7 +251,7 @@ export default function* WorkspaceSaga(): SagaIterator {
       state.workspaces[workspaceLocation].externalLibrary
     ]);
 
-    const chapterChanged: boolean = newChapter !== oldChapter || newVariant !== oldVariant
+    const chapterChanged: boolean = newChapter !== oldChapter || newVariant !== oldVariant;
     const changeChapter: boolean = isNativeJSChapter(newChapter)
       ? chapterChanged && (yield call(showNativeJSDisclaimer))
       : chapterChanged;

--- a/src/commons/utils/DialogHelper.tsx
+++ b/src/commons/utils/DialogHelper.tsx
@@ -75,7 +75,7 @@ export function showConfirmDialog<T>(
   }));
 }
 
-export function showSimpleConfirmDialog(props: {
+export interface SimpleConfirmDialogProps {
   icon?: IconName;
   title?: string;
   contents?: React.ReactNode;
@@ -83,7 +83,9 @@ export function showSimpleConfirmDialog(props: {
   positiveIntent?: Intent;
   negativeLabel?: string;
   props?: Partial<ConfirmDialogProps<boolean>>;
-}): Promise<boolean> {
+}
+
+export function showSimpleConfirmDialog(props: SimpleConfirmDialogProps): Promise<boolean> {
   return showConfirmDialog<boolean>({
     title: props.title,
     contents: props.contents,

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -12,7 +12,7 @@ import { HotKeys } from 'react-hotkeys';
 import { useSelector } from 'react-redux';
 import { useMediaQuery } from 'react-responsive';
 import { RouteComponentProps } from 'react-router';
-import { showWarningMessage } from 'src/commons/utils/NotificationsHelper';
+import { showNativeJSWarningOnUrlLoad } from 'src/commons/nativeJS/NativeJSUtils';
 
 import {
   InterpreterOutput,
@@ -139,12 +139,12 @@ export type StateProps = {
 
 const keyMap = { goGreen: 'h u l k' };
 
-function handleHash(hash: string, props: PlaygroundProps) {
+export function handleHash(hash: string, props: PlaygroundProps) {
   const qs = parseQuery(hash);
 
   const chapter = stringParamToInt(qs.chap) || undefined;
   if (chapter && isNativeJSChapter(chapter)) {
-    showWarningMessage(`Users are not allowed to load full JavaScript code from shared links.`);
+    showNativeJSWarningOnUrlLoad();
   } else {
     const programLz = qs.lz ?? qs.prgrm;
     const program = programLz && decompressFromEncodedURIComponent(programLz);

--- a/src/pages/playground/__tests__/Playground.tsx
+++ b/src/pages/playground/__tests__/Playground.tsx
@@ -5,7 +5,7 @@ import { mockInitialStore } from 'src/commons/mocks/StoreMocks';
 
 import { Position } from '../../../commons/editor/EditorTypes';
 import { mockRouterProps } from '../../../commons/mocks/ComponentMocks';
-import Playground, { PlaygroundProps } from '../Playground';
+import Playground, { handleHash, PlaygroundProps } from '../Playground';
 
 const baseProps = {
   editorValue: '',
@@ -104,4 +104,25 @@ test('Playground with link renders correctly', () => {
   );
   const tree = shallow(app);
   expect(tree.debug()).toMatchSnapshot();
+});
+
+describe('handleHash', () => {
+  test('disables loading hash with fullJS chapter in URL params', () => {
+    const testHash = '#chap=-1&prgrm=CYSwzgDgNghgngCgOQAsCmUoHsCESCUA3EA';
+
+    const mockHandleEditorValueChanged = jest.fn();
+    const mockHandleChapterSelect = jest.fn();
+    const mockHandleChangeExecTime = jest.fn();
+
+    handleHash(testHash, {
+      ...playgroundLinkProps, // dummy props (will not be used)
+      handleEditorValueChange: mockHandleEditorValueChanged,
+      handleChapterSelect: mockHandleChapterSelect,
+      handleChangeExecTime: mockHandleChangeExecTime
+    });
+
+    expect(mockHandleEditorValueChanged).not.toHaveBeenCalled();
+    expect(mockHandleChapterSelect).not.toHaveBeenCalled();
+    expect(mockHandleChangeExecTime).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
- Fixes #2058 
- Fixes #2059 
- Fixes #2062  

### Description
As the title and previous issues suggest, this PR adds a disclaimer when user tries to switch to `fullJS` mode. Inside `fullJS`, there will be no `Share` button provided, and any link that includes `chap=-1` will be rejected with a warning.

### Demo
![disclaimer](https://user-images.githubusercontent.com/95509524/151637433-c7935e23-21c3-46b0-9975-4cf7cf0e7dd7.png)
![warning](https://user-images.githubusercontent.com/95509524/151637450-41d53278-05c3-4083-a013-af583425613b.png)
![source buttons](https://user-images.githubusercontent.com/95509524/151637479-643fc3b9-722d-4188-87af-47a55717c358.png)
![fullJS buttons](https://user-images.githubusercontent.com/95509524/151637493-df87906c-7a84-4600-9722-b42a60fccd0a.png)