### PR TITLE
Fix draw_data([])

### DIFF
--- a/src/features/dataVisualizer/Config.ts
+++ b/src/features/dataVisualizer/Config.ts
@@ -7,6 +7,7 @@ export const Config = {
   Fill: 'white',
 
   BoxWidth: 45,
+  BoxMinWidth: 15, // Set to half of BoxHeight for empty arrays following EnvVisualizerConfig
   BoxHeight: 30,
   BoxSpacingX: 50,
   BoxSpacingY: 60,

--- a/src/features/dataVisualizer/drawable/ArrayDrawable.tsx
+++ b/src/features/dataVisualizer/drawable/ArrayDrawable.tsx
@@ -51,7 +51,7 @@ export class ArrayDrawable extends React.PureComponent<ArrayProps> {
       <Group x={this.props.x} y={this.props.y}>
         {/* Outer rectangle */}
         <Rect
-          width={Config.BoxWidth * this.props.nodes.length}
+          width={Math.max(Config.BoxWidth * this.props.nodes.length, Config.BoxMinWidth)}
           height={Config.BoxHeight}
           strokeWidth={Config.StrokeWidth}
           stroke={Config.Stroke}

--- a/src/features/dataVisualizer/drawable/ArrayDrawable.tsx
+++ b/src/features/dataVisualizer/drawable/ArrayDrawable.tsx
@@ -59,17 +59,18 @@ export class ArrayDrawable extends React.PureComponent<ArrayProps> {
           preventDefault={false}
         />
         {/* Vertical lines in the box */}
-        {Array.from(Array(this.props.nodes.length - 1), (e, i) => {
-          return (
-            <Line
-              key={'line' + i}
-              points={[Config.BoxWidth * (i + 1), 0, Config.BoxWidth * (i + 1), Config.BoxHeight]}
-              strokeWidth={Config.StrokeWidth}
-              stroke={Config.Stroke}
-              preventDefault={false}
-            />
-          );
-        })}
+        {this.props.nodes.length > 1 &&
+          Array.from(Array(this.props.nodes.length - 1), (e, i) => {
+            return (
+              <Line
+                key={'line' + i}
+                points={[Config.BoxWidth * (i + 1), 0, Config.BoxWidth * (i + 1), Config.BoxHeight]}
+                strokeWidth={Config.StrokeWidth}
+                stroke={Config.Stroke}
+                preventDefault={false}
+              />
+            );
+          })}
         {this.props.nodes.map(
           (child, index) => child instanceof DataTreeNode && createChildText(child, index)
         )}

--- a/src/features/dataVisualizer/tree/Tree.tsx
+++ b/src/features/dataVisualizer/tree/Tree.tsx
@@ -266,7 +266,8 @@ class TreeDrawer {
           childrenWidths.length > 0 ? childrenWidths.reduce((x, y) => x + y + Config.DistanceX) : 0;
         const nodeWidth = Math.max(
           node.children.length * Config.BoxWidth + Config.StrokeWidth,
-          childrenWidth
+          childrenWidth,
+          Config.BoxMinWidth + Config.StrokeWidth
         );
         this.nodeWidths.set(node, nodeWidth);
         return nodeWidth;


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Since only n - 1 lines need to be drawn, the vertical lines only need to be drawn for arrays of length > 1. Previously tried to create Array of length = -1.
Fixes source-academy/js-slang#1181

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Running `draw_data([]);` displays array with width 0
Running `draw_data([null, null]);` displays array with vertical line between boxes.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
