### PR TITLE
Implement SICP section cache to remember last viewed page

### DIFF
--- a/src/commons/application/Application.tsx
+++ b/src/commons/application/Application.tsx
@@ -136,10 +136,7 @@ const Application: React.FC<ApplicationProps> = props => {
       to="/sicpjs/:section?"
       key="oldToNewSicpRedirect"
     />,
-    <Route exact path="/sicpjs" key="sicpRedirect">
-      <Redirect to="/sicpjs/index" />
-    </Route>,
-    <Route path="/sicpjs/:section" component={Sicp} key="sicp" />,
+    <Route path="/sicpjs/:section?" component={Sicp} key="sicp" />,
     Constants.enableGitHubAssessments ? (
       <Route
         path="/githubassessments"

--- a/src/commons/application/__tests__/__snapshots__/Application.tsx.snap
+++ b/src/commons/application/__tests__/__snapshots__/Application.tsx.snap
@@ -10,10 +10,7 @@ exports[`Application renders correctly 1`] = `
         <Route path=\\"/contributors\\" component={[function]} />
         <Route path=\\"/callback/github\\" component={[Function: GitHubCallback]} />
         <Redirect from=\\"/interactive-sicp/:section?\\" to=\\"/sicpjs/:section?\\" />
-        <Route exact={true} path=\\"/sicpjs\\">
-          <Redirect to=\\"/sicpjs/index\\" />
-        </Route>
-        <Route path=\\"/sicpjs/:section\\" component={[Function: Sicp]} />
+        <Route path=\\"/sicpjs/:section?\\" component={[Function: Sicp]} />
         <Route path=\\"/githubassessments\\" render={[Function: render]} />
         <Route path=\\"/courses/:courseId(\\\\\\\\d+)?\\" render={[Function: redirectToLogin]} />
         <Route path=\\"/welcome\\" render={[Function: redirectToLogin]} />

--- a/src/commons/navigationBar/NavigationBar.tsx
+++ b/src/commons/navigationBar/NavigationBar.tsx
@@ -132,7 +132,7 @@ const NavigationBar: React.FC<NavigationBarProps> = props => {
                 Classes.MINIMAL,
                 Classes.LARGE
               )}
-              to="/sicpjs/index"
+              to={`/sicpjs/`}
               onClick={() => setMobileSideMenuOpen(false)}
             >
               <Icon icon={IconNames.BOOK} />
@@ -162,7 +162,7 @@ const NavigationBar: React.FC<NavigationBarProps> = props => {
         <NavLink
           activeClassName={Classes.ACTIVE}
           className={classNames('NavigationBar__link__mobile', Classes.BUTTON, Classes.MINIMAL)}
-          to="/sicpjs/index"
+          to={`/sicpjs/`}
         >
           <Icon icon={IconNames.BOOK} />
           <div>SICP JS</div>
@@ -182,7 +182,7 @@ const NavigationBar: React.FC<NavigationBarProps> = props => {
       <NavLink
         activeClassName={Classes.ACTIVE}
         className={classNames('NavigationBar__link__mobile', Classes.BUTTON, Classes.MINIMAL)}
-        to="/sicpjs/index"
+        to={`/sicpjs/`}
       >
         <Icon icon={IconNames.BOOK} />
         <div>SICP JS</div>
@@ -326,7 +326,7 @@ const NavigationBar: React.FC<NavigationBarProps> = props => {
         <NavLink
           activeClassName={Classes.ACTIVE}
           className={classNames('NavigationBar__link', Classes.BUTTON, Classes.MINIMAL)}
-          to="/sicpjs/index"
+          to={`/sicpjs/`}
         >
           <Icon icon={IconNames.BOOK} />
           <div className="navbar-button-text">SICP JS</div>

--- a/src/commons/navigationBar/__tests__/__snapshots__/NavigationBar.tsx.snap
+++ b/src/commons/navigationBar/__tests__/__snapshots__/NavigationBar.tsx.snap
@@ -72,7 +72,7 @@ exports[`NavigationBar renders correctly for student with course 1`] = `
           Classroom
         </div>
       </NavLink>
-      <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/sicpjs/index\\">
+      <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/sicpjs/\\">
         <Blueprint3.Icon icon=\\"book\\" />
         <div className=\\"navbar-button-text\\">
           SICP JS
@@ -130,7 +130,7 @@ exports[`NavigationBar renders correctly for student without course 1`] = `
           Classroom
         </div>
       </NavLink>
-      <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/sicpjs/index\\">
+      <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link bp3-button bp3-minimal\\" to=\\"/sicpjs/\\">
         <Blueprint3.Icon icon=\\"book\\" />
         <div className=\\"navbar-button-text\\">
           SICP JS

--- a/src/commons/navigationBar/subcomponents/NavigationBarMobileSideMenu.tsx
+++ b/src/commons/navigationBar/subcomponents/NavigationBarMobileSideMenu.tsx
@@ -123,7 +123,7 @@ const NavigationBarMobileSideMenu: React.FC<NavigationBarMobileSideMenuProps> = 
           Classes.MINIMAL,
           Classes.LARGE
         )}
-        to="/sicpjs/index"
+        to={`/sicpjs/`}
         onClick={props.onClose}
       >
         <Icon icon={IconNames.BOOK} />

--- a/src/commons/navigationBar/subcomponents/__tests__/__snapshots__/NavigationBarMobileSideMenu.tsx.snap
+++ b/src/commons/navigationBar/subcomponents/__tests__/__snapshots__/NavigationBarMobileSideMenu.tsx.snap
@@ -19,7 +19,7 @@ exports[`NavigationBarMobileSideMenu renders correctly when logged in (no course
       Classroom
     </div>
   </NavLink>
-  <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link_mobile bp3-button bp3-minimal bp3-large\\" to=\\"/sicpjs/index\\" onClick={[Function: onClose]}>
+  <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link_mobile bp3-button bp3-minimal bp3-large\\" to=\\"/sicpjs/\\" onClick={[Function: onClose]}>
     <Blueprint3.Icon icon=\\"book\\" />
     <div className=\\"navbar-button-text\\">
       SICP JS
@@ -77,7 +77,7 @@ exports[`NavigationBarMobileSideMenu renders correctly when logged in (with cour
       Classroom
     </div>
   </NavLink>
-  <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link_mobile bp3-button bp3-minimal bp3-large\\" to=\\"/sicpjs/index\\" onClick={[Function: onClose]}>
+  <NavLink activeClassName=\\"bp3-active\\" className=\\"NavigationBar__link_mobile bp3-button bp3-minimal bp3-large\\" to=\\"/sicpjs/\\" onClick={[Function: onClose]}>
     <Blueprint3.Icon icon=\\"book\\" />
     <div className=\\"navbar-button-text\\">
       SICP JS

--- a/src/commons/utils/Hooks.ts
+++ b/src/commons/utils/Hooks.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { readLocalStorage, setLocalStorage } from './LocalStorageHelper';
+
 // The following section is licensed under the following terms:
 //
 // MIT License
@@ -89,13 +91,10 @@ export function useLocalStorageState<T>(
   key: string,
   defaultValue: T
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
-  const [value, setValue] = React.useState<T>(() => {
-    const localStorageValue = window.localStorage.getItem(key);
-    return localStorageValue ? JSON.parse(localStorageValue) : defaultValue;
-  });
+  const [value, setValue] = React.useState<T>(readLocalStorage(key, defaultValue));
 
   React.useEffect(() => {
-    window.localStorage.setItem(key, JSON.stringify(value));
+    setLocalStorage(key, value);
   }, [key, value]);
 
   return [value, setValue];

--- a/src/commons/utils/LocalStorageHelper.ts
+++ b/src/commons/utils/LocalStorageHelper.ts
@@ -1,0 +1,8 @@
+export const readLocalStorage = (key: string, defaultValue?: any) => {
+  const localStorageValue = window.localStorage.getItem(key);
+  return localStorageValue ? JSON.parse(localStorageValue) : defaultValue;
+};
+
+export const setLocalStorage = (key: string, value: any) => {
+  window.localStorage.setItem(key, JSON.stringify(value));
+};

--- a/src/features/sicp/utils/SicpUtils.ts
+++ b/src/features/sicp/utils/SicpUtils.ts
@@ -1,0 +1,13 @@
+import { readLocalStorage, setLocalStorage } from 'src/commons/utils/LocalStorageHelper';
+
+export const SICP_INDEX = 'index';
+export const SICP_CACHE_KEY = 'sicp-section';
+
+export const setSicpSectionLocalStorage = (value: string) => {
+  setLocalStorage(SICP_CACHE_KEY, value);
+};
+
+export const readSicpSectionLocalStorage = () => {
+  const data = readLocalStorage(SICP_CACHE_KEY, SICP_INDEX);
+  return data;
+};


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Addresses #2035 

### Type of change

- [ ] New feature (non-breaking change which adds functionality)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Possible manual testcases for the reviewer to check:
1. Happy flow:
    - navigate to some page in SICPJS with the `next` and `previous` buttons located in the SICP navbar and at the bottom of the page, or use the URL to navigate
    - navigate away from SICPJS
    - navigate back to SICPJS using the main navbar
    - Result: the last visited page is loaded
2. Unhappy flow (invalid link shld lead back to '/sicpjs/index')
    - navigate to some non-existent page in SICPJS (e.g. '/sicpjs/10')
    - error page should be displayed
    - navigate to some other page (optional)
    - click on the SICPJS button in the main navbar
    - Result: '/sicpjs/index' is loaded
3. Unhappy flow (user clears cache/ or closes private browser)
    - after clearing cache, click on the SICPJS button in the main navbar
    - Result: '/sicpjs/index' is loaded

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
