### PR TITLE
Source Native Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "classnames": "^2.3.1",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.5.31",
+    "js-slang": "^0.5.32",
     "konva": "^8.3.2",
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",

--- a/src/commons/__tests__/Markdown.tsx
+++ b/src/commons/__tests__/Markdown.tsx
@@ -1,9 +1,10 @@
 import { mount } from 'enzyme';
+import { Variant } from 'js-slang/dist/types';
 
 import Markdown from '../Markdown';
 import { generateSourceIntroduction } from '../utils/IntroductionHelper';
 
-const mockProps = (sourceChapter: number, sourceVariant: string) => {
+const mockProps = (sourceChapter: number, sourceVariant: Variant) => {
   return {
     content: generateSourceIntroduction(sourceChapter, sourceVariant),
     openLinksInNewWindow: true

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -140,7 +140,7 @@ export const styliseSublanguage = (chapter: number, variant: Variant = 'default'
       }`;
 };
 
-const sublanguages: { chapter: number; variant: Variant }[] = [
+export const sublanguages: { chapter: number; variant: Variant }[] = [
   { chapter: 1, variant: 'default' },
   { chapter: 1, variant: 'wasm' },
   { chapter: 1, variant: 'lazy' },

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -115,7 +115,8 @@ const variantDisplay: Map<Variant, string> = new Map([
   ['non-det', 'Non-Det'],
   ['concurrent', 'Concurrent'],
   ['lazy', 'Lazy'],
-  ['gpu', 'GPU']
+  ['gpu', 'GPU'],
+  ['native', 'Native']
 ]);
 
 // We will treat chapter === -1 as full JS for now
@@ -143,13 +144,17 @@ const sublanguages: { chapter: number; variant: Variant }[] = [
   { chapter: 1, variant: 'default' },
   { chapter: 1, variant: 'wasm' },
   { chapter: 1, variant: 'lazy' },
+  { chapter: 1, variant: 'native' },
   { chapter: 2, variant: 'default' },
   { chapter: 2, variant: 'lazy' },
+  { chapter: 2, variant: 'native' },
   { chapter: 3, variant: 'default' },
   { chapter: 3, variant: 'concurrent' },
   { chapter: 3, variant: 'non-det' },
+  { chapter: 3, variant: 'native' },
   { chapter: 4, variant: 'default' },
-  { chapter: 4, variant: 'gpu' }
+  { chapter: 4, variant: 'gpu' },
+  { chapter: 4, variant: 'native' }
 ];
 
 export const sourceLanguages = sublanguages.map(sublang => {

--- a/src/commons/utils/IntroductionHelper.ts
+++ b/src/commons/utils/IntroductionHelper.ts
@@ -17,14 +17,6 @@ and also the [_Source Academy keyboard shortcuts_](${Links.sourceHotkeys}).
 `;
 
 const generateSourceDocsLink = (sourceChapter: number, sourceVariant: Variant) => {
-  // `.includes` and `.find` are not used here since we are dealing with reference types
-  if (
-    sublanguages.filter(lang => lang.chapter === sourceChapter && lang.variant === sourceVariant)
-      .length === 0
-  ) {
-    return 'You have chosen an invalid sublanguage. Please pick a sublanguage from the dropdown instead.';
-  }
-
   if (isFullJSChapter(sourceChapter)) {
     return (
       `However, you have chosen full JavaScript, which runs your program directly, using JavaScript strict mode [_(ECMAScript 2021)_](${Links.ecmaScript_2021}).` +
@@ -33,8 +25,16 @@ const generateSourceDocsLink = (sourceChapter: number, sourceVariant: Variant) =
     );
   }
 
+  // `.includes` and `.find` are not used here since we are dealing with reference types
+  if (
+    sublanguages.filter(lang => lang.chapter === sourceChapter && lang.variant === sourceVariant)
+      .length === 0
+  ) {
+    return 'You have chosen an invalid sublanguage. Please pick a sublanguage from the dropdown instead.';
+  }
+
   const sourceDocsLink: string = `${Links.sourceDocs}source_${sourceChapter}${
-    sourceVariant !== 'default' ? `_${sourceVariant}` : ''
+    sourceVariant !== 'default' && sourceVariant !== 'native' ? `_${sourceVariant}` : ''
   }/`;
 
   return `You have chosen the sublanguage [_${styliseSublanguage(

--- a/src/commons/utils/IntroductionHelper.ts
+++ b/src/commons/utils/IntroductionHelper.ts
@@ -1,7 +1,7 @@
-import { isFullJSChapter } from '../application/ApplicationTypes';
-import { Links } from './Constants';
+import { Variant } from 'js-slang/dist/types';
 
-const CHAP = '\xa7';
+import { isFullJSChapter, styliseSublanguage, sublanguages } from '../application/ApplicationTypes';
+import { Links } from './Constants';
 
 const MAIN_INTRODUCTION = `
 Welcome to the Source Academy playground!
@@ -16,47 +16,38 @@ and also the [_Source Academy keyboard shortcuts_](${Links.sourceHotkeys}).
 
 `;
 
-const FULLJS_INTRODUCTION =
-  MAIN_INTRODUCTION +
-  `However, you have chosen full JavaScript, which runs your program directly, using JavaScript strict mode [_(ECMAScript 2021)_](${Links.ecmaScript_2021}).` +
-  '\n\n<b>Warning:</b> If your program freezes during execution, you can try refreshing the tab. Note that you need to open the browser console (typically by pressing `F12`) before using breakpoints.' +
-  HOTKEYS_INTRODUCTION;
-
-const generateSourceDocsLink = (sourceType: string) => {
-  switch (sourceType) {
-    case '1 default':
-      return `You have chosen the sublanguage [_Source ${CHAP}1_](${Links.source_1}).`;
-    case '1 wasm':
-      return `You have chosen the sublanguage [_Source ${CHAP}1 WebAssembly_](${Links.source_1_Wasm}).`;
-    case '1 lazy':
-      return `You have chosen the sublanguage [_Source ${CHAP}1 Lazy_](${Links.source_1_Lazy}).`;
-    case '2 default':
-      return `You have chosen the sublanguage [_Source ${CHAP}2_](${Links.source_2}).`;
-    case '2 lazy':
-      return `You have chosen the sublanguage [_Source ${CHAP}2 Lazy_](${Links.source_2_Lazy}).`;
-    case '3 default':
-      return `You have chosen the sublanguage [_Source ${CHAP}3_](${Links.source_3}).`;
-    case '3 non-det':
-      return `You have chosen the sublanguage [_Source ${CHAP}3 Non-Det_](${Links.source_3_Nondet}).`;
-    case '3 concurrent':
-      return `You have chosen the sublanguage [_Source ${CHAP}3 Concurrent_](${Links.source_3_Concurrent}).`;
-    case '4 default':
-      return `You have chosen the sublanguage [_Source ${CHAP}4_](${Links.source_4}).`;
-    case '4 gpu':
-      return `You have chosen the sublanguage [_Source ${CHAP}4 GPU_](${Links.source_4_Gpu}).`;
-    case '-1 default':
-      return `However, you have chosen full JavaScript, which runs your program directly, using JavaScript strict mode [_(ECMAScript 2021)_](${Links.ecmaScript_2021}).`;
-    default:
-      return 'You have chosen an invalid sublanguage. Please pick a sublanguage from the dropdown instead.';
+const generateSourceDocsLink = (sourceChapter: number, sourceVariant: Variant) => {
+  // `.includes` and `.find` are not used here since we are dealing with reference types
+  if (
+    sublanguages.filter(lang => lang.chapter === sourceChapter && lang.variant === sourceVariant).length === 0
+  ) {
+    return 'You have chosen an invalid sublanguage. Please pick a sublanguage from the dropdown instead.';
   }
+
+  if (isFullJSChapter(sourceChapter)) {
+    return (
+      `However, you have chosen full JavaScript, which runs your program directly, using JavaScript strict mode [_(ECMAScript 2021)_](${Links.ecmaScript_2021}).` +
+      '\n\n<b>Warning:</b> If your program freezes during execution, you can try refreshing the tab. ' +
+      'Note that you need to open the browser console (typically by pressing `F12`) before using breakpoints.'
+    );
+  }
+
+  const sourceDocsLink: string = `${Links.sourceDocs}source_${sourceChapter}${
+    sourceVariant !== 'default' ? `_${sourceVariant}` : ''
+  }/`;
+
+  return `You have chosen the sublanguage [_${styliseSublanguage(
+    sourceChapter,
+    sourceVariant
+  )}_](${sourceDocsLink}).`;
 };
 
-const generateIntroductionText = (sourceType: string) => {
-  return MAIN_INTRODUCTION + generateSourceDocsLink(sourceType) + HOTKEYS_INTRODUCTION;
+const generateIntroductionText = (sourceChapter: number, sourceVariant: Variant) => {
+  return (
+    MAIN_INTRODUCTION + generateSourceDocsLink(sourceChapter, sourceVariant) + HOTKEYS_INTRODUCTION
+  );
 };
 
-export const generateSourceIntroduction = (sourceChapter: number, sourceVariant: string) => {
-  return isFullJSChapter(sourceChapter)
-    ? FULLJS_INTRODUCTION
-    : generateIntroductionText(`${sourceChapter} ${sourceVariant}`);
+export const generateSourceIntroduction = (sourceChapter: number, sourceVariant: Variant) => {
+  return generateIntroductionText(sourceChapter, sourceVariant);
 };

--- a/src/commons/utils/IntroductionHelper.ts
+++ b/src/commons/utils/IntroductionHelper.ts
@@ -19,7 +19,8 @@ and also the [_Source Academy keyboard shortcuts_](${Links.sourceHotkeys}).
 const generateSourceDocsLink = (sourceChapter: number, sourceVariant: Variant) => {
   // `.includes` and `.find` are not used here since we are dealing with reference types
   if (
-    sublanguages.filter(lang => lang.chapter === sourceChapter && lang.variant === sourceVariant).length === 0
+    sublanguages.filter(lang => lang.chapter === sourceChapter && lang.variant === sourceVariant)
+      .length === 0
   ) {
     return 'You have chosen an invalid sublanguage. Please pick a sublanguage from the dropdown instead.';
   }

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -567,7 +567,10 @@ const Playground: React.FC<PlaygroundProps> = props => {
       tabs.push(envVisualizerTab);
     }
 
-    if (props.playgroundSourceChapter <= 2 && props.playgroundSourceVariant === 'default') {
+    if (
+      props.playgroundSourceChapter <= 2 &&
+      (props.playgroundSourceVariant === 'default' || props.playgroundSourceVariant === 'native')
+    ) {
       // Enable Subst Visualizer only for default Source 1 & 2
       tabs.push({
         label: 'Stepper',

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -550,7 +550,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
 
     // (TEMP) Remove tabs for fullJS until support is integrated
     if (isFullJSChapter(props.playgroundSourceChapter)) {
-      return tabs;
+      return [...tabs, dataVisualizerTab];
     }
 
     if (props.playgroundSourceChapter >= 2 && !usingRemoteExecution) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,6 +2061,11 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/estree@0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
 "@types/gapi.auth2@^0.0.56":
   version "0.0.56"
   resolved "https://registry.npmjs.org/@types/gapi.auth2/-/gapi.auth2-0.0.56.tgz"
@@ -8159,13 +8164,13 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
-js-slang@^0.5.31:
-  version "0.5.31"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.31.tgz#fa2f43a28815b981a3d4e11d4f374c7b5871e738"
-  integrity sha512-WePMRLq7vkSEpx9lqHOAej8nIEIkJH6JMbpaOTQfF2TahPujejx6aT/viXPzSzjmAIq4d/em0qjPNGXfWw4i+Q==
+js-slang@^0.5.32:
+  version "0.5.32"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.32.tgz#97c22250a9c1653675010e03ce81d834892b8cfe"
+  integrity sha512-bUUi1muU5xS+DRfiJMYrE3jLX3dxGfbKPVnqGgqjsUZNm+9ymsl2aLW2huExEY5qu6pQpc9ccYJCpk+kKQlhYw==
   dependencies:
     "@joeychenofficial/alt-ergo-modified" "^2.4.0"
-    "@types/estree" "0.0.50"
+    "@types/estree" "0.0.51"
     acorn "^8.0.3"
     acorn-loose "^8.0.0"
     acorn-walk "^8.0.0"


### PR DESCRIPTION
To be tested and merged together with https://github.com/source-academy/js-slang/pull/1231

> CI will only pass after bumping js-slang once it is merged

Using the `Native` variant, we will expect to see performance gains from existing Source snippets while still adhering to existing source syntax and builtIns rules 

- [x] Add introduction text for Source Native variants