### PR TITLE
Add editor border

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -378,7 +378,7 @@ const EditorBase = React.memo(
     });
 
     return (
-      <HotKeys className="Editor" handlers={handlers}>
+      <HotKeys className="Editor bp4-card bp4-elevation-0" handlers={handlers}>
         <div className="row editor-react-ace">
           <AceEditor {...aceEditorProps} ref={useMergedRef(reactAceRef, forwardedRef)} />
         </div>

--- a/src/commons/sourceRecorder/SourceRecorderEditor.tsx
+++ b/src/commons/sourceRecorder/SourceRecorderEditor.tsx
@@ -195,7 +195,7 @@ class SourcecastEditor extends React.PureComponent<SourceRecorderEditorProps, {}
 
   public render() {
     return (
-      <HotKeys className="Editor" handlers={handlers}>
+      <HotKeys className="Editor bp4-card bp4-elevation-0" handlers={handlers}>
         <div className="row editor-react-ace">
           <AceEditor
             className="react-ace"

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -103,10 +103,12 @@ $code-color-error: #ff4444;
     flex-direction: column;
     height: 100%;
     width: 100%;
+    background-color: $cadet-color-2;
 
     .editor-react-ace {
       flex: 1;
       height: 100%;
+      margin: 2px;
 
       #brace-editor {
         height: 100%;


### PR DESCRIPTION
### Description

Standardize workspace UI after BlueprintJS upgrade (which added a box-shadow to its card component)

