### PR TITLE
Add assessment opening date to student view

### DIFF
--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -194,12 +194,20 @@ const Assessment: React.FC<AssessmentProps> = props => {
               <Markdown content={overview.shortSummary} />
             </div>
             <div className="listing-footer">
-              <Text className="listing-due-date">
-                <Icon className="listing-due-icon" iconSize={12} icon={IconNames.TIME} />
-                {beforeNow(overview.openAt)
-                  ? `Due: ${getPrettyDate(overview.closeAt)}`
-                  : `Opens at: ${getPrettyDate(overview.openAt)}`}
-              </Text>
+              <div>
+                <Text className="listing-due-date">
+                  <Icon className="listing-due-icon" iconSize={12} icon={IconNames.CALENDAR} />
+                  {`${beforeNow(overview.openAt) ? 'Opened' : 'Opens'}: ${getPrettyDate(
+                    overview.openAt
+                  )}`}
+                </Text>
+                {beforeNow(overview.openAt) && (
+                  <Text className="listing-due-date">
+                    <Icon className="listing-due-icon" iconSize={12} icon={IconNames.TIME} />
+                    {`Due: ${getPrettyDate(overview.closeAt)}`}
+                  </Text>
+                )}
+              </div>
               <div className="listing-button">
                 {renderAttemptButton ? makeAssessmentInteractButton(overview) : null}
               </div>

--- a/src/commons/assessment/__tests__/__snapshots__/Assessment.tsx.snap
+++ b/src/commons/assessment/__tests__/__snapshots__/Assessment.tsx.snap
@@ -136,18 +136,20 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                     </Memo(Markdown)>
                                   </div>
                                   <div className=\\"listing-footer\\">
-                                    <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
-                                      <div className=\\"listing-due-date\\" title={[undefined]}>
-                                        <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
-                                          <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
-                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
-                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
-                                            </svg>
-                                          </span>
-                                        </Blueprint4.Icon>
-                                        Opens at: 18th June, 13:24
-                                      </div>
-                                    </Blueprint4.Text>
+                                    <div>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"calendar\\">
+                                            <span icon=\\"calendar\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-calendar listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"calendar\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Opens: 18th June, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                    </div>
                                     <div className=\\"listing-button\\" />
                                   </div>
                                 </div>
@@ -233,18 +235,32 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                     </Memo(Markdown)>
                                   </div>
                                   <div className=\\"listing-footer\\">
-                                    <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
-                                      <div className=\\"listing-due-date\\" title={[undefined]}>
-                                        <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
-                                          <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
-                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
-                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
-                                            </svg>
-                                          </span>
-                                        </Blueprint4.Icon>
-                                        Due: 18th June, 13:24
-                                      </div>
-                                    </Blueprint4.Text>
+                                    <div>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"calendar\\">
+                                            <span icon=\\"calendar\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-calendar listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"calendar\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Opened: 18th July, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
+                                            <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Due: 18th June, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                    </div>
                                     <div className=\\"listing-button\\">
                                       <NavLink to=\\"/courses/1/missions/2/0\\">
                                         <Link aria-current={{...}} className={[undefined]} style={[undefined]} to={{...}}>
@@ -336,18 +352,32 @@ exports[`Assessment page does not show attempt Button for upcoming assessments f
                                     </Memo(Markdown)>
                                   </div>
                                   <div className=\\"listing-footer\\">
-                                    <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
-                                      <div className=\\"listing-due-date\\" title={[undefined]}>
-                                        <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
-                                          <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
-                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
-                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
-                                            </svg>
-                                          </span>
-                                        </Blueprint4.Icon>
-                                        Due: 18th June, 13:24
-                                      </div>
-                                    </Blueprint4.Text>
+                                    <div>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"calendar\\">
+                                            <span icon=\\"calendar\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-calendar listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"calendar\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Opened: 18th June, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
+                                            <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Due: 18th June, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                    </div>
                                     <div className=\\"listing-button\\">
                                       <NavLink to=\\"/courses/1/missions/1/0\\">
                                         <Link aria-current={{...}} className={[undefined]} style={[undefined]} to={{...}}>
@@ -556,18 +586,20 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                     </Memo(Markdown)>
                                   </div>
                                   <div className=\\"listing-footer\\">
-                                    <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
-                                      <div className=\\"listing-due-date\\" title={[undefined]}>
-                                        <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
-                                          <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
-                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
-                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
-                                            </svg>
-                                          </span>
-                                        </Blueprint4.Icon>
-                                        Opens at: 18th June, 13:24
-                                      </div>
-                                    </Blueprint4.Text>
+                                    <div>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"calendar\\">
+                                            <span icon=\\"calendar\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-calendar listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"calendar\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Opens: 18th June, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                    </div>
                                     <div className=\\"listing-button\\">
                                       <NavLink to=\\"/courses/1/missions/1/0\\">
                                         <Link aria-current={{...}} className={[undefined]} style={[undefined]} to={{...}}>
@@ -680,18 +712,32 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                     </Memo(Markdown)>
                                   </div>
                                   <div className=\\"listing-footer\\">
-                                    <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
-                                      <div className=\\"listing-due-date\\" title={[undefined]}>
-                                        <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
-                                          <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
-                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
-                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
-                                            </svg>
-                                          </span>
-                                        </Blueprint4.Icon>
-                                        Due: 18th June, 13:24
-                                      </div>
-                                    </Blueprint4.Text>
+                                    <div>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"calendar\\">
+                                            <span icon=\\"calendar\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-calendar listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"calendar\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Opened: 18th July, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
+                                            <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Due: 18th June, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                    </div>
                                     <div className=\\"listing-button\\">
                                       <NavLink to=\\"/courses/1/missions/2/0\\">
                                         <Link aria-current={{...}} className={[undefined]} style={[undefined]} to={{...}}>
@@ -783,18 +829,32 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                                     </Memo(Markdown)>
                                   </div>
                                   <div className=\\"listing-footer\\">
-                                    <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
-                                      <div className=\\"listing-due-date\\" title={[undefined]}>
-                                        <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
-                                          <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
-                                            <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
-                                              <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
-                                            </svg>
-                                          </span>
-                                        </Blueprint4.Icon>
-                                        Due: 18th June, 13:24
-                                      </div>
-                                    </Blueprint4.Text>
+                                    <div>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"calendar\\">
+                                            <span icon=\\"calendar\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-calendar listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"calendar\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Opened: 18th June, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                      <Blueprint4.Text className=\\"listing-due-date\\" ellipsize={false}>
+                                        <div className=\\"listing-due-date\\" title={[undefined]}>
+                                          <Blueprint4.Icon className=\\"listing-due-icon\\" iconSize={12} icon=\\"time\\">
+                                            <span icon=\\"time\\" aria-hidden={true} className=\\"bp4-icon bp4-icon-time listing-due-icon\\" title={[undefined]}>
+                                              <svg fill={[undefined]} data-icon=\\"time\\" width={12} height={12} viewBox=\\"0 0 16 16\\" aria-labelledby={[undefined]} role=\\"img\\">
+                                                <path d=\\"M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm1-6.41V4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .28.11.53.29.71l2 2a1.003 1.003 0 001.42-1.42L9 7.59z\\" fillRule=\\"evenodd\\" />
+                                              </svg>
+                                            </span>
+                                          </Blueprint4.Icon>
+                                          Due: 18th June, 13:24
+                                        </div>
+                                      </Blueprint4.Text>
+                                    </div>
                                     <div className=\\"listing-button\\">
                                       <NavLink to=\\"/courses/1/missions/1/0\\">
                                         <Link aria-current={{...}} className={[undefined]} style={[undefined]} to={{...}}>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Old UI (don't know opening date once assessment opens):
![image](https://user-images.githubusercontent.com/53928333/185533381-c733ecf1-7e9f-41ae-a481-7dbf125f0fd7.png)

Updated UI (add opening date & shortened to 'Opens'/ 'Opened' to make UI more uniform):
![image](https://user-images.githubusercontent.com/53928333/185533170-43c6d9eb-3ecb-4d80-9c32-be8227eecf37.png)

### Checklist

- [x] I have tested this code
