### PR TITLE
Refactor full JS language representation

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -124,20 +124,25 @@ const variantDisplay: Map<Variant, string> = new Map([
 // and not to introduce unnecessary new types to handle "other" languages (for now)
 export const fullJSLanguage: SourceLanguage = {
   chapter: -1,
-  variant: 'default',
+  variant: 'js',
   displayName: 'full JavaScript'
 };
 
-export const isFullJSChapter = (chapter: number) => {
+export const isOtherLanguage = (chapter: number) => {
   return chapter === -1;
 };
 
+export const isFullJSLanguage = (chapter: number, variant: Variant) => {
+  return isOtherLanguage(chapter) && variant === 'js';
+};
+
 export const styliseSublanguage = (chapter: number, variant: Variant = 'default') => {
-  return isFullJSChapter(chapter)
-    ? fullJSLanguage.displayName
-    : `Source \xa7${chapter}${
-        variantDisplay.has(variant) ? ` ${variantDisplay.get(variant)}` : ''
-      }`;
+  if (isFullJSLanguage(chapter, variant)) {
+    return fullJSLanguage.displayName;
+  }
+  return `Source \xa7${chapter}${
+    variantDisplay.has(variant) ? ` ${variantDisplay.get(variant)}` : ''
+  }`;
 };
 
 export const sublanguages: { chapter: number; variant: Variant }[] = [

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -27,7 +27,12 @@ import EnvVisualizer from 'src/features/envVisualizer/EnvVisualizer';
 import { EventType } from '../../features/achievement/AchievementTypes';
 import DataVisualizer from '../../features/dataVisualizer/dataVisualizer';
 import { DeviceSession } from '../../features/remoteExecution/RemoteExecutionTypes';
-import { isFullJSChapter, OverallState, styliseSublanguage } from '../application/ApplicationTypes';
+import {
+  isFullJSLanguage,
+  isOtherLanguage,
+  OverallState,
+  styliseSublanguage
+} from '../application/ApplicationTypes';
 import { externalLibraries, ExternalLibraryName } from '../application/types/ExternalTypes';
 import {
   BEGIN_DEBUG_PAUSE,
@@ -252,7 +257,7 @@ export default function* WorkspaceSaga(): SagaIterator {
     ]);
 
     const chapterChanged: boolean = newChapter !== oldChapter || newVariant !== oldVariant;
-    const toChangeChapter: boolean = isFullJSChapter(newChapter)
+    const toChangeChapter: boolean = isFullJSLanguage(newChapter, newVariant)
       ? chapterChanged && (yield call(showFullJSDisclaimer))
       : chapterChanged;
 
@@ -549,7 +554,7 @@ export function* evalEditor(
     let value = editorCode;
     // Check for initial syntax errors. If there are errors, we continue with
     // eval and let it print the error messages.
-    if (!isFullJSChapter(context.chapter)) {
+    if (!isOtherLanguage(context.chapter)) {
       parse(value, context);
     }
     if (!context.errors.length) {
@@ -564,7 +569,7 @@ export function* evalEditor(
         context.errors = [];
         exploded[index] = 'debugger;' + exploded[index];
         value = exploded.join('\n');
-        if (!isFullJSChapter(context.chapter)) {
+        if (!isOtherLanguage(context.chapter)) {
           parse(value, context);
         }
         if (context.errors.length) {
@@ -764,7 +769,7 @@ export function* evalCode(
   const isWasm: boolean = context.variant === 'wasm';
 
   // Handles `console.log` statements in fullJS
-  const detachConsole: () => void = isFullJSChapter(context.chapter)
+  const detachConsole: () => void = isFullJSLanguage(context.chapter, context.variant)
     ? DisplayBufferService.attachConsole(workspaceLocation)
     : () => {};
 

--- a/src/commons/utils/AceHelper.ts
+++ b/src/commons/utils/AceHelper.ts
@@ -2,7 +2,7 @@ import { HighlightRulesSelector, ModeSelector } from 'js-slang/dist/editors/ace/
 import { Variant } from 'js-slang/dist/types';
 
 import { HighlightRulesSelector_native } from '../../features/fullJS/fullJSHighlight';
-import { isFullJSChapter } from '../application/ApplicationTypes';
+import { isFullJSLanguage } from '../application/ApplicationTypes';
 import { Documentation } from '../documentation/Documentation';
 /**
  * This _modifies global state_ and defines a new Ace mode globally, if it does not already exist.
@@ -19,7 +19,7 @@ export const selectMode = (chapter: number, variant: Variant, library: string) =
     return;
   }
 
-  if (!isFullJSChapter(chapter)) {
+  if (!isFullJSLanguage(chapter, variant)) {
     HighlightRulesSelector(chapter, variant, library, Documentation.externalLibraries[library]);
   } else {
     HighlightRulesSelector_native(

--- a/src/commons/utils/IntroductionHelper.ts
+++ b/src/commons/utils/IntroductionHelper.ts
@@ -1,6 +1,10 @@
 import { Variant } from 'js-slang/dist/types';
 
-import { isFullJSChapter, styliseSublanguage, sublanguages } from '../application/ApplicationTypes';
+import {
+  isFullJSLanguage,
+  styliseSublanguage,
+  sublanguages
+} from '../application/ApplicationTypes';
 import { Links } from './Constants';
 
 const MAIN_INTRODUCTION = `
@@ -17,7 +21,7 @@ and also the [_Source Academy keyboard shortcuts_](${Links.sourceHotkeys}).
 `;
 
 const generateSourceDocsLink = (sourceChapter: number, sourceVariant: Variant) => {
-  if (isFullJSChapter(sourceChapter)) {
+  if (isFullJSLanguage(sourceChapter, sourceVariant)) {
     return (
       `However, you have chosen full JavaScript, which runs your program directly, using JavaScript strict mode [_(ECMAScript 2021)_](${Links.ecmaScript_2021}).` +
       '\n\n<b>Warning:</b> If your program freezes during execution, you can try refreshing the tab. ' +

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -16,7 +16,7 @@ import { showFullJSWarningOnUrlLoad } from 'src/commons/fullJS/FullJSUtils';
 
 import {
   InterpreterOutput,
-  isFullJSChapter,
+  isFullJSLanguage,
   OverallState,
   sourceLanguages
 } from '../../commons/application/ApplicationTypes';
@@ -143,7 +143,9 @@ export function handleHash(hash: string, props: PlaygroundProps) {
   const qs = parseQuery(hash);
 
   const chapter = stringParamToInt(qs.chap) || undefined;
-  if (chapter && isFullJSChapter(chapter)) {
+  // All hashes with chapter -1 are defaulted to js variant
+  const variant = (qs.variant || 'js') as Variant;
+  if (chapter && isFullJSLanguage(chapter, variant)) {
     showFullJSWarningOnUrlLoad();
   } else {
     const programLz = qs.lz ?? qs.prgrm;
@@ -320,8 +322,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         // Disable pause for FullJS, because: one cannot stop `eval()`
         pauseDisabled={
           usingRemoteExecution ||
-          (!(props.playgroundSourceChapter === undefined) &&
-            isFullJSChapter(props.playgroundSourceChapter))
+          isFullJSLanguage(props.playgroundSourceChapter, props.playgroundSourceVariant)
         }
       />
     ),
@@ -336,6 +337,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
       props.isEditorAutorun,
       props.isRunning,
       props.playgroundSourceChapter,
+      props.playgroundSourceVariant,
       usingRemoteExecution
     ]
   );
@@ -549,7 +551,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     const tabs: SideContentTab[] = [playgroundIntroductionTab];
 
     // (TEMP) Remove tabs for fullJS until support is integrated
-    if (isFullJSChapter(props.playgroundSourceChapter)) {
+    if (isFullJSLanguage(props.playgroundSourceChapter, props.playgroundSourceVariant)) {
       return [...tabs, dataVisualizerTab];
     }
 
@@ -731,12 +733,15 @@ const Playground: React.FC<PlaygroundProps> = props => {
     controlBarProps: {
       editorButtons: [
         autorunButtons,
-        isFullJSChapter(props.playgroundSourceChapter) ? null : shareButton,
+        isFullJSLanguage(props.playgroundSourceChapter, props.playgroundSourceVariant)
+          ? null
+          : shareButton,
         chapterSelect,
         isSicpEditor ? null : sessionButtons,
         persistenceButtons,
         githubButtons,
-        usingRemoteExecution || isFullJSChapter(props.playgroundSourceChapter)
+        usingRemoteExecution ||
+        isFullJSLanguage(props.playgroundSourceChapter, props.playgroundSourceVariant)
           ? null
           : props.usingSubst
           ? stepperStepLimit
@@ -770,7 +775,9 @@ const Playground: React.FC<PlaygroundProps> = props => {
         editorButtons: [
           autorunButtons,
           chapterSelect,
-          isFullJSChapter(props.playgroundSourceChapter) ? null : shareButton,
+          isFullJSLanguage(props.playgroundSourceChapter, props.playgroundSourceVariant)
+            ? null
+            : shareButton,
           isSicpEditor ? null : sessionButtons,
           persistenceButtons,
           githubButtons


### PR DESCRIPTION
### Description

Frontend counterpart to [js-slang#1285](https://github.com/source-academy/js-slang/pull/1285). Refactors full JS to have chapter -1 and variant 'js' before adding HTML support (HTML will have chapter -1 and variant 'html').

Will need the js-slang PR to be merged and js-slang version bumped first.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements
