### PR TITLE
Move editor out of MobileSideContent into MobileWorkspace

### DIFF
--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -212,9 +212,10 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
         <ControlBar {...props.mobileSideContentProps.mobileControlBarProps} />
       )}
 
-      <div className="mobile-editor-panel">{createWorkspaceInput()}</div>
-
-      <MobileSideContent {...updatedMobileSideContentProps()} {...draggableReplProps} />
+      <div>
+        <div className="mobile-editor-panel">{createWorkspaceInput()}</div>
+        <MobileSideContent {...updatedMobileSideContentProps()} {...draggableReplProps} />
+      </div>
 
       <DraggableRepl
         key={'repl'}

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -170,19 +170,18 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
     () => ({
       label: 'Editor',
       iconName: IconNames.EDIT,
-      body: createWorkspaceInput(),
+      body: null,
       id: SideContentType.mobileEditor,
       toSpawn: () => true
     }),
-    // eslint-disable-next-line
-    [props.customEditor, props.editorProps, props.mcqProps]
+    []
   );
 
   const mobileRunTab: SideContentTab = React.useMemo(
     () => ({
       label: 'Run',
       iconName: IconNames.PLAY,
-      body: <div></div>, // placeholder div since run tab does not have a specific panel body
+      body: null,
       id: SideContentType.mobileEditorRun,
       toSpawn: () => true
     }),
@@ -212,6 +211,8 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
       {inAssessmentWorkspace && (
         <ControlBar {...props.mobileSideContentProps.mobileControlBarProps} />
       )}
+
+      <div className="mobile-editor-panel">{createWorkspaceInput()}</div>
 
       <MobileSideContent
         {...updatedMobileSideContentProps()}

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -214,11 +214,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
 
       <div className="mobile-editor-panel">{createWorkspaceInput()}</div>
 
-      <MobileSideContent
-        {...updatedMobileSideContentProps()}
-        {...draggableReplProps}
-        editorRef={editorRef}
-      />
+      <MobileSideContent {...updatedMobileSideContentProps()} {...draggableReplProps} />
 
       <DraggableRepl
         key={'repl'}

--- a/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
+++ b/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
@@ -2,7 +2,6 @@ import { Classes, Icon, Tab, TabId, Tabs } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import classNames from 'classnames';
 import React from 'react';
-import ReactAce from 'react-ace/lib/ace';
 import { useSelector } from 'react-redux';
 
 import { OverallState } from '../../application/ApplicationTypes';
@@ -42,7 +41,6 @@ type OwnProps = {
   handleShowRepl: () => void;
   handleHideRepl: () => void;
   disableRepl: (newState: boolean) => void;
-  editorRef: React.RefObject<ReactAce>;
 };
 
 const MobileSideContent: React.FC<MobileSideContentProps & OwnProps> = props => {
@@ -168,16 +166,6 @@ const MobileSideContent: React.FC<MobileSideContentProps & OwnProps> = props => 
       } else {
         onChange(newTabId, prevTabId, event);
         resetAlert(prevTabId);
-      }
-
-      /**
-       * ReactAce's editor value is not updated visually despite state change
-       * when the component is 'hidden'. We have to manually trigger the editor
-       * to update the visible value when switching to the mobile editor tab.
-       */
-      if (newTabId === SideContentType.mobileEditor) {
-        // props.editorRef.current is null when MCQ is rendered instead of the editor
-        props.editorRef.current?.editor.renderer.updateFull();
       }
 
       // Evaluate program upon pressing the 'Run' tab on mobile

--- a/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
+++ b/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
@@ -79,6 +79,10 @@ const MobileSideContent: React.FC<MobileSideContentProps & OwnProps> = props => 
   const renderedPanels = () => {
     // TODO: Fix the CSS of all the panels (e.g. subst_visualizer)
     const renderPanel = (tab: SideContentTab, workspaceLocation?: WorkspaceLocation) => {
+      if (!tab.body) {
+        return;
+      }
+
       const tabBody: JSX.Element = workspaceLocation
         ? {
             ...tab.body,
@@ -89,23 +93,7 @@ const MobileSideContent: React.FC<MobileSideContentProps & OwnProps> = props => 
           }
         : tab.body;
 
-      if (tab.id === SideContentType.mobileEditorRun) {
-        return;
-      }
-
-      return tab.id === SideContentType.mobileEditor ? (
-        // Render the Editor Panel when the selected tab is 'Editor' or 'Run'
-        selectedTabId === SideContentType.mobileEditor ||
-        selectedTabId === SideContentType.mobileEditorRun ? (
-          <div className="mobile-editor-panel" key={'editor'}>
-            {tabBody}
-          </div>
-        ) : (
-          <div className="mobile-unselected-panel" key={'editor'}>
-            {tabBody}
-          </div>
-        )
-      ) : tab.id === selectedTabId ? (
+      return tab.id === selectedTabId ? (
         // Render the other panels only when their corresponding tab is selected
         <div className="mobile-selected-panel" key={tab.id}>
           {tabBody}

--- a/src/commons/sideContent/SideContent.tsx
+++ b/src/commons/sideContent/SideContent.tsx
@@ -1,4 +1,4 @@
-import { Card, Icon, Tab, TabId, Tabs } from '@blueprintjs/core';
+import { Card, Icon, Tab, TabId, TabProps, Tabs } from '@blueprintjs/core';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
@@ -91,6 +91,16 @@ const SideContent = (props: SideContentProps) => {
           </div>
         </Tooltip2>
       );
+      const tabProps: Partial<TabProps> = {
+        id: tabId,
+        title: tabTitle,
+        disabled: tab.disabled,
+        className: 'side-content-tab'
+      };
+
+      if (!tab.body) {
+        return <Tab key={tabId} {...tabProps} />;
+      }
 
       const tabBody: JSX.Element = workspaceLocation
         ? {
@@ -105,16 +115,7 @@ const SideContent = (props: SideContentProps) => {
         : tab.body;
       const tabPanel: JSX.Element = <div className="side-content-text">{tabBody}</div>;
 
-      return (
-        <Tab
-          key={tabId}
-          id={tabId}
-          title={tabTitle}
-          panel={tabPanel}
-          disabled={tab.disabled}
-          className="side-content-tab"
-        />
-      );
+      return <Tab key={tabId} {...tabProps} panel={tabPanel} />;
     };
 
     return dynamicTabs.map(tab =>

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -43,7 +43,7 @@ export enum SideContentType {
  *   icon which will be displayed over the SideContent panel.
  *
  * @property body The element to be rendered in the SideContent panel
- *  when the tab is selected.
+ *  when the tab is selected. If null, the panel will not be rendered.
  *
  * @property id A string/number that will be used as the tab ID and key.
  *  If id is undefined, id will be set to label by the renderTab function.
@@ -55,7 +55,7 @@ export enum SideContentType {
 export type SideContentTab = {
   label: string;
   iconName: IconName;
-  body: JSX.Element;
+  body: JSX.Element | null;
   toSpawn: (context: DebuggerContext) => boolean;
   id?: SideContentType;
   disabled?: boolean;

--- a/src/styles/_mobileworkspace.scss
+++ b/src/styles/_mobileworkspace.scss
@@ -165,8 +165,10 @@ $shadow-light: rgba(0, 0, 0, 0.2);
   }
 
   .mobile-selected-panel {
+    position: absolute;
     height: var(--mobile-panel-height, calc(100% - 70px));
     width: 100vw;
+    z-index: 1;
     padding: 20px 15px 20px 15px;
     background-color: $cadet-color-2;
     white-space: pre-wrap;

--- a/src/styles/_mobileworkspace.scss
+++ b/src/styles/_mobileworkspace.scss
@@ -221,6 +221,7 @@ $shadow-light: rgba(0, 0, 0, 0.2);
   }
 
   .mobile-editor-panel {
+    position: absolute;
     width: 100vw;
     height: var(--mobile-panel-height, calc(100% - 70px));
     z-index: 1;


### PR DESCRIPTION
### Description

The following pairs of components are equivalent:
|Desktop View|Mobile View|
|-|-|
|`Workspace`|`MobileWorkspace`|
|`SideContent`|`MobileSideContent`|

However in the desktop view, the editor is a child of the `Workspace` component while in the mobile view, the editor is a child of the `MobileSideContent` component which is in itself a child of the `MobileWorkspace` component. This results in `MobileSideContent` not being truly agnostic of the kinds of tabs that are passed in, resulting in tight coupling.

For consistency, as well as to address the tight coupling as mentioned above, the `Editor` component should be moved out of `MobileSideContent` into `MobileWorkspace`. This was done by allowing the `body` field of `SideContentTab`s to be `null`, indicating that no panel should be rendered for the tab. When that happens, the editor that is underneath will be visible.

This also allows us to remove the forced rendering of the editor in the `changeTabsCallback` of the `MobileSideContent` component.

Part of the refactoring for #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

Use developer tools to set the screen resolution to one that triggers the mobile view.