### PR TITLE
Fix stepper side content panel not using white text on mobile view

### DIFF
--- a/src/commons/sideContent/SideContentSubstVisualizer.tsx
+++ b/src/commons/sideContent/SideContentSubstVisualizer.tsx
@@ -7,6 +7,7 @@ import { HotKeys } from 'react-hotkeys';
 import { HighlightRulesSelector, ModeSelector } from 'js-slang/dist/editors/ace/modes/source';
 import 'js-slang/dist/editors/ace/theme/source';
 import { IStepperPropContents } from 'js-slang/dist/stepper/stepper';
+import classNames from 'classnames';
 
 const SubstDefaultText = () => {
   return (
@@ -111,7 +112,7 @@ class SideContentSubstVisualizer extends React.Component<SubstVisualizerProps, S
     return (
       <HotKeys keyMap={substKeyMap} handlers={substHandlers}>
         <div>
-          <div className="sa-substituter">
+          <div className={classNames('sa-substituter', Classes.DARK)}>
             <Slider
               disabled={!hasRunCode}
               min={1}


### PR DESCRIPTION
### Description

Fixes #2198.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Navigate to the playground.
1. Set the language as Source 1 or Source 2 (so that the stepper appears).
1. Navigate to the stepper tab.
1. Use developer tools to set the screen resolution to one that triggers the mobile view.