### PR TITLE
Bump js-slang, refactor language chapter and variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "classnames": "^2.3.1",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.5.33",
+    "js-slang": "^0.5.34",
     "konva": "^8.3.2",
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",

--- a/src/commons/XMLParser/XMLParserHelper.ts
+++ b/src/commons/XMLParser/XMLParserHelper.ts
@@ -1,3 +1,4 @@
+import { Chapter } from 'js-slang/dist/types';
 import { Builder } from 'xml2js';
 
 import { ExternalLibraryName } from '../application/types/ExternalTypes';
@@ -7,6 +8,7 @@ import {
   AssessmentStatuses,
   AssessmentType,
   BaseQuestion,
+  emptyLibrary,
   GradingStatuses,
   IMCQQuestion,
   IProgrammingQuestion,
@@ -112,14 +114,7 @@ const altEval = (str: string): any => {
 
 const makeLibrary = (deploymentArr: XmlParseStrDeployment[] | undefined): Library => {
   if (deploymentArr === undefined) {
-    return {
-      chapter: -1,
-      external: {
-        name: 'NONE' as ExternalLibraryName,
-        symbols: []
-      },
-      globals: []
-    };
+    return emptyLibrary();
   } else {
     const deployment = deploymentArr[0];
     const external = deployment.IMPORT || deployment.EXTERNAL;
@@ -131,7 +126,7 @@ const makeLibrary = (deploymentArr: XmlParseStrDeployment[] | undefined): Librar
         >)
       : [];
     return {
-      chapter: parseInt(deployment.$.interpreter, 10),
+      chapter: parseInt(deployment.$.interpreter, 10) as Chapter,
       external: {
         name: nameVal as ExternalLibraryName,
         symbols: symbolsVal

--- a/src/commons/__tests__/Markdown.tsx
+++ b/src/commons/__tests__/Markdown.tsx
@@ -1,10 +1,10 @@
 import { mount } from 'enzyme';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 
 import Markdown from '../Markdown';
 import { generateSourceIntroduction } from '../utils/IntroductionHelper';
 
-const mockProps = (sourceChapter: number, sourceVariant: Variant) => {
+const mockProps = (sourceChapter: Chapter, sourceVariant: Variant) => {
   return {
     content: generateSourceIntroduction(sourceChapter, sourceVariant),
     openLinksInNewWindow: true
@@ -12,43 +12,43 @@ const mockProps = (sourceChapter: number, sourceVariant: Variant) => {
 };
 
 test('Markdown page renders correctly', () => {
-  const app = <Markdown {...mockProps(1, 'default')} />;
+  const app = <Markdown {...mockProps(Chapter.SOURCE_1, Variant.DEFAULT)} />;
   const tree = mount(app);
   expect(tree.debug()).toMatchSnapshot();
 });
 
 test('Markdown page renders correct Source information', () => {
-  const source1Default = <Markdown {...mockProps(1, 'default')} />;
+  const source1Default = <Markdown {...mockProps(Chapter.SOURCE_1, Variant.DEFAULT)} />;
   expect(source1Default.props.content).toContain('Source \xa71');
 
-  const source1Lazy = <Markdown {...mockProps(1, 'lazy')} />;
+  const source1Lazy = <Markdown {...mockProps(Chapter.SOURCE_1, Variant.LAZY)} />;
   expect(source1Lazy.props.content).toContain('Source \xa71 Lazy');
 
-  const source1Wasm = <Markdown {...mockProps(1, 'wasm')} />;
+  const source1Wasm = <Markdown {...mockProps(Chapter.SOURCE_1, Variant.WASM)} />;
   expect(source1Wasm.props.content).toContain('Source \xa71 WebAssembly');
 
-  const source2Default = <Markdown {...mockProps(2, 'default')} />;
+  const source2Default = <Markdown {...mockProps(Chapter.SOURCE_2, Variant.DEFAULT)} />;
   expect(source2Default.props.content).toContain('Source \xa72');
 
-  const source2Lazy = <Markdown {...mockProps(2, 'lazy')} />;
+  const source2Lazy = <Markdown {...mockProps(Chapter.SOURCE_2, Variant.LAZY)} />;
   expect(source2Lazy.props.content).toContain('Source \xa72 Lazy');
 
-  const source3Default = <Markdown {...mockProps(3, 'default')} />;
+  const source3Default = <Markdown {...mockProps(Chapter.SOURCE_3, Variant.DEFAULT)} />;
   expect(source3Default.props.content).toContain('Source \xa73');
 
-  const source3NonDet = <Markdown {...mockProps(3, 'non-det')} />;
+  const source3NonDet = <Markdown {...mockProps(Chapter.SOURCE_3, Variant.NON_DET)} />;
   expect(source3NonDet.props.content).toContain('Source \xa73 Non-Det');
 
-  const source3Concurrent = <Markdown {...mockProps(3, 'concurrent')} />;
+  const source3Concurrent = <Markdown {...mockProps(Chapter.SOURCE_3, Variant.CONCURRENT)} />;
   expect(source3Concurrent.props.content).toContain('Source \xa73 Concurrent');
 
-  const source4Default = <Markdown {...mockProps(4, 'default')} />;
+  const source4Default = <Markdown {...mockProps(Chapter.SOURCE_4, Variant.DEFAULT)} />;
   expect(source4Default.props.content).toContain('Source \xa74');
 
-  const source4GPU = <Markdown {...mockProps(4, 'gpu')} />;
+  const source4GPU = <Markdown {...mockProps(Chapter.SOURCE_4, Variant.GPU)} />;
   expect(source4GPU.props.content).toContain('Source \xa74 GPU');
 
-  const invalidSource = <Markdown {...mockProps(5, 'default')} />;
+  const invalidSource = <Markdown {...mockProps(5, Variant.DEFAULT)} />;
   expect(invalidSource.props.content).toContain(
     'You have chosen an invalid sublanguage. Please pick a sublanguage from the dropdown instead'
   );

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -1,4 +1,4 @@
-import { SourceError, Variant } from 'js-slang/dist/types';
+import { Chapter, Language, SourceError, Variant } from 'js-slang/dist/types';
 
 import { AcademyState } from '../../features/academy/AcademyTypes';
 import { AchievementState } from '../../features/achievement/AchievementTypes';
@@ -101,71 +101,67 @@ export enum Role {
 }
 
 /**
- * Defines the Source sublanguages available for use.
+ * Defines the languages available for use on Source Academy,
+ * including Source sublanguages and other languages e.g. full JS.
  * For external libraries, see ExternalLibrariesTypes.ts
  */
-export type SourceLanguage = {
-  chapter: number;
-  variant: Variant;
+export interface SALanguage extends Language {
   displayName: string;
-};
+}
 
 const variantDisplay: Map<Variant, string> = new Map([
-  ['wasm', 'WebAssembly'],
-  ['non-det', 'Non-Det'],
-  ['concurrent', 'Concurrent'],
-  ['lazy', 'Lazy'],
-  ['gpu', 'GPU'],
-  ['native', 'Native']
+  [Variant.WASM, 'WebAssembly'],
+  [Variant.NON_DET, 'Non-Det'],
+  [Variant.CONCURRENT, 'Concurrent'],
+  [Variant.LAZY, 'Lazy'],
+  [Variant.GPU, 'GPU'],
+  [Variant.NATIVE, 'Native']
 ]);
 
-// We will treat chapter === -1 as full JS for now
-// This is because we want to separate it from being a Source sub-language
-// and not to introduce unnecessary new types to handle "other" languages (for now)
-export const fullJSLanguage: SourceLanguage = {
-  chapter: -1,
-  variant: 'default',
+export const fullJSLanguage: SALanguage = {
+  chapter: Chapter.FULL_JS,
+  variant: Variant.DEFAULT,
   displayName: 'full JavaScript'
 };
 
-export const isFullJSChapter = (chapter: number) => {
-  return chapter === -1;
-};
-
-export const styliseSublanguage = (chapter: number, variant: Variant = 'default') => {
-  return isFullJSChapter(chapter)
+export const styliseSublanguage = (chapter: Chapter, variant: Variant = Variant.DEFAULT) => {
+  return chapter === Chapter.FULL_JS
     ? fullJSLanguage.displayName
     : `Source \xa7${chapter}${
         variantDisplay.has(variant) ? ` ${variantDisplay.get(variant)}` : ''
       }`;
 };
 
-export const sublanguages: { chapter: number; variant: Variant }[] = [
-  { chapter: 1, variant: 'default' },
-  { chapter: 1, variant: 'wasm' },
-  { chapter: 1, variant: 'lazy' },
-  { chapter: 1, variant: 'native' },
-  { chapter: 2, variant: 'default' },
-  { chapter: 2, variant: 'lazy' },
-  { chapter: 2, variant: 'native' },
-  { chapter: 3, variant: 'default' },
-  { chapter: 3, variant: 'concurrent' },
-  { chapter: 3, variant: 'non-det' },
-  { chapter: 3, variant: 'native' },
-  { chapter: 4, variant: 'default' },
-  { chapter: 4, variant: 'gpu' },
-  { chapter: 4, variant: 'native' }
+export const sublanguages: Language[] = [
+  { chapter: Chapter.SOURCE_1, variant: Variant.DEFAULT },
+  { chapter: Chapter.SOURCE_1, variant: Variant.WASM },
+  { chapter: Chapter.SOURCE_1, variant: Variant.LAZY },
+  { chapter: Chapter.SOURCE_1, variant: Variant.NATIVE },
+  { chapter: Chapter.SOURCE_2, variant: Variant.DEFAULT },
+  { chapter: Chapter.SOURCE_2, variant: Variant.LAZY },
+  { chapter: Chapter.SOURCE_2, variant: Variant.NATIVE },
+  { chapter: Chapter.SOURCE_3, variant: Variant.DEFAULT },
+  { chapter: Chapter.SOURCE_3, variant: Variant.CONCURRENT },
+  { chapter: Chapter.SOURCE_3, variant: Variant.NON_DET },
+  { chapter: Chapter.SOURCE_3, variant: Variant.NATIVE },
+  { chapter: Chapter.SOURCE_4, variant: Variant.DEFAULT },
+  { chapter: Chapter.SOURCE_4, variant: Variant.GPU },
+  { chapter: Chapter.SOURCE_4, variant: Variant.NATIVE }
 ];
 
-export const sourceLanguages = sublanguages.map(sublang => {
+export const sourceLanguages: SALanguage[] = sublanguages.map(sublang => {
   return {
     ...sublang,
     displayName: styliseSublanguage(sublang.chapter, sublang.variant)
   };
 });
 
-export const defaultLanguages = sourceLanguages.filter(sublang => sublang.variant === 'default');
-export const variantLanguages = sourceLanguages.filter(sublang => sublang.variant !== 'default');
+export const defaultLanguages = sourceLanguages.filter(
+  sublang => sublang.variant === Variant.DEFAULT
+);
+export const variantLanguages = sourceLanguages.filter(
+  sublang => sublang.variant !== Variant.DEFAULT
+);
 
 const currentEnvironment = (): ApplicationEnvironment => {
   switch (process.env.NODE_ENV) {
@@ -219,7 +215,7 @@ export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): Wo
     Constants.defaultSourceChapter,
     [],
     workspaceLocation,
-    Constants.defaultSourceVariant as Variant
+    Constants.defaultSourceVariant
   ),
   editorPrepend: '',
   editorSessionId: '',
@@ -276,7 +272,11 @@ export const defaultWorkspaceManager: WorkspaceManagerState = {
     description: null,
     inputToApply: null,
     playbackData: {
-      init: { editorValue: '', chapter: 1, externalLibrary: ExternalLibraryName.NONE },
+      init: {
+        editorValue: '',
+        chapter: Chapter.SOURCE_1,
+        externalLibrary: ExternalLibraryName.NONE
+      },
       inputs: []
     },
     playbackDuration: 0,
@@ -288,7 +288,11 @@ export const defaultWorkspaceManager: WorkspaceManagerState = {
   sourcereel: {
     ...createDefaultWorkspace('sourcereel'),
     playbackData: {
-      init: { editorValue: '', chapter: 1, externalLibrary: ExternalLibraryName.NONE },
+      init: {
+        editorValue: '',
+        chapter: Chapter.SOURCE_1,
+        externalLibrary: ExternalLibraryName.NONE
+      },
       inputs: []
     },
     recordingStatus: RecordingStatus.notStarted,

--- a/src/commons/application/actions/__tests__/SessionActions.ts
+++ b/src/commons/application/actions/__tests__/SessionActions.ts
@@ -1,4 +1,4 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 
 import { Grading, GradingOverview } from '../../../../features/grading/GradingTypes';
 import { Assessment, AssessmentOverview } from '../../../assessment/AssessmentTypes';
@@ -230,8 +230,8 @@ test('setCourseConfiguration generates correct action object', () => {
     enableGame: true,
     enableAchievements: true,
     enableSourcecast: true,
-    sourceChapter: 1,
-    sourceVariant: 'default' as Variant,
+    sourceChapter: Chapter.SOURCE_1,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: 'Help text',
     assessmentTypes: ['Missions', 'Quests', 'Paths', 'Contests', 'Others']
   };
@@ -611,8 +611,8 @@ test('updateCourseConfig generates correct action object', () => {
     enableGame: true,
     enableAchievements: true,
     enableSourcecast: true,
-    sourceChapter: 1,
-    sourceVariant: 'default' as Variant,
+    sourceChapter: Chapter.SOURCE_1,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: 'Help text',
     assessmentTypes: ['Missions', 'Quests', 'Paths', 'Contests', 'Others']
   };

--- a/src/commons/application/reducers/__tests__/SessionReducer.ts
+++ b/src/commons/application/reducers/__tests__/SessionReducer.ts
@@ -1,4 +1,4 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 
 import { Grading, GradingOverview } from '../../../../features/grading/GradingTypes';
 import {
@@ -97,8 +97,8 @@ test('SET_COURSE_CONFIGURATION works correctly', () => {
     enableGame: true,
     enableAchievements: true,
     enableSourcecast: true,
-    sourceChapter: 1,
-    sourceVariant: 'default' as Variant,
+    sourceChapter: Chapter.SOURCE_1,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: 'Help text',
     assessmentTypes: ['Missions', 'Quests', 'Paths', 'Contests', 'Others']
   };

--- a/src/commons/application/types/SessionTypes.ts
+++ b/src/commons/application/types/SessionTypes.ts
@@ -1,5 +1,5 @@
 import { Octokit } from '@octokit/rest';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 
 import { MissionRepoData } from '../../../commons/githubAssessments/GitHubMissionTypes';
 import { Grading, GradingOverview } from '../../../features/grading/GradingTypes';
@@ -152,7 +152,7 @@ export type CourseConfiguration = {
   enableGame: boolean;
   enableAchievements: boolean;
   enableSourcecast: boolean;
-  sourceChapter: number;
+  sourceChapter: Chapter;
   sourceVariant: Variant;
   moduleHelpText: string;
   assetsPrefix: string;

--- a/src/commons/assessment/AssessmentTypes.ts
+++ b/src/commons/assessment/AssessmentTypes.ts
@@ -1,4 +1,4 @@
-import { SourceError, Variant } from 'js-slang/dist/types';
+import { Chapter, SourceError, Variant } from 'js-slang/dist/types';
 
 import { ExternalLibrary, ExternalLibraryName } from '../application/types/ExternalTypes';
 
@@ -149,7 +149,7 @@ export type BaseQuestion = {
 export type Question = IProgrammingQuestion | IMCQQuestion | IContestVotingQuestion;
 
 export type Library = {
-  chapter: number;
+  chapter: Chapter;
   variant?: Variant;
   execTimeMs?: number;
   external: ExternalLibrary;
@@ -216,7 +216,7 @@ export const emptyLibrary = (): Library => {
 
 export const normalLibrary = (): Library => {
   return {
-    chapter: 1,
+    chapter: Chapter.SOURCE_1,
     external: {
       name: 'NONE' as ExternalLibraryName,
       symbols: []

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -11,7 +11,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { stringify } from 'js-slang/dist/utils/stringify';
 import { isEqual } from 'lodash';
 import * as React from 'react';
@@ -650,8 +650,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
         handleChapterSelect={handleChapterSelect}
         sourceChapter={props.assessment!.questions[questionId].library.chapter}
         sourceVariant={
-          props.assessment!.questions[questionId].library.variant ??
-          (Constants.defaultSourceVariant as Variant)
+          props.assessment!.questions[questionId].library.variant ?? Constants.defaultSourceVariant
         }
         disabled={true}
         key="chapter"
@@ -783,8 +782,8 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
       ? {
           editorSessionId: '',
           editorValue: props.editorValue!,
-          sourceChapter: question.library.chapter || 4,
-          sourceVariant: question.library.variant ?? ('default' as const),
+          sourceChapter: question.library.chapter || Chapter.SOURCE_4,
+          sourceVariant: question.library.variant ?? Variant.DEFAULT,
           externalLibrary: question.library.external.name || 'NONE',
           handleDeclarationNavigate: props.handleDeclarationNavigate,
           handleEditorEval: handleEval,
@@ -813,8 +812,8 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
     handleReplValueChange: props.handleReplValueChange,
     output: props.output,
     replValue: props.replValue,
-    sourceChapter: question?.library?.chapter || 4,
-    sourceVariant: question.library.variant ?? ('default' as const),
+    sourceChapter: question?.library?.chapter || Chapter.SOURCE_4,
+    sourceVariant: question.library.variant ?? Variant.DEFAULT,
     externalLibrary: question?.library?.external?.name || 'NONE',
     replButtons: replButtons()
   };

--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -1,13 +1,13 @@
 import { Button, Classes, Menu, MenuItem } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemListRenderer, ItemRenderer, Select } from '@blueprintjs/select';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 
 import {
   defaultLanguages,
   fullJSLanguage,
-  SourceLanguage,
+  SALanguage,
   sourceLanguages,
   styliseSublanguage,
   variantLanguages
@@ -17,25 +17,22 @@ import Constants from '../utils/Constants';
 type ControlBarChapterSelectProps = DispatchProps & StateProps;
 
 type DispatchProps = {
-  handleChapterSelect?: (i: SourceLanguage, e?: React.SyntheticEvent<HTMLElement>) => void;
+  handleChapterSelect?: (i: SALanguage, e?: React.SyntheticEvent<HTMLElement>) => void;
 };
 
 type StateProps = {
-  sourceChapter: number;
+  sourceChapter: Chapter;
   sourceVariant: Variant;
   disabled?: boolean;
   key: string;
 };
 
 export function ControlBarChapterSelect(props: ControlBarChapterSelectProps) {
-  const chapterRenderer: ItemRenderer<SourceLanguage> = (lang, { handleClick }) => (
+  const chapterRenderer: ItemRenderer<SALanguage> = (lang, { handleClick }) => (
     <MenuItem key={lang.displayName} onClick={handleClick} text={lang.displayName} />
   );
 
-  const chapterListRenderer: ItemListRenderer<SourceLanguage> = ({
-    itemsParentRef,
-    renderItem
-  }) => {
+  const chapterListRenderer: ItemListRenderer<SALanguage> = ({ itemsParentRef, renderItem }) => {
     const defaultChoices = defaultLanguages.map(renderItem);
     const variantChoices = variantLanguages.map(renderItem);
     const fullJSChoice = renderItem(fullJSLanguage, 0);
@@ -50,12 +47,12 @@ export function ControlBarChapterSelect(props: ControlBarChapterSelectProps) {
     );
   };
 
-  const ChapterSelectComponent = Select.ofType<SourceLanguage>();
+  const ChapterSelectComponent = Select.ofType<SALanguage>();
 
   const chapSelect = (
     currentChap: number,
     currentVariant: Variant,
-    handleSelect = (item: SourceLanguage, event?: React.SyntheticEvent<HTMLElement>) => {},
+    handleSelect = (item: SALanguage, event?: React.SyntheticEvent<HTMLElement>) => {},
     disabled: boolean
   ) => (
     <ChapterSelectComponent

--- a/src/commons/dropdown/DropdownCreateCourse.tsx
+++ b/src/commons/dropdown/DropdownCreateCourse.tsx
@@ -12,7 +12,7 @@ import {
   TextArea
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 
 import { CourseHelpTextEditorTab } from '../../pages/academy/adminPanel/subcomponents/CourseConfigPanel';
@@ -35,17 +35,22 @@ const DropdownCreateCourse: React.FC<DialogProps> = props => {
     enableGame: true,
     enableAchievements: true,
     enableSourcecast: true,
-    sourceChapter: 1,
-    sourceVariant: 'default',
+    sourceChapter: Chapter.SOURCE_1,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: ''
   });
 
   const [courseHelpTextSelectedTab, setCourseHelpTextSelectedTab] =
     React.useState<CourseHelpTextEditorTab>(CourseHelpTextEditorTab.WRITE);
 
-  const sourceChapterOptions = [{ value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }];
+  const sourceChapterOptions = [
+    { value: Chapter.SOURCE_1 },
+    { value: Chapter.SOURCE_2 },
+    { value: Chapter.SOURCE_3 },
+    { value: Chapter.SOURCE_4 }
+  ];
 
-  const sourceVariantOptions = (chapter: number) =>
+  const sourceVariantOptions = (chapter: Chapter) =>
     sourceLanguages
       .filter(e => e.chapter === chapter)
       .map(e => {

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -9,6 +9,7 @@ import {
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 
 import { InterpreterOutput } from '../application/ApplicationTypes';
@@ -210,8 +211,8 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
         handleReplValueChange: this.props.handleReplValueChange,
         output: this.props.output,
         replValue: this.props.replValue,
-        sourceChapter: question?.library?.chapter || 4,
-        sourceVariant: 'default',
+        sourceChapter: question?.library?.chapter || Chapter.SOURCE_4,
+        sourceVariant: Variant.DEFAULT,
         externalLibrary: question?.library?.external?.name || 'NONE',
         replButtons: this.replButtons()
       }

--- a/src/commons/editingWorkspace/EditingWorkspaceContainer.ts
+++ b/src/commons/editingWorkspace/EditingWorkspaceContainer.ts
@@ -1,3 +1,4 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -63,8 +64,8 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
     {
       handleBrowseHistoryDown: () => browseReplHistoryDown(workspaceLocation),
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
-      handleChapterSelect: (chapter: any, changeEvent: any) =>
-        chapterSelect(chapter, 'default', workspaceLocation),
+      handleChapterSelect: (chapter: Chapter, changeEvent: any) =>
+        chapterSelect(chapter, Variant.DEFAULT, workspaceLocation),
       handleClearContext: (library: Library, shouldInitLibrary: boolean) =>
         beginClearContext(workspaceLocation, library, shouldInitLibrary),
       handleDeclarationNavigate: (cursorPosition: Position) =>

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentDeploymentTab.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentDeploymentTab.tsx
@@ -1,14 +1,10 @@
 import { Button, Classes, Divider, MenuItem, Switch } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemRenderer, Select } from '@blueprintjs/select';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 
-import {
-  SourceLanguage,
-  sourceLanguages,
-  styliseSublanguage
-} from '../application/ApplicationTypes';
+import { SALanguage, sourceLanguages, styliseSublanguage } from '../application/ApplicationTypes';
 import {
   External,
   externalLibraries,
@@ -196,7 +192,7 @@ export class DeploymentTab extends React.Component<DeploymentTabProps, {}> {
     this.props.updateAssessment(assessment);
   };
 
-  private handleChapterSelect = (i: SourceLanguage, _e?: React.SyntheticEvent<HTMLElement>) => {
+  private handleChapterSelect = (i: SALanguage, _e?: React.SyntheticEvent<HTMLElement>) => {
     const assessment = this.props.assessment;
     const deployment = getValueFromPath(this.props.pathToLibrary, assessment) as Library;
     deployment.chapter = i.chapter;
@@ -244,9 +240,9 @@ const altEval = (str: string): any => {
 };
 
 const chapterSelect = (
-  currentChap: number,
-  variant: Variant = 'default',
-  handleSelect = (i: SourceLanguage, e?: React.SyntheticEvent<HTMLElement>) => {}
+  currentChap: Chapter,
+  variant: Variant = Variant.DEFAULT,
+  handleSelect = (i: SALanguage, e?: React.SyntheticEvent<HTMLElement>) => {}
 ) => (
   <ChapterSelectComponent
     className={Classes.MINIMAL}
@@ -263,9 +259,9 @@ const chapterSelect = (
   </ChapterSelectComponent>
 );
 
-const ChapterSelectComponent = Select.ofType<SourceLanguage>();
+const ChapterSelectComponent = Select.ofType<SALanguage>();
 
-const chapterRenderer: ItemRenderer<SourceLanguage> = (chap, { handleClick, modifiers, query }) => (
+const chapterRenderer: ItemRenderer<SALanguage> = (chap, { handleClick, modifiers, query }) => (
   <MenuItem active={false} key={chap.displayName} onClick={handleClick} text={chap.displayName} />
 );
 

--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -4,7 +4,7 @@ import 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/ext-searchbox';
 import 'js-slang/dist/editors/ace/theme/source';
 
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 import AceEditor, { IAceEditorProps, IEditorProps } from 'react-ace';
 import * as AceBuilds from 'ace-builds';
@@ -62,7 +62,7 @@ type StateProps = {
   highlightedLines: HighlightedLines[];
   isEditorAutorun: boolean;
   newCursorPosition?: Position;
-  sourceChapter?: number;
+  sourceChapter?: Chapter;
   externalLibraryName?: string;
   sourceVariant?: Variant;
   hooks?: EditorHook[];
@@ -227,8 +227,8 @@ const EditorBase = React.memo(
     }, []);
 
     const [sourceChapter, sourceVariant, externalLibraryName] = [
-      props.sourceChapter || 1,
-      props.sourceVariant || 'default',
+      props.sourceChapter || Chapter.SOURCE_1,
+      props.sourceVariant || Variant.DEFAULT,
       props.externalLibraryName || 'NONE'
     ];
 

--- a/src/commons/editor/UseNavigation.tsx
+++ b/src/commons/editor/UseNavigation.tsx
@@ -1,4 +1,5 @@
 import { createContext, hasDeclaration } from 'js-slang';
+import { Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 
 import { Documentation } from '../documentation/Documentation';
@@ -40,7 +41,9 @@ const useNavigation: EditorHook = (inProps, outProps, keyBindings, reactAceRef) 
 
     const url = Links.sourceDocs;
     const sourceVariant =
-      propsRef.current.sourceVariant === 'default' ? '' : `_${propsRef.current.sourceVariant}`;
+      propsRef.current.sourceVariant === Variant.DEFAULT
+        ? ''
+        : `_${propsRef.current.sourceVariant}`;
     const external =
       propsRef.current.externalLibraryName === undefined
         ? 'NONE'

--- a/src/commons/githubAssessments/GitHubMissionDataUtils.ts
+++ b/src/commons/githubAssessments/GitHubMissionDataUtils.ts
@@ -3,6 +3,7 @@ import {
   GetResponseDataTypeFromEndpointMethod,
   GetResponseTypeFromEndpointMethod
 } from '@octokit/types';
+import { Chapter } from 'js-slang/dist/types';
 import { isEqual } from 'lodash';
 
 import { showWarningMessage } from '../../commons/utils/NotificationsHelper';
@@ -270,7 +271,7 @@ function convertMetadataStringToMissionMetadata(metadataString: string) {
   } catch (err) {
     console.error(err);
     return {
-      sourceVersion: 4
+      sourceVersion: Chapter.SOURCE_4
     } as MissionMetadata;
   }
 }
@@ -449,7 +450,7 @@ export function convertToMCQQuestionIfMCQText(possibleMCQText: string): [boolean
     content: '',
     grade: 0,
     id: 0,
-    library: { chapter: 4, external: { name: 'NONE', symbols: [] }, globals: [] },
+    library: { chapter: Chapter.SOURCE_4, external: { name: 'NONE', symbols: [] }, globals: [] },
     maxGrade: 0,
     xp: 0,
     maxXp: 0

--- a/src/commons/githubAssessments/GitHubMissionTypes.ts
+++ b/src/commons/githubAssessments/GitHubMissionTypes.ts
@@ -1,3 +1,5 @@
+import { Chapter } from 'js-slang/dist/types';
+
 import { Testcase } from '../assessment/AssessmentTypes';
 
 /**
@@ -17,7 +19,7 @@ export type TaskData = {
  * An code representation of a GitHub-hosted mission's '.metadata' file.
  */
 export type MissionMetadata = {
-  sourceVersion: number;
+  sourceVersion: Chapter;
 };
 
 /**

--- a/src/commons/githubAssessments/__tests__/GitHubMissionDataUtils.ts
+++ b/src/commons/githubAssessments/__tests__/GitHubMissionDataUtils.ts
@@ -1,4 +1,5 @@
 import { Octokit } from '@octokit/rest';
+import { Chapter } from 'js-slang/dist/types';
 
 import { IMCQQuestion } from '../../assessment/AssessmentTypes';
 import * as GitHubMissionDataUtils from '../GitHubMissionDataUtils';
@@ -788,7 +789,7 @@ test('convertToMCQQuestionIfMCQText works properly', () => {
     content: '',
     grade: 0,
     id: 0,
-    library: { chapter: 4, external: { name: 'NONE', symbols: [] }, globals: [] },
+    library: { chapter: Chapter.SOURCE_4, external: { name: 'NONE', symbols: [] }, globals: [] },
     maxGrade: 0,
     xp: 0,
     maxXp: 0
@@ -815,7 +816,7 @@ test('convertIMCQQuestionToMCQText works properly', () => {
     content: '',
     grade: 0,
     id: 0,
-    library: { chapter: 4, external: { name: 'NONE', symbols: [] }, globals: [] },
+    library: { chapter: Chapter.SOURCE_4, external: { name: 'NONE', symbols: [] }, globals: [] },
     maxGrade: 0,
     xp: 0,
     maxXp: 0

--- a/src/commons/mocks/AssessmentMocks.ts
+++ b/src/commons/mocks/AssessmentMocks.ts
@@ -1,3 +1,5 @@
+import { Chapter } from 'js-slang/dist/types';
+
 import { externalLibraries, ExternalLibraryName } from '../application/types/ExternalTypes';
 import {
   Assessment,
@@ -283,7 +285,7 @@ const mockGlobals: Array<[string, any]> = [
 ];
 
 const mockSoundLibrary: Library = {
-  chapter: 4,
+  chapter: Chapter.SOURCE_4,
   external: {
     name: ExternalLibraryName.SOUNDS,
     symbols: externalLibraries.get(ExternalLibraryName.SOUNDS)!
@@ -292,7 +294,7 @@ const mockSoundLibrary: Library = {
 };
 
 export const mockRuneLibrary: Library = {
-  chapter: 1,
+  chapter: Chapter.SOURCE_1,
   external: {
     name: ExternalLibraryName.RUNES,
     symbols: externalLibraries.get(ExternalLibraryName.RUNES)!
@@ -301,7 +303,7 @@ export const mockRuneLibrary: Library = {
 };
 
 const mockBinaryTreeLibrary: Library = {
-  chapter: 4,
+  chapter: Chapter.SOURCE_4,
   external: {
     name: ExternalLibraryName.BINARYTREES,
     symbols: externalLibraries.get(ExternalLibraryName.BINARYTREES)!
@@ -310,7 +312,7 @@ const mockBinaryTreeLibrary: Library = {
 };
 
 const mockToneMatrixLibrary: Library = {
-  chapter: 4,
+  chapter: Chapter.SOURCE_4,
   external: {
     name: ExternalLibraryName.SOUNDS,
     symbols: ['get_matrix']

--- a/src/commons/mocks/BackendMocks.ts
+++ b/src/commons/mocks/BackendMocks.ts
@@ -6,7 +6,7 @@ import { Grading, GradingOverview, GradingQuestion } from '../../features/gradin
 import {
   OverallState,
   Role,
-  SourceLanguage,
+  SALanguage,
   styliseSublanguage
 } from '../application/ApplicationTypes';
 import {
@@ -76,7 +76,7 @@ export function* mockBackendSaga(): SagaIterator {
     const courseRegistration = { ...mockCourseRegistrations[0] };
     const courseConfiguration = { ...mockCourseConfigurations[0] };
     const assessmentConfigurations = [...mockAssessmentConfigurations[0]];
-    const sublanguage: SourceLanguage = {
+    const sublanguage: SALanguage = {
       chapter: courseConfiguration.sourceChapter,
       variant: courseConfiguration.sourceVariant,
       displayName: styliseSublanguage(

--- a/src/commons/mocks/UserMocks.ts
+++ b/src/commons/mocks/UserMocks.ts
@@ -1,3 +1,5 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
+
 import { GameState, Role } from '../application/ApplicationTypes';
 import {
   AdminPanelCourseRegistration,
@@ -128,8 +130,8 @@ export const mockCourseConfigurations: CourseConfiguration[] = [
     enableGame: false,
     enableAchievements: true,
     enableSourcecast: true,
-    sourceChapter: 1,
-    sourceVariant: 'default',
+    sourceChapter: Chapter.SOURCE_1,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: '',
     assetsPrefix: ''
   },
@@ -140,8 +142,8 @@ export const mockCourseConfigurations: CourseConfiguration[] = [
     enableGame: false,
     enableAchievements: false,
     enableSourcecast: false,
-    sourceChapter: 2,
-    sourceVariant: 'default',
+    sourceChapter: Chapter.SOURCE_2,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: 'Help Text!',
     assetsPrefix: ''
   }

--- a/src/commons/repl/Repl.tsx
+++ b/src/commons/repl/Repl.tsx
@@ -1,7 +1,7 @@
 import { Card, Classes, Pre } from '@blueprintjs/core';
 import classNames from 'classnames';
 import { parseError } from 'js-slang';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { stringify } from 'js-slang/dist/utils/stringify';
 import * as React from 'react';
 import AceEditor from 'react-ace';
@@ -21,7 +21,7 @@ type StateProps = {
   hidden?: boolean;
   inputHidden?: boolean;
   usingSubst?: boolean;
-  sourceChapter: number;
+  sourceChapter: Chapter;
   sourceVariant: Variant;
   externalLibrary: ExternalLibraryName;
   disableScrolling?: boolean;

--- a/src/commons/repl/ReplInput.tsx
+++ b/src/commons/repl/ReplInput.tsx
@@ -1,6 +1,6 @@
 import { Classes } from '@blueprintjs/core';
 import classNames from 'classnames';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 import AceEditor from 'react-ace';
 import MediaQuery from 'react-responsive';
@@ -20,7 +20,7 @@ type DispatchProps = {
 
 type StateProps = {
   replValue: string;
-  sourceChapter: number;
+  sourceChapter: Chapter;
   sourceVariant: Variant;
   externalLibrary: ExternalLibraryName;
   disableScrolling?: boolean;

--- a/src/commons/repl/__tests__/Repl.tsx
+++ b/src/commons/repl/__tests__/Repl.tsx
@@ -1,4 +1,5 @@
 import { shallow } from 'enzyme';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { ExternalLibraryName } from 'src/commons/application/types/ExternalTypes';
 
 import {
@@ -42,8 +43,8 @@ test('Repl renders correctly', () => {
     handleReplOutputClear: () => {},
     output: [mockResultOutput, mockCodeOutput, mockErrorOutput, mockRunningOutput],
     replValue: '',
-    sourceChapter: 1,
-    sourceVariant: 'default' as const,
+    sourceChapter: Chapter.SOURCE_1,
+    sourceVariant: Variant.DEFAULT,
     externalLibrary: ExternalLibraryName.NONE,
     replButtons: []
   };

--- a/src/commons/sagas/PersistenceSaga.tsx
+++ b/src/commons/sagas/PersistenceSaga.tsx
@@ -1,4 +1,5 @@
 import { Intent } from '@blueprintjs/core';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { SagaIterator } from 'redux-saga';
 import { call, put, select } from 'redux-saga/effects';
 
@@ -82,8 +83,8 @@ export function* persistenceSaga(): SagaIterator {
       if (meta && meta.appProperties) {
         yield put(
           actions.chapterSelect(
-            parseInt(meta.appProperties.chapter || '4', 10),
-            meta.appProperties.variant || 'default',
+            parseInt(meta.appProperties.chapter || '4', 10) as Chapter,
+            meta.appProperties.variant || Variant.DEFAULT,
             'playground'
           )
         );

--- a/src/commons/sagas/PlaygroundSaga.ts
+++ b/src/commons/sagas/PlaygroundSaga.ts
@@ -1,4 +1,4 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { compressToEncodedURIComponent } from 'lz-string';
 import * as qs from 'query-string';
 import { SagaIterator } from 'redux-saga';
@@ -63,7 +63,7 @@ function* updateQueryString() {
     return;
   }
   const codeString: string = code as string;
-  const chapter: number = yield select(
+  const chapter: Chapter = yield select(
     (state: OverallState) => state.workspaces.playground.context.chapter
   );
   const variant: Variant = yield select(

--- a/src/commons/sagas/RemoteExecutionSaga.ts
+++ b/src/commons/sagas/RemoteExecutionSaga.ts
@@ -1,6 +1,7 @@
 import { SlingClient } from '@sourceacademy/sling-client';
 import { assemble, compile, Context } from 'js-slang';
 import { ExceptionError } from 'js-slang/dist/errors/errors';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { SagaIterator } from 'redux-saga';
 import { call, put, race, select, take } from 'redux-saga/effects';
 
@@ -146,8 +147,8 @@ export function* remoteExecutionSaga(): SagaIterator {
         actions.beginClearContext(
           workspace,
           {
-            chapter: deviceType?.languageChapter || 3,
-            variant: 'default',
+            chapter: deviceType?.languageChapter || Chapter.SOURCE_3,
+            variant: Variant.DEFAULT,
             external: {
               name: deviceType?.deviceLibraryName || ExternalLibraryName.NONE,
               symbols: deviceType?.internalFunctions || []

--- a/src/commons/sagas/__tests__/BackendSaga.ts
+++ b/src/commons/sagas/__tests__/BackendSaga.ts
@@ -1,4 +1,4 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { call } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 import { history } from 'src/commons/utils/HistoryHelper';
@@ -24,7 +24,7 @@ import {
   updateLatestViewedCourse,
   updateNotifications
 } from '../../application/actions/SessionActions';
-import { GameState, Role, SourceLanguage, Story } from '../../application/ApplicationTypes';
+import { GameState, Role, SALanguage, Story } from '../../application/ApplicationTypes';
 import {
   ACKNOWLEDGE_NOTIFICATIONS,
   AdminPanelCourseRegistration,
@@ -164,8 +164,8 @@ const mockCourseConfiguration1: CourseConfiguration = {
   enableGame: true,
   enableAchievements: true,
   enableSourcecast: true,
-  sourceChapter: 1,
-  sourceVariant: 'default' as Variant,
+  sourceChapter: Chapter.SOURCE_1,
+  sourceVariant: Variant.DEFAULT,
   moduleHelpText: 'Help text',
   assetsPrefix: ''
 };
@@ -194,8 +194,8 @@ const mockCourseConfiguration2: CourseConfiguration = {
   enableGame: true,
   enableAchievements: true,
   enableSourcecast: true,
-  sourceChapter: 4,
-  sourceVariant: 'default' as Variant,
+  sourceChapter: Chapter.SOURCE_4,
+  sourceVariant: Variant.DEFAULT,
   moduleHelpText: 'Help text',
   assetsPrefix: ''
 };
@@ -770,9 +770,9 @@ describe('Test ACKNOWLEDGE_NOTIFICATIONS action', () => {
 
 describe('Test CHANGE_SUBLANGUAGE action', () => {
   test('when chapter is changed', () => {
-    const sublang: SourceLanguage = {
-      chapter: 4,
-      variant: 'gpu',
+    const sublang: SALanguage = {
+      chapter: Chapter.SOURCE_4,
+      variant: Variant.GPU,
       displayName: 'Source \xa74 GPU'
     };
 
@@ -787,7 +787,10 @@ describe('Test CHANGE_SUBLANGUAGE action', () => {
       )
       .provide([
         [
-          call(putCourseConfig, mockTokens, { sourceChapter: 4, sourceVariant: 'gpu' }),
+          call(putCourseConfig, mockTokens, {
+            sourceChapter: Chapter.SOURCE_4,
+            sourceVariant: Variant.GPU
+          }),
           { ok: true }
         ]
       ])
@@ -861,8 +864,8 @@ describe('Test UPDATE_COURSE_CONFIG action', () => {
     enableGame: false,
     enableAchievements: false,
     enableSourcecast: false,
-    sourceChapter: 4,
-    sourceVariant: 'default',
+    sourceChapter: Chapter.SOURCE_4,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: 'Help',
     assetsPrefix: ''
   };
@@ -958,8 +961,8 @@ describe('Test CREATE_COURSE action', () => {
     enableGame: true,
     enableAchievements: true,
     enableSourcecast: true,
-    sourceChapter: 1,
-    sourceVariant: 'default',
+    sourceChapter: Chapter.SOURCE_1,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: 'Help Text'
   };
   const user = mockUser;

--- a/src/commons/sagas/__tests__/PersistenceSaga.ts
+++ b/src/commons/sagas/__tests__/PersistenceSaga.ts
@@ -1,3 +1,4 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { expectSaga } from 'redux-saga-test-plan';
 
 import { ExternalLibraryName } from '../../../commons/application/types/ExternalTypes';
@@ -22,8 +23,8 @@ const USER_EMAIL = 'test@email.com';
 const FILE_ID = '123';
 const FILE_NAME = 'file';
 const FILE_DATA = '// Hello world';
-const SOURCE_CHAPTER = 3;
-const SOURCE_VARIANT = 'lazy';
+const SOURCE_CHAPTER = Chapter.SOURCE_3;
+const SOURCE_VARIANT = Variant.LAZY;
 const SOURCE_LIBRARY = ExternalLibraryName.MACHINELEARNING;
 
 beforeAll(() => {

--- a/src/commons/sagas/__tests__/PlaygroundSaga.ts
+++ b/src/commons/sagas/__tests__/PlaygroundSaga.ts
@@ -1,4 +1,4 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { compressToEncodedURIComponent } from 'lz-string';
 import * as qs from 'query-string';
 import { call } from 'redux-saga/effects';
@@ -356,7 +356,7 @@ describe('Playground saga tests', () => {
 });
 
 function createQueryString(code: string, state: OverallState): string {
-  const chapter: number = state.workspaces.playground.context.chapter;
+  const chapter: Chapter = state.workspaces.playground.context.chapter;
   const variant: Variant = state.workspaces.playground.context.variant;
   const external: ExternalLibraryName = state.workspaces.playground.externalLibrary;
   const execTime: number = state.workspaces.playground.execTime;

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -1,6 +1,6 @@
 import { Context, IOptions, Result, resume, runInContext } from 'js-slang';
 import createContext from 'js-slang/dist/createContext';
-import { Finished, Variant } from 'js-slang/dist/types';
+import { Chapter, Finished, Variant } from 'js-slang/dist/types';
 import { call } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
@@ -99,7 +99,7 @@ describe('EVAL_EDITOR', () => {
     const editorPostpend = '42;';
     const execTime = 1000;
     const context = createContext();
-    const variant: Variant = 'default';
+    const variant = Variant.DEFAULT;
     const globals: Array<[string, any]> = [
       ['testNumber', 3.141592653589793],
       ['testObject', { a: 1, b: 2 }],
@@ -337,7 +337,7 @@ describe('EVAL_TESTCASE', () => {
 
     const library: Library = {
       chapter: context.chapter,
-      variant: 'default',
+      variant: Variant.DEFAULT,
       external: {
         name: ExternalLibraryName.NONE,
         symbols: context.externalSymbols
@@ -424,15 +424,15 @@ describe('CHAPTER_SELECT', () => {
     ];
     context = {
       ...mockRuntimeContext(),
-      chapter: 4
+      chapter: Chapter.SOURCE_4
     };
   });
 
   test('puts beginClearContext, clearReplOutput and calls showSuccessMessage correctly', () => {
-    const newChapter = 3;
+    const newChapter = Chapter.SOURCE_3;
     const library: Library = {
       chapter: newChapter,
-      variant: 'default',
+      variant: Variant.DEFAULT,
       external: {
         name: 'NONE' as ExternalLibraryName,
         symbols: context.externalSymbols
@@ -449,14 +449,14 @@ describe('CHAPTER_SELECT', () => {
       .call(showSuccessMessage, `Switched to Source \xa7${newChapter}`, 1000)
       .dispatch({
         type: CHAPTER_SELECT,
-        payload: { chapter: newChapter, variant: 'default', workspaceLocation }
+        payload: { chapter: newChapter, variant: Variant.DEFAULT, workspaceLocation }
       })
       .silentRun();
   });
 
   test('does not call beginClearContext, clearReplOutput and showSuccessMessage when oldChapter === newChapter and oldVariant === newVariant', () => {
-    const newChapter = 4;
-    const newVariant: Variant = 'default';
+    const newChapter = Chapter.SOURCE_4;
+    const newVariant = Variant.DEFAULT;
     const newDefaultState = generateDefaultState(workspaceLocation, { context, globals });
 
     return expectSaga(workspaceSaga)
@@ -528,7 +528,7 @@ describe('CHAPTER_SELECT', () => {
 describe('PLAYGROUND_EXTERNAL_SELECT', () => {
   let workspaceLocation: WorkspaceLocation;
   let globals: Array<[string, any]>;
-  let chapter: number;
+  let chapter: Chapter;
   let context: Context;
 
   beforeEach(() => {
@@ -538,7 +538,7 @@ describe('PLAYGROUND_EXTERNAL_SELECT', () => {
       ['testObject', { a: 1, b: 2 }],
       ['testArray', [1, 2, 'a', 'b']]
     ];
-    chapter = 4;
+    chapter = Chapter.SOURCE_4;
     context = {
       ...mockRuntimeContext(),
       chapter
@@ -611,7 +611,7 @@ describe('BEGIN_CLEAR_CONTEXT', () => {
   let loadLib: any;
   let getReadyWebGLForCanvas: any;
   let getReadyStringifyForRunes: any;
-  let chapter: number;
+  let chapter: Chapter;
   let globals: Array<[string, any]>;
   let workspaceLocation: WorkspaceLocation;
 
@@ -625,7 +625,7 @@ describe('BEGIN_CLEAR_CONTEXT', () => {
     (window as any).getReadyStringifyForRunes = getReadyStringifyForRunes;
 
     workspaceLocation = 'grading';
-    chapter = 4;
+    chapter = Chapter.SOURCE_4;
     globals = [
       ['testNumber', 3.141592653589793],
       ['testObject', { a: 1, b: 2 }],
@@ -1061,7 +1061,7 @@ describe('NAV_DECLARATION', () => {
     editorValue = 'const foo = (x) => -1; foo(2);';
     context = {
       ...mockRuntimeContext(),
-      chapter: 4
+      chapter: Chapter.SOURCE_4
     };
     state = generateDefaultState(workspaceLocation, { editorValue, context });
   });

--- a/src/commons/sideContent/githubAssessments/SideContentMissionEditor.tsx
+++ b/src/commons/sideContent/githubAssessments/SideContentMissionEditor.tsx
@@ -1,8 +1,8 @@
 import { Label } from '@blueprintjs/core';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter } from 'js-slang/dist/types';
 import React from 'react';
 
-import { SourceLanguage } from '../../application/ApplicationTypes';
+import { SALanguage } from '../../application/ApplicationTypes';
 import { ControlBarChapterSelect } from '../../controlBar/ControlBarChapterSelect';
 import { MissionMetadata } from '../../githubAssessments/GitHubMissionTypes';
 import Constants from '../../utils/Constants';
@@ -22,7 +22,7 @@ const SideContentMissionEditor: React.FC<SideContentMissionEditorProps> = props 
         <div className="SideContentMissionEditorOptionColumn">
           <ControlBarChapterSelect
             sourceChapter={props.missionMetadata.sourceVersion}
-            sourceVariant={Constants.defaultSourceVariant as Variant}
+            sourceVariant={Constants.defaultSourceVariant}
             key="chapter"
             disabled={false}
             handleChapterSelect={handleChapterSelect}
@@ -38,8 +38,8 @@ const SideContentMissionEditor: React.FC<SideContentMissionEditorProps> = props 
     props.setMissionMetadata(newMetadata);
   }
 
-  function handleChapterSelect(i: SourceLanguage, e?: React.SyntheticEvent<HTMLElement>) {
-    setMissionMetadataWrapper<number>('sourceVersion', i.chapter);
+  function handleChapterSelect(i: SALanguage, e?: React.SyntheticEvent<HTMLElement>) {
+    setMissionMetadataWrapper<Chapter>('sourceVersion', i.chapter);
   }
 };
 

--- a/src/commons/sourceRecorder/SourceRecorderControlBar.tsx
+++ b/src/commons/sourceRecorder/SourceRecorderControlBar.tsx
@@ -1,5 +1,6 @@
 import { ButtonGroup, Slider } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
+import { Chapter } from 'js-slang/dist/types';
 import * as React from 'react';
 
 import {
@@ -23,7 +24,7 @@ type DispatchProps = {
   handleSetInputToApply: (inputToApply: Input) => void;
   handleSetSourcecastDuration: (duration: number) => void;
   handleSetSourcecastStatus: (playbackStatus: PlaybackStatus) => void;
-  handleChapterSelect: (chapter: number) => void;
+  handleChapterSelect: (chapter: Chapter) => void;
   handleExternalSelect: (name: ExternalLibraryName) => void;
   handlePromptAutocomplete: (row: number, col: number, callback: any) => void;
 };

--- a/src/commons/utils/AceHelper.ts
+++ b/src/commons/utils/AceHelper.ts
@@ -1,15 +1,14 @@
 import { HighlightRulesSelector, ModeSelector } from 'js-slang/dist/editors/ace/modes/source';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 
 import { HighlightRulesSelector_native } from '../../features/fullJS/fullJSHighlight';
-import { isFullJSChapter } from '../application/ApplicationTypes';
 import { Documentation } from '../documentation/Documentation';
 /**
  * This _modifies global state_ and defines a new Ace mode globally, if it does not already exist.
  *
  * You can call this directly in render functions.
  */
-export const selectMode = (chapter: number, variant: Variant, library: string) => {
+export const selectMode = (chapter: Chapter, variant: Variant, library: string) => {
   if (
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -19,7 +18,7 @@ export const selectMode = (chapter: number, variant: Variant, library: string) =
     return;
   }
 
-  if (!isFullJSChapter(chapter)) {
+  if (chapter !== Chapter.FULL_JS) {
     HighlightRulesSelector(chapter, variant, library, Documentation.externalLibraries[library]);
   } else {
     HighlightRulesSelector_native(
@@ -32,5 +31,5 @@ export const selectMode = (chapter: number, variant: Variant, library: string) =
   ModeSelector(chapter, variant, library);
 };
 
-export const getModeString = (chapter: number, variant: Variant, library: string) =>
+export const getModeString = (chapter: Chapter, variant: Variant, library: string) =>
   `source${chapter}${variant}${library}`;

--- a/src/commons/utils/Constants.ts
+++ b/src/commons/utils/Constants.ts
@@ -1,3 +1,4 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
 import moment, { Moment } from 'moment';
 
 function isTrue(value?: string, defaultTo?: boolean): boolean {
@@ -16,8 +17,8 @@ const backendUrl = process.env.REACT_APP_BACKEND_URL;
 const cadetLoggerUrl = isTest ? undefined : process.env.REACT_APP_CADET_LOGGER;
 const cadetLoggerInterval = parseInt(process.env.REACT_APP_CADET_LOGGER_INTERVAL || '10000', 10);
 const useBackend = !isTest && isTrue(process.env.REACT_APP_USE_BACKEND);
-const defaultSourceChapter = 4;
-const defaultSourceVariant = 'default';
+const defaultSourceChapter = Chapter.SOURCE_4;
+const defaultSourceVariant = Variant.DEFAULT;
 const defaultQuestionId = 0;
 const maxBrowseIndex = 50;
 const mobileBreakpoint = 768;

--- a/src/commons/utils/IntroductionHelper.ts
+++ b/src/commons/utils/IntroductionHelper.ts
@@ -1,6 +1,6 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 
-import { isFullJSChapter, styliseSublanguage, sublanguages } from '../application/ApplicationTypes';
+import { styliseSublanguage, sublanguages } from '../application/ApplicationTypes';
 import { Links } from './Constants';
 
 const MAIN_INTRODUCTION = `
@@ -16,8 +16,8 @@ and also the [_Source Academy keyboard shortcuts_](${Links.sourceHotkeys}).
 
 `;
 
-const generateSourceDocsLink = (sourceChapter: number, sourceVariant: Variant) => {
-  if (isFullJSChapter(sourceChapter)) {
+const generateSourceDocsLink = (sourceChapter: Chapter, sourceVariant: Variant) => {
+  if (sourceChapter === Chapter.FULL_JS) {
     return (
       `However, you have chosen full JavaScript, which runs your program directly, using JavaScript strict mode [_(ECMAScript 2021)_](${Links.ecmaScript_2021}).` +
       '\n\n<b>Warning:</b> If your program freezes during execution, you can try refreshing the tab. ' +
@@ -34,7 +34,7 @@ const generateSourceDocsLink = (sourceChapter: number, sourceVariant: Variant) =
   }
 
   const sourceDocsLink: string = `${Links.sourceDocs}source_${sourceChapter}${
-    sourceVariant !== 'default' && sourceVariant !== 'native' ? `_${sourceVariant}` : ''
+    sourceVariant !== Variant.DEFAULT && sourceVariant !== Variant.NATIVE ? `_${sourceVariant}` : ''
   }/`;
 
   return `You have chosen the sublanguage [_${styliseSublanguage(
@@ -43,12 +43,12 @@ const generateSourceDocsLink = (sourceChapter: number, sourceVariant: Variant) =
   )}_](${sourceDocsLink}).`;
 };
 
-const generateIntroductionText = (sourceChapter: number, sourceVariant: Variant) => {
+const generateIntroductionText = (sourceChapter: Chapter, sourceVariant: Variant) => {
   return (
     MAIN_INTRODUCTION + generateSourceDocsLink(sourceChapter, sourceVariant) + HOTKEYS_INTRODUCTION
   );
 };
 
-export const generateSourceIntroduction = (sourceChapter: number, sourceVariant: Variant) => {
+export const generateSourceIntroduction = (sourceChapter: Chapter, sourceVariant: Variant) => {
   return generateIntroductionText(sourceChapter, sourceVariant);
 };

--- a/src/commons/utils/JsSlangHelper.ts
+++ b/src/commons/utils/JsSlangHelper.ts
@@ -1,6 +1,6 @@
 /* tslint:disable: ban-types*/
 import createSlangContext, { defineBuiltin, importBuiltins } from 'js-slang/dist/createContext';
-import { Context, CustomBuiltIns, Value, Variant } from 'js-slang/dist/types';
+import { Chapter, Context, CustomBuiltIns, Value, Variant } from 'js-slang/dist/types';
 import { stringify } from 'js-slang/dist/utils/stringify';
 import { difference, keys } from 'lodash';
 import EnvVisualizer from 'src/features/envVisualizer/EnvVisualizer';
@@ -122,10 +122,10 @@ export const externalBuiltIns = {
  * externalBuiltIns, such as display and prompt.
  */
 export function createContext<T>(
-  chapter: number,
+  chapter: Chapter,
   externals: string[],
   externalContext: T,
-  variant: Variant = 'default',
+  variant: Variant = Variant.DEFAULT,
   moduleParams?: any
 ) {
   return createSlangContext<T>(

--- a/src/commons/workspace/WorkspaceActions.ts
+++ b/src/commons/workspace/WorkspaceActions.ts
@@ -1,9 +1,9 @@
 import { Context } from 'js-slang';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { action } from 'typesafe-actions';
 
 import { SET_EDITOR_READONLY } from '../../features/sourceRecorder/sourcecast/SourcecastTypes';
-import { SourceLanguage } from '../application/ApplicationTypes';
+import { SALanguage } from '../application/ApplicationTypes';
 import { ExternalLibraryName } from '../application/types/ExternalTypes';
 import { HIGHLIGHT_LINE } from '../application/types/InterpreterTypes';
 import { Library } from '../assessment/AssessmentTypes';
@@ -77,7 +77,7 @@ export const changeStepLimit = (stepLimit: number, workspaceLocation: WorkspaceL
   action(CHANGE_STEP_LIMIT, { stepLimit, workspaceLocation });
 
 export const chapterSelect = (
-  chapter: number,
+  chapter: Chapter,
   variant: Variant,
   workspaceLocation: WorkspaceLocation
 ) =>
@@ -250,11 +250,9 @@ export const updateHasUnsavedChanges = (
     hasUnsavedChanges
   });
 
-export const changeSublanguage = (sublang: SourceLanguage) =>
-  action(CHANGE_SUBLANGUAGE, { sublang });
+export const changeSublanguage = (sublang: SALanguage) => action(CHANGE_SUBLANGUAGE, { sublang });
 
-export const updateSublanguage = (sublang: SourceLanguage) =>
-  action(UPDATE_SUBLANGUAGE, { sublang });
+export const updateSublanguage = (sublang: SALanguage) => action(UPDATE_SUBLANGUAGE, { sublang });
 
 export const promptAutocomplete = (
   workspaceLocation: WorkspaceLocation,

--- a/src/commons/workspace/__tests__/WorkspaceActions.ts
+++ b/src/commons/workspace/__tests__/WorkspaceActions.ts
@@ -1,4 +1,6 @@
-import { createDefaultWorkspace, SourceLanguage } from '../../application/ApplicationTypes';
+import { Chapter, Variant } from 'js-slang/dist/types';
+
+import { createDefaultWorkspace, SALanguage } from '../../application/ApplicationTypes';
 import { ExternalLibraryName } from '../../application/types/ExternalTypes';
 import { HIGHLIGHT_LINE } from '../../application/types/InterpreterTypes';
 import { Library } from '../../assessment/AssessmentTypes';
@@ -140,8 +142,8 @@ test('changeSideContentHeight generates correct action object', () => {
 });
 
 test('chapterSelect generates correct action object', () => {
-  const chapter = 3;
-  const variant = 'default';
+  const chapter = Chapter.SOURCE_3;
+  const variant = Variant.DEFAULT;
   const action = chapterSelect(chapter, variant, playgroundWorkspace);
   expect(action).toEqual({
     type: CHAPTER_SELECT,
@@ -178,7 +180,7 @@ test('toggleEditorAutorun generates correct action object', () => {
 
 test('beginClearContext generates correct action object', () => {
   const library: Library = {
-    chapter: 4,
+    chapter: Chapter.SOURCE_4,
     external: {
       name: ExternalLibraryName.SOUNDS,
       symbols: []
@@ -229,7 +231,7 @@ test('clearReplOutput generates correct action object', () => {
 
 test('endClearContext generates correct action object', () => {
   const library: Library = {
-    chapter: 4,
+    chapter: Chapter.SOURCE_4,
     external: {
       name: ExternalLibraryName.SOUNDS,
       symbols: []
@@ -437,9 +439,9 @@ test('moveCursor generates correct action object', () => {
 });
 
 test('changeSublanguage generates correct action object', () => {
-  const sublang: SourceLanguage = {
-    chapter: 2,
-    variant: 'default',
+  const sublang: SALanguage = {
+    chapter: Chapter.SOURCE_2,
+    variant: Variant.DEFAULT,
     displayName: 'Source \xa72'
   };
   const action = changeSublanguage(sublang);
@@ -452,9 +454,9 @@ test('changeSublanguage generates correct action object', () => {
 });
 
 test('updateChapter generates correct action object', () => {
-  const sublang: SourceLanguage = {
-    chapter: 2,
-    variant: 'default',
+  const sublang: SALanguage = {
+    chapter: Chapter.SOURCE_2,
+    variant: Variant.DEFAULT,
     displayName: 'Source \xa72'
   };
   const action = updateSublanguage(sublang);

--- a/src/commons/workspace/__tests__/WorkspaceReducer.ts
+++ b/src/commons/workspace/__tests__/WorkspaceReducer.ts
@@ -1,3 +1,4 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { cloneDeep } from 'lodash';
 
 import { ExternalLibraryName } from '../../../commons/application/types/ExternalTypes';
@@ -502,7 +503,7 @@ describe('END_CLEAR_CONTEXT', () => {
       ['testArray', [1, 2, 'a', 'b']]
     ];
     const library: Library = {
-      chapter: 4,
+      chapter: Chapter.SOURCE_4,
       external: {
         name: 'SOUNDS' as ExternalLibraryName,
         symbols: []
@@ -519,7 +520,7 @@ describe('END_CLEAR_CONTEXT', () => {
         library.chapter,
         library.external.symbols,
         location,
-        'default'
+        Variant.DEFAULT
       );
 
       // Note: we stringify because context contains functions which cause

--- a/src/features/academy/__tests__/AcademyActions.ts
+++ b/src/features/academy/__tests__/AcademyActions.ts
@@ -1,3 +1,4 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { Role } from 'src/commons/application/ApplicationTypes';
 import { UpdateCourseConfiguration } from 'src/commons/application/types/SessionTypes';
 import { UsernameRoleGroup } from 'src/pages/academy/adminPanel/subcomponents/AddUserPanel';
@@ -30,8 +31,8 @@ test('createCourse generates correct action object', () => {
     enableGame: true,
     enableAchievements: true,
     enableSourcecast: true,
-    sourceChapter: 1,
-    sourceVariant: 'default',
+    sourceChapter: Chapter.SOURCE_1,
+    sourceVariant: Variant.DEFAULT,
     moduleHelpText: 'Help Text'
   };
 

--- a/src/features/eventLogging/index.ts
+++ b/src/features/eventLogging/index.ts
@@ -1,3 +1,4 @@
+import { Chapter } from 'js-slang/dist/types';
 import { v4 as uuid } from 'uuid';
 
 import { ExternalLibraryName } from '../../commons/application/types/ExternalTypes';
@@ -6,7 +7,7 @@ import { Input as RecorderInput } from '../sourceRecorder/SourceRecorderTypes';
 export const playgroundQuestionId: number = -1;
 
 type PlaybackInitial = {
-  chapter: number;
+  chapter: Chapter;
   externalLibrary?: ExternalLibraryName;
   editorValue: string;
 };

--- a/src/features/fullJS/fullJSHighlight.js
+++ b/src/features/fullJS/fullJSHighlight.js
@@ -1,8 +1,10 @@
 /* eslint-disable */
 import * as ace from 'ace-builds/src-noconflict/ace';
+import { Variant } from 'js-slang/dist/types';
+
 export function HighlightRulesSelector_native(
   id,
-  variant = 'default',
+  variant = Variant.DEFAULT,
   external = 'NONE',
   externalLibraries = []
 ) {
@@ -14,7 +16,7 @@ export function HighlightRulesSelector_native(
     ).DocCommentHighlightRules;
     const TextHighlightRules = acequire('./text_highlight_rules').TextHighlightRules;
     const identifierRegex = '[a-zA-Z\\$_\u00a1-\uffff][a-zA-Z\\d\\$_\u00a1-\uffff]*';
-    const chapter = variant === 'default' ? id.toString() : id.toString() + '_' + variant;
+    const chapter = variant === Variant.DEFAULT ? id.toString() : id.toString() + '_' + variant;
 
     // Currently there are no builtin libraries for NativeJS
     // const builtin_lib = SourceDocumentation.builtins[chapter];

--- a/src/features/game/scenes/roomPreview/RoomPreview.ts
+++ b/src/features/game/scenes/roomPreview/RoomPreview.ts
@@ -1,4 +1,5 @@
 import { Context, runInContext } from 'js-slang';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { createContext } from 'src/commons/utils/JsSlangHelper';
 
 import ImageAssets from '../../assets/ImageAssets';
@@ -169,7 +170,7 @@ export default class RoomPreview extends Phaser.Scene {
   }
 
   public createContext() {
-    this.context = createContext(4, [], 'playground', 'default', {
+    this.context = createContext(Chapter.SOURCE_4, [], 'playground', Variant.DEFAULT, {
       game: {
         scene: this,
         preloadImageMap: this.preloadImageMap,

--- a/src/features/remoteExecution/RemoteExecutionTypes.ts
+++ b/src/features/remoteExecution/RemoteExecutionTypes.ts
@@ -1,4 +1,5 @@
 import { SlingClient } from '@sourceacademy/sling-client';
+import { Chapter } from 'js-slang/dist/types';
 import { ExternalLibraryName } from 'src/commons/application/types/ExternalTypes';
 
 import { WorkspaceLocation } from '../../commons/workspace/WorkspaceTypes';
@@ -41,7 +42,7 @@ export interface DeviceType {
   id: string;
   name: string;
   internalFunctions: string[];
-  languageChapter: number;
+  languageChapter: Chapter;
   deviceLibraryName: ExternalLibraryName;
 }
 
@@ -95,7 +96,7 @@ export const deviceTypes: DeviceType[] = [
       'ev3_ledGetBrightness',
       'ev3_ledSetBrightness'
     ],
-    languageChapter: 3,
+    languageChapter: Chapter.SOURCE_3,
     deviceLibraryName: ExternalLibraryName.EV3
   }
 ];

--- a/src/features/sourceRecorder/SourceRecorderTypes.ts
+++ b/src/features/sourceRecorder/SourceRecorderTypes.ts
@@ -1,4 +1,5 @@
 import { Ace } from 'ace-builds/ace';
+import { Chapter } from 'js-slang/dist/types';
 
 import { ExternalLibraryName } from '../../commons/application/types/ExternalTypes';
 import { Position } from '../../commons/editor/EditorTypes';
@@ -51,7 +52,7 @@ export type Input = keyof InputTypeShape extends infer K
 
 export type PlaybackData = {
   init: {
-    chapter: number;
+    chapter: Chapter;
     externalLibrary: ExternalLibraryName;
     editorValue: string;
   };

--- a/src/features/sourceRecorder/__tests__/SourceRecorderActions.ts
+++ b/src/features/sourceRecorder/__tests__/SourceRecorderActions.ts
@@ -1,3 +1,5 @@
+import { Chapter } from 'js-slang/dist/types';
+
 import { ExternalLibraryName } from '../../../commons/application/types/ExternalTypes';
 import { WorkspaceLocation } from '../../../commons/workspace/WorkspaceTypes';
 import {
@@ -35,7 +37,7 @@ test('saveSourcecastData generates correct action object', () => {
   const playbackData: PlaybackData = {
     init: {
       editorValue: 'Editor Init Value',
-      chapter: 1,
+      chapter: Chapter.SOURCE_1,
       externalLibrary: ExternalLibraryName.NONE
     },
     inputs: []
@@ -135,7 +137,7 @@ test('setSourcecastData generates correct action object', () => {
   };
   const playbackData: PlaybackData = {
     init: {
-      chapter: 1,
+      chapter: Chapter.SOURCE_1,
       externalLibrary: ExternalLibraryName.NONE,
       editorValue: ''
     },

--- a/src/features/sourceRecorder/sourcecast/__tests__/SourcecastReducer.ts
+++ b/src/features/sourceRecorder/sourcecast/__tests__/SourcecastReducer.ts
@@ -1,3 +1,4 @@
+import { Chapter } from 'js-slang/dist/types';
 import { action as generateAction } from 'typesafe-actions';
 
 import { defaultWorkspaceManager } from '../../../../commons/application/ApplicationTypes';
@@ -39,7 +40,7 @@ describe('SAVE_SOURCECAST_DATA', () => {
     };
     const playbackData: PlaybackData = {
       init: {
-        chapter: 1,
+        chapter: Chapter.SOURCE_1,
         externalLibrary: ExternalLibraryName.NONE,
         editorValue: ''
       },
@@ -159,7 +160,7 @@ describe('SET_SOURCECAST_DATA', () => {
     };
     const playbackData: PlaybackData = {
       init: {
-        chapter: 1,
+        chapter: Chapter.SOURCE_1,
         externalLibrary: ExternalLibraryName.NONE,
         editorValue: ''
       },

--- a/src/features/sourceRecorder/sourcereel/__tests__/SourcereelActions.ts
+++ b/src/features/sourceRecorder/sourcereel/__tests__/SourcereelActions.ts
@@ -1,3 +1,5 @@
+import { Chapter } from 'js-slang/dist/types';
+
 import { ExternalLibraryName } from '../../../../commons/application/types/ExternalTypes';
 import { WorkspaceLocation } from '../../../../commons/workspace/WorkspaceTypes';
 import { CodeDelta, Input, PlaybackData } from '../../SourceRecorderTypes';
@@ -29,7 +31,7 @@ function dateIsCloseEnough(dateA: number, dateB: number) {
 test('recordInit generates correct action object', () => {
   const initData: PlaybackData['init'] = {
     editorValue: 'Init Value',
-    chapter: 1,
+    chapter: Chapter.SOURCE_1,
     externalLibrary: ExternalLibraryName.NONE
   };
   const action = recordInit(initData, sourcereelWorkspace);

--- a/src/features/sourceRecorder/sourcereel/__tests__/SourcereelReducer.ts
+++ b/src/features/sourceRecorder/sourcereel/__tests__/SourcereelReducer.ts
@@ -1,3 +1,4 @@
+import { Chapter } from 'js-slang/dist/types';
 import { action as generateAction } from 'typesafe-actions';
 
 import { defaultWorkspaceManager } from '../../../../commons/application/ApplicationTypes';
@@ -18,7 +19,7 @@ describe('RECORD_INIT', () => {
   test('records editorInitValue correctly', () => {
     const initData: PlaybackData['init'] = {
       editorValue: 'test init value',
-      chapter: 1,
+      chapter: Chapter.SOURCE_1,
       externalLibrary: ExternalLibraryName.NONE
     };
     const action = generateAction(RECORD_INIT, { initData, workspaceLocation: undefined! });

--- a/src/pages/__tests__/createStore.test.ts
+++ b/src/pages/__tests__/createStore.test.ts
@@ -20,7 +20,7 @@ const mockChangedStoredState: SavedState = {
   playgroundEditorValue: 'Nihao everybody',
   playgroundIsEditorAutorun: true,
   playgroundSourceChapter: Constants.defaultSourceChapter,
-  playgroundSourceVariant: 'default' as Variant,
+  playgroundSourceVariant: Variant.DEFAULT,
   playgroundExternalLibrary: 'NONE' as ExternalLibraryName
 };
 

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -1,6 +1,7 @@
 import { Classes, NonIdealState, Spinner, SpinnerSize } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 import { ExternalLibraryName } from 'src/commons/application/types/ExternalTypes';
 import SideContentVideoDisplay from 'src/commons/sideContent/SideContentVideoDisplay';
@@ -201,8 +202,8 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
               handleEditorUpdateBreakpoints: this.props.handleEditorUpdateBreakpoints,
               handlePromptAutocomplete: this.props.handlePromptAutocomplete,
               isEditorAutorun: false,
-              sourceChapter: question?.library?.chapter || 4,
-              sourceVariant: question?.library?.variant ?? ('default' as const),
+              sourceChapter: question?.library?.chapter || Chapter.SOURCE_4,
+              sourceVariant: question?.library?.variant ?? Variant.DEFAULT,
               externalLibraryName: question?.library?.external?.name || 'NONE'
             }
           : undefined,
@@ -224,8 +225,8 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
         handleReplValueChange: this.props.handleReplValueChange,
         output: this.props.output,
         replValue: this.props.replValue,
-        sourceChapter: question?.library?.chapter || 4,
-        sourceVariant: question?.library?.variant ?? ('default' as const),
+        sourceChapter: question?.library?.chapter || Chapter.SOURCE_4,
+        sourceVariant: question?.library?.variant ?? Variant.DEFAULT,
         externalLibrary: question?.library?.external?.name || 'NONE',
         replButtons: this.replButtons()
       }

--- a/src/pages/academy/groundControl/subcomponents/DefaultChapterSelect.tsx
+++ b/src/pages/academy/groundControl/subcomponents/DefaultChapterSelect.tsx
@@ -1,12 +1,12 @@
 import { Button, Classes, Dialog, Intent, Menu, MenuItem } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { ItemListRenderer, ItemRenderer, Select } from '@blueprintjs/select';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 
 import {
   defaultLanguages,
-  SourceLanguage,
+  SALanguage,
   sourceLanguages,
   styliseSublanguage,
   variantLanguages
@@ -16,11 +16,11 @@ import controlButton from '../../../../commons/ControlButton';
 export type DefaultChapterSelectProps = DispatchProps & StateProps;
 
 export type DispatchProps = {
-  handleUpdateSublanguage: (sublang: SourceLanguage) => void;
+  handleUpdateSublanguage: (sublang: SALanguage) => void;
 };
 
 export type StateProps = {
-  sourceChapter: number;
+  sourceChapter: Chapter;
   sourceVariant: Variant;
 };
 
@@ -28,11 +28,11 @@ const DefaultChapterSelect: React.FunctionComponent<DefaultChapterSelectProps> =
   const { handleUpdateSublanguage } = props;
   const { sourceChapter, sourceVariant } = props;
 
-  const [chosenSublang, setSublanguage] = React.useState<SourceLanguage>(sourceLanguages[0]);
+  const [chosenSublang, setSublanguage] = React.useState<SALanguage>(sourceLanguages[0]);
   const [isDialogOpen, setDialogState] = React.useState<boolean>(false);
 
   const handleOpenDialog = React.useCallback(
-    (choice: SourceLanguage) => {
+    (choice: SALanguage) => {
       setDialogState(true);
       setSublanguage(choice);
     },
@@ -46,14 +46,14 @@ const DefaultChapterSelect: React.FunctionComponent<DefaultChapterSelectProps> =
     handleUpdateSublanguage(chosenSublang);
   }, [chosenSublang, setDialogState, handleUpdateSublanguage]);
 
-  const chapterRenderer: ItemRenderer<SourceLanguage> = React.useCallback(
+  const chapterRenderer: ItemRenderer<SALanguage> = React.useCallback(
     (lang, { handleClick }) => (
       <MenuItem key={lang.displayName} onClick={handleClick} text={lang.displayName} />
     ),
     []
   );
 
-  const chapterListRenderer: ItemListRenderer<SourceLanguage> = React.useCallback(
+  const chapterListRenderer: ItemListRenderer<SALanguage> = React.useCallback(
     ({ itemsParentRef, renderItem }) => {
       const defaultChoices = defaultLanguages.map(renderItem);
       const variantChoices = variantLanguages.map(renderItem);
@@ -70,7 +70,7 @@ const DefaultChapterSelect: React.FunctionComponent<DefaultChapterSelectProps> =
     []
   );
 
-  const DefaultChapterSelectComponent = Select.ofType<SourceLanguage>();
+  const DefaultChapterSelectComponent = Select.ofType<SALanguage>();
 
   const dialog = (
     <Dialog

--- a/src/pages/academy/groundControl/subcomponents/DefaultChapterSelectContainer.ts
+++ b/src/pages/academy/groundControl/subcomponents/DefaultChapterSelectContainer.ts
@@ -1,4 +1,3 @@
-import { Variant } from 'js-slang/dist/types';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import Constants from 'src/commons/utils/Constants';
@@ -10,7 +9,7 @@ import DefaultChapterSelect, { DispatchProps, StateProps } from './DefaultChapte
 const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => ({
   // Temporarily load the defaults when the course configuration fetch has yet to return
   sourceChapter: state.session.sourceChapter || Constants.defaultSourceChapter,
-  sourceVariant: state.session.sourceVariant || (Constants.defaultSourceVariant as Variant)
+  sourceVariant: state.session.sourceVariant || Constants.defaultSourceVariant
 });
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dispatch) =>

--- a/src/pages/academy/sourcereel/Sourcereel.tsx
+++ b/src/pages/academy/sourcereel/Sourcereel.tsx
@@ -1,7 +1,7 @@
 import { Classes, Pre } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 
 import { InterpreterOutput } from '../../../commons/application/ApplicationTypes';
@@ -39,7 +39,7 @@ type SourcereelProps = DispatchProps & StateProps;
 export type DispatchProps = {
   handleBrowseHistoryDown: () => void;
   handleBrowseHistoryUp: () => void;
-  handleChapterSelect: (chapter: number) => void;
+  handleChapterSelect: (chapter: Chapter) => void;
   handleDebuggerPause: () => void;
   handleDebuggerResume: () => void;
   handleDebuggerReset: () => void;
@@ -115,7 +115,7 @@ export type StateProps = {
   timeElapsedBeforePause: number;
   sideContentHeight?: number;
   sourcecastIndex: SourcecastData[] | null;
-  sourceChapter: number;
+  sourceChapter: Chapter;
   sourceVariant: Variant;
   timeResumed: number;
   courseId?: number;
@@ -188,7 +188,7 @@ class Sourcereel extends React.Component<SourcereelProps, State> {
       />
     );
 
-    const chapterSelectHandler = ({ chapter }: { chapter: number }, e: any) => {
+    const chapterSelectHandler = ({ chapter }: { chapter: Chapter }, e: any) => {
       this.props.handleChapterSelect(chapter);
       if (this.props.recordingStatus !== RecordingStatus.recording) {
         return;

--- a/src/pages/academy/sourcereel/SourcereelContainer.ts
+++ b/src/pages/academy/sourcereel/SourcereelContainer.ts
@@ -1,3 +1,4 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -97,7 +98,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
     {
       handleBrowseHistoryDown: () => browseReplHistoryDown(location),
       handleBrowseHistoryUp: () => browseReplHistoryUp(location),
-      handleChapterSelect: (chapter: number) => chapterSelect(chapter, 'default', location),
+      handleChapterSelect: (chapter: Chapter) => chapterSelect(chapter, Variant.DEFAULT, location),
       handleDeclarationNavigate: (cursorPosition: Position) =>
         navigateToDeclaration(location, cursorPosition),
       handleDeleteSourcecastEntry: (id: number) => deleteSourcecastEntry(id, 'sourcecast'),

--- a/src/pages/githubAssessments/GitHubAssessmentDefaultValues.ts
+++ b/src/pages/githubAssessments/GitHubAssessmentDefaultValues.ts
@@ -1,3 +1,5 @@
+import { Chapter } from 'js-slang/dist/types';
+
 import { IMCQQuestion } from '../../commons/assessment/AssessmentTypes';
 import { MissionMetadata, TaskData } from '../../commons/githubAssessments/GitHubMissionTypes';
 
@@ -70,7 +72,7 @@ If you need a more detailed cheatsheet, please click [here](https://www.markdown
 export const defaultStarterCode = '// Your program here!\n';
 
 export const defaultMissionMetadata = {
-  sourceVersion: 1
+  sourceVersion: Chapter.SOURCE_1
 } as MissionMetadata;
 
 export const defaultTask = {
@@ -91,7 +93,7 @@ export const defaultMCQQuestion = {
   content: '',
   grade: 0,
   id: 0,
-  library: { chapter: 4, external: { name: 'NONE', symbols: [] }, globals: [] },
+  library: { chapter: Chapter.SOURCE_4, external: { name: 'NONE', symbols: [] }, globals: [] },
   maxGrade: 0,
   xp: 0,
   maxXp: 0

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -10,7 +10,7 @@ import {
 import { IconNames } from '@blueprintjs/icons';
 import { GetResponseTypeFromEndpointMethod } from '@octokit/types';
 import classNames from 'classnames';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { isEqual } from 'lodash';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useMediaQuery } from 'react-responsive';
@@ -88,7 +88,7 @@ export type GitHubAssessmentWorkspaceProps = DispatchProps & StateProps & RouteC
 export type DispatchProps = {
   handleBrowseHistoryDown: () => void;
   handleBrowseHistoryUp: () => void;
-  handleChapterSelect: (chapter: number, variant: Variant) => void;
+  handleChapterSelect: (chapter: Chapter, variant: Variant) => void;
   handleDeclarationNavigate: (cursorPosition: Position) => void;
   handleEditorEval: () => void;
   handleEditorValueChange: (val: string) => void;
@@ -125,7 +125,7 @@ export type StateProps = {
   output: InterpreterOutput[];
   replValue: string;
   sideContentHeight?: number;
-  sourceChapter: number;
+  sourceChapter: Chapter;
 };
 
 const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = props => {
@@ -921,7 +921,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
       <ControlBarChapterSelect
         handleChapterSelect={() => {}}
         sourceChapter={missionMetadata.sourceVersion}
-        sourceVariant={Constants.defaultSourceVariant as Variant}
+        sourceVariant={Constants.defaultSourceVariant}
         disabled={true}
         key="chapter"
       />
@@ -1082,8 +1082,8 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
     handleReplValueChange: props.handleReplValueChange,
     output: props.output,
     replValue: props.replValue,
-    sourceChapter: missionMetadata.sourceVersion || 4,
-    sourceVariant: 'default' as Variant,
+    sourceChapter: missionMetadata.sourceVersion || Chapter.SOURCE_4,
+    sourceVariant: Variant.DEFAULT,
     externalLibrary: ExternalLibraryName.NONE,
     replButtons: replButtons()
   };

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspaceContainer.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspaceContainer.tsx
@@ -1,3 +1,4 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { withRouter } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -57,8 +58,8 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
     {
       handleBrowseHistoryDown: () => browseReplHistoryDown(workspaceLocation),
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
-      handleChapterSelect: (chapter: number) =>
-        chapterSelect(chapter, 'default', workspaceLocation),
+      handleChapterSelect: (chapter: Chapter) =>
+        chapterSelect(chapter, Variant.DEFAULT, workspaceLocation),
       handleDeclarationNavigate: (cursorPosition: Position) =>
         navigateToDeclaration(workspaceLocation, cursorPosition),
       handleEditorEval: () => evalEditor(workspaceLocation),

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -4,7 +4,7 @@ import { Octokit } from '@octokit/rest';
 import { Ace, Range } from 'ace-builds';
 import classNames from 'classnames';
 import { isStepperOutput } from 'js-slang/dist/stepper/stepper';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { isEqual } from 'lodash';
 import { decompressFromEncodedURIComponent } from 'lz-string';
 import * as React from 'react';
@@ -16,7 +16,6 @@ import { showFullJSWarningOnUrlLoad } from 'src/commons/fullJS/FullJSUtils';
 
 import {
   InterpreterOutput,
-  isFullJSChapter,
   OverallState,
   sourceLanguages
 } from '../../commons/application/ApplicationTypes';
@@ -69,7 +68,7 @@ export type DispatchProps = {
   handleBrowseHistoryUp: () => void;
   handleChangeExecTime: (execTime: number) => void;
   handleChangeStepLimit: (stepLimit: number) => void;
-  handleChapterSelect: (chapter: number, variant: Variant) => void;
+  handleChapterSelect: (chapter: Chapter, variant: Variant) => void;
   handleDeclarationNavigate: (cursorPosition: Position) => void;
   handleEditorEval: () => void;
   handleEditorHeightChange: (height: number) => void;
@@ -143,7 +142,7 @@ export function handleHash(hash: string, props: PlaygroundProps) {
   const qs = parseQuery(hash);
 
   const chapter = stringParamToInt(qs.chap) || undefined;
-  if (chapter && isFullJSChapter(chapter)) {
+  if (chapter === Chapter.FULL_JS) {
     showFullJSWarningOnUrlLoad();
   } else {
     const programLz = qs.lz ?? qs.prgrm;
@@ -154,7 +153,7 @@ export function handleHash(hash: string, props: PlaygroundProps) {
     const variant: Variant =
       sourceLanguages.find(
         language => language.chapter === chapter && language.variant === qs.variant
-      )?.variant ?? 'default';
+      )?.variant ?? Variant.DEFAULT;
     if (chapter) {
       props.handleChapterSelect(chapter, variant);
     }
@@ -318,11 +317,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         key="autorun"
         autorunDisabled={usingRemoteExecution}
         // Disable pause for FullJS, because: one cannot stop `eval()`
-        pauseDisabled={
-          usingRemoteExecution ||
-          (!(props.playgroundSourceChapter === undefined) &&
-            isFullJSChapter(props.playgroundSourceChapter))
-        }
+        pauseDisabled={usingRemoteExecution || props.playgroundSourceChapter === Chapter.FULL_JS}
       />
     ),
     [
@@ -341,7 +336,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
   );
 
   const chapterSelectHandler = React.useCallback(
-    ({ chapter, variant }: { chapter: number; variant: Variant }, e: any) => {
+    ({ chapter, variant }: { chapter: Chapter; variant: Variant }, e: any) => {
       const { handleUsingSubst, handleReplOutputClear, handleChapterSelect } = propsRef.current;
       if ((chapter <= 2 && hasBreakpoints) || selectedTab === SideContentType.substVisualizer) {
         handleUsingSubst(true);
@@ -549,7 +544,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     const tabs: SideContentTab[] = [playgroundIntroductionTab];
 
     // (TEMP) Remove tabs for fullJS until support is integrated
-    if (isFullJSChapter(props.playgroundSourceChapter)) {
+    if (props.playgroundSourceChapter === Chapter.FULL_JS) {
       return [...tabs, dataVisualizerTab];
     }
 
@@ -559,8 +554,8 @@ const Playground: React.FC<PlaygroundProps> = props => {
     }
     if (
       props.playgroundSourceChapter >= 3 &&
-      props.playgroundSourceVariant !== 'concurrent' &&
-      props.playgroundSourceVariant !== 'non-det' &&
+      props.playgroundSourceVariant !== Variant.CONCURRENT &&
+      props.playgroundSourceVariant !== Variant.NON_DET &&
       !usingRemoteExecution
     ) {
       // Enable Env Visualizer for Source Chapter 3 and above
@@ -569,7 +564,8 @@ const Playground: React.FC<PlaygroundProps> = props => {
 
     if (
       props.playgroundSourceChapter <= 2 &&
-      (props.playgroundSourceVariant === 'default' || props.playgroundSourceVariant === 'native')
+      (props.playgroundSourceVariant === Variant.DEFAULT ||
+        props.playgroundSourceVariant === Variant.NATIVE)
     ) {
       // Enable Subst Visualizer only for default Source 1 & 2
       tabs.push({
@@ -685,7 +681,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     [selectedTab]
   );
 
-  const replDisabled = props.playgroundSourceVariant === 'concurrent' || usingRemoteExecution;
+  const replDisabled = props.playgroundSourceVariant === Variant.CONCURRENT || usingRemoteExecution;
 
   const editorProps = {
     onChange: onChangeMethod,
@@ -731,12 +727,12 @@ const Playground: React.FC<PlaygroundProps> = props => {
     controlBarProps: {
       editorButtons: [
         autorunButtons,
-        isFullJSChapter(props.playgroundSourceChapter) ? null : shareButton,
+        props.playgroundSourceChapter === Chapter.FULL_JS ? null : shareButton,
         chapterSelect,
         isSicpEditor ? null : sessionButtons,
         persistenceButtons,
         githubButtons,
-        usingRemoteExecution || isFullJSChapter(props.playgroundSourceChapter)
+        usingRemoteExecution || props.playgroundSourceChapter === Chapter.FULL_JS
           ? null
           : props.usingSubst
           ? stepperStepLimit
@@ -770,7 +766,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         editorButtons: [
           autorunButtons,
           chapterSelect,
-          isFullJSChapter(props.playgroundSourceChapter) ? null : shareButton,
+          props.playgroundSourceChapter === Chapter.FULL_JS ? null : shareButton,
           isSicpEditor ? null : sessionButtons,
           persistenceButtons,
           githubButtons

--- a/src/pages/playground/PlaygroundContainer.ts
+++ b/src/pages/playground/PlaygroundContainer.ts
@@ -1,4 +1,4 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { withRouter } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -99,7 +99,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
       handleChangeExecTime: (execTime: number) => changeExecTime(execTime, workspaceLocation),
       handleChangeStepLimit: (stepLimit: number) => changeStepLimit(stepLimit, workspaceLocation),
-      handleChapterSelect: (chapter: number, variant: Variant) =>
+      handleChapterSelect: (chapter: Chapter, variant: Variant) =>
         chapterSelect(chapter, variant, workspaceLocation),
       handleDeclarationNavigate: (cursorPosition: Position) =>
         navigateToDeclaration(workspaceLocation, cursorPosition),

--- a/src/pages/playground/__tests__/Playground.tsx
+++ b/src/pages/playground/__tests__/Playground.tsx
@@ -1,5 +1,5 @@
 import { shallow } from 'enzyme';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { Provider } from 'react-redux';
 import { mockInitialStore } from 'src/commons/mocks/StoreMocks';
 
@@ -20,8 +20,8 @@ const baseProps = {
   editorWidth: '50%',
   isEditorAutorun: false,
   sideContentHeight: 40,
-  playgroundSourceChapter: 2,
-  playgroundSourceVariant: 'default' as Variant,
+  playgroundSourceChapter: Chapter.SOURCE_2,
+  playgroundSourceVariant: Variant.DEFAULT,
   output: [],
   replValue: '',
   sharedbConnected: false,
@@ -34,7 +34,7 @@ const baseProps = {
   handleBrowseHistoryUp: () => {},
   handleChangeExecTime: (execTime: number) => {},
   handleChangeStepLimit: (stepLimit: number) => {},
-  handleChapterSelect: (chapter: number) => {},
+  handleChapterSelect: (chapter: Chapter) => {},
   handleDeclarationNavigate: (cursorPosition: Position) => {},
   handleEditorEval: () => {},
   handleEditorHeightChange: (height: number) => {},

--- a/src/pages/sicp/subcomponents/SicpWorkspaceContainer.tsx
+++ b/src/pages/sicp/subcomponents/SicpWorkspaceContainer.tsx
@@ -1,4 +1,4 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { withRouter } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -100,7 +100,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
       handleBrowseHistoryUp: () => browseReplHistoryUp(workspaceLocation),
       handleChangeExecTime: (execTime: number) => changeExecTime(execTime, workspaceLocation),
       handleChangeStepLimit: (stepLimit: number) => changeStepLimit(stepLimit, workspaceLocation),
-      handleChapterSelect: (chapter: number, variant: Variant) =>
+      handleChapterSelect: (chapter: Chapter, variant: Variant) =>
         chapterSelect(chapter, variant, workspaceLocation),
       handleDeclarationNavigate: (cursorPosition: Position) =>
         navigateToDeclaration(workspaceLocation, cursorPosition),

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -1,7 +1,7 @@
 import { Classes, Pre } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import * as React from 'react';
 import ReactAce from 'react-ace/lib/ace';
 import { useMediaQuery } from 'react-responsive';
@@ -45,7 +45,7 @@ export type SourcecastProps = DispatchProps &
 export type DispatchProps = {
   handleBrowseHistoryDown: () => void;
   handleBrowseHistoryUp: () => void;
-  handleChapterSelect: (chapter: number) => void;
+  handleChapterSelect: (chapter: Chapter) => void;
   handleDebuggerPause: () => void;
   handleDebuggerResume: () => void;
   handleDebuggerReset: () => void;
@@ -105,7 +105,7 @@ export type StateProps = {
   replValue: string;
   sideContentHeight?: number;
   sourcecastIndex: SourcecastData[] | null;
-  sourceChapter: number;
+  sourceChapter: Chapter;
   sourceVariant: Variant;
   uid: string | null;
   courseId?: number;
@@ -198,7 +198,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
     />
   );
 
-  const chapterSelectHandler = ({ chapter }: { chapter: number }, e: any) =>
+  const chapterSelectHandler = ({ chapter }: { chapter: Chapter }, e: any) =>
     props.handleChapterSelect(chapter);
 
   const chapterSelect = (

--- a/src/pages/sourcecast/SourcecastContainer.ts
+++ b/src/pages/sourcecast/SourcecastContainer.ts
@@ -1,3 +1,4 @@
+import { Chapter, Variant } from 'js-slang/dist/types';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { withRouter } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -86,7 +87,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch: Dis
     {
       handleBrowseHistoryDown: () => browseReplHistoryDown(location),
       handleBrowseHistoryUp: () => browseReplHistoryUp(location),
-      handleChapterSelect: (chapter: number) => chapterSelect(chapter, 'default', location),
+      handleChapterSelect: (chapter: Chapter) => chapterSelect(chapter, Variant.DEFAULT, location),
       handleDeclarationNavigate: (cursorPosition: Position) =>
         navigateToDeclaration(location, cursorPosition),
       handleEditorEval: () => evalEditor(location),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,7 +2083,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@0.0.51":
+"@types/estree@*":
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
@@ -2092,6 +2092,11 @@
   version "0.0.39"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@0.0.52":
+  version "0.0.52"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.52.tgz#7f1f57ad5b741f3d5b210d3b1f145640d89bf8fe"
+  integrity sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==
 
 "@types/estree@1.0.0":
   version "1.0.0"
@@ -8262,13 +8267,13 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
-js-slang@^0.5.33:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.33.tgz#62bb1be0ac0a6463b36d24a3209cb1f9d03c5c9c"
-  integrity sha512-BxZXR8ewvckTcPNBC7ICfjHa1kJBCrYaMqmxtAYmnLiznWkOi/4YB96S0aKXh8PZlsv0Zg10B5VJrlVZtIKmCw==
+js-slang@^0.5.34:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.34.tgz#c4305582cc5420781e54befb08c38d119733c026"
+  integrity sha512-aSUyN3VzTgXolbhiVxWjooszaAL5wrMBL9VAceYzVP9/OvgsUnICNeCIn1cKGbegakxqywHE/O/E86uft1VRaQ==
   dependencies:
     "@joeychenofficial/alt-ergo-modified" "^2.4.0"
-    "@types/estree" "0.0.51"
+    "@types/estree" "0.0.52"
     acorn "^8.0.3"
     acorn-loose "^8.0.0"
     acorn-walk "^8.0.0"
@@ -8277,7 +8282,7 @@ js-slang@^0.5.33:
     gpu.js "^2.10.4"
     lodash "^4.17.20"
     node-getopt "^0.3.2"
-    source-map "^0.7.3"
+    source-map "0.7.3"
     xmlhttprequest-ts "^1.0.1"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
@@ -12513,15 +12518,15 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@0.7.3, source-map@^0.7.3, source-map@~0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.7.3, source-map@~0.7.2:
-  version "0.7.3"
-  resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 sourcemap-codec@^1.4.4:
   version "1.4.8"


### PR DESCRIPTION
### Description

Frontend counterpart to [js-slang#1286](https://github.com/source-academy/js-slang/pull/1286).

- Bumped js-slang to 0.5.34.
- Refactored code to use the new `Chapter` and `Variant` enums defined in js-slang.
- Renamed `SourceLanguage` to `SALanguage` since languages supported on Source Academy is expanding beyond Source to include support for full JS, HTML, etc. Also changed it from a type to interface that extends the js-slang `Language` interface (difference being the addition of the `displayName` attribute).

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

As this PR is purely refactoring, there should be no changes in app behaviour.
