### PR TITLE
Bump js-slang to 0.5.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "classnames": "^2.3.1",
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
-    "js-slang": "^0.5.34",
+    "js-slang": "^0.5.35",
     "konva": "^8.3.2",
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8267,10 +8267,10 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
-js-slang@^0.5.34:
-  version "0.5.34"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.34.tgz#c4305582cc5420781e54befb08c38d119733c026"
-  integrity sha512-aSUyN3VzTgXolbhiVxWjooszaAL5wrMBL9VAceYzVP9/OvgsUnICNeCIn1cKGbegakxqywHE/O/E86uft1VRaQ==
+js-slang@^0.5.35:
+  version "0.5.35"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.5.35.tgz#4d608c5f5dd172716bb43bbbb3ed1ed2f2321c6b"
+  integrity sha512-ly5tdF2wN95kHHL6NY0ifXpMYF4qJSIeDrf4Llxi1ImvD+jYQfWi8jBc15ktThL6az2GqzeLrLW8C5dKJwf/Cg==
   dependencies:
     "@joeychenofficial/alt-ergo-modified" "^2.4.0"
     "@types/estree" "0.0.52"


### PR DESCRIPTION
### Description

Bumping js-slang, which includes a hotfix for module param passing.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
- [ ] I have updated the documentation
