### PR TITLE
Remove blueprintjs padding in mobile editor

### DIFF
--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -103,6 +103,7 @@ $code-color-error: #ff4444;
     flex-direction: column;
     height: 100%;
     width: 100%;
+    padding: 0;
     background-color: $cadet-color-2;
 
     .editor-react-ace {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Type of change
UI fix for mobile editor tab.

New:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/53928333/187607903-c85b21e1-ec8e-4a6c-851a-8c14c6c1c591.png">

Old:
<img width="478" alt="image" src="https://user-images.githubusercontent.com/53928333/187608120-7d1daff6-8fcb-4fc0-982f-d87f1b11d796.png">


### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
