### PR TITLE
Move draggable REPL logic out of MobileSideContent into MobileWorkspace

### DIFF
--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -160,10 +160,32 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
     document.documentElement.style.setProperty('--mobile-repl-height', '0px');
   };
 
-  const draggableReplProps = {
-    handleShowRepl: handleShowRepl(-300),
-    handleHideRepl: handleHideRepl,
-    disableRepl: setIsDraggableReplDisabled
+  const handleTabChangeForRepl = (newTabId: SideContentType, prevTabId: SideContentType) => {
+    // Evaluate program upon pressing the 'Run' tab on mobile
+    if (
+      (prevTabId === SideContentType.substVisualizer ||
+        prevTabId === SideContentType.autograder ||
+        prevTabId === SideContentType.testcases) &&
+      newTabId === SideContentType.mobileEditorRun
+    ) {
+      props.editorProps?.handleEditorEval();
+    } else if (newTabId === SideContentType.mobileEditorRun) {
+      props.editorProps?.handleEditorEval();
+      handleShowRepl(-300)();
+    } else {
+      handleHideRepl();
+    }
+
+    // Disable draggable Repl when on stepper tab
+    if (
+      newTabId === SideContentType.substVisualizer ||
+      (prevTabId === SideContentType.substVisualizer &&
+        newTabId === SideContentType.mobileEditorRun)
+    ) {
+      setIsDraggableReplDisabled(true);
+    } else {
+      setIsDraggableReplDisabled(false);
+    }
   };
 
   const mobileEditorTab: SideContentTab = React.useMemo(
@@ -191,6 +213,14 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
   const updatedMobileSideContentProps = () => {
     return {
       ...props.mobileSideContentProps,
+      onChange: (
+        newTabId: SideContentType,
+        prevTabId: SideContentType,
+        event: React.MouseEvent<HTMLElement>
+      ) => {
+        props.mobileSideContentProps.onChange(newTabId, prevTabId, event);
+        handleTabChangeForRepl(newTabId, prevTabId);
+      },
       tabs: [mobileEditorTab, ...props.mobileSideContentProps.tabs, mobileRunTab]
     };
   };
@@ -214,7 +244,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
 
       <div>
         <div className="mobile-editor-panel">{createWorkspaceInput()}</div>
-        <MobileSideContent {...updatedMobileSideContentProps()} {...draggableReplProps} />
+        <MobileSideContent {...updatedMobileSideContentProps()} />
       </div>
 
       <DraggableRepl

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -113,7 +113,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
 
   const createWorkspaceInput = () => {
     if (props.customEditor) {
-      return props.customEditor(editorRef, handleShowRepl(-100));
+      return props.customEditor(editorRef, () => handleShowRepl(-100));
     } else if (props.editorProps) {
       return <Editor {...props.editorProps} ref={editorRef} />;
     } else {
@@ -150,7 +150,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
     setDraggableReplPosition(position);
   };
 
-  const handleShowRepl = (offset: number) => () => {
+  const handleShowRepl = (offset: number) => {
     document.documentElement.style.setProperty('--mobile-repl-height', Math.max(-offset, 0) + 'px');
     setDraggableReplPosition({ x: 0, y: offset });
   };
@@ -171,7 +171,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
       props.editorProps?.handleEditorEval();
     } else if (newTabId === SideContentType.mobileEditorRun) {
       props.editorProps?.handleEditorEval();
-      handleShowRepl(-300)();
+      handleShowRepl(-300);
     } else {
       handleHideRepl();
     }

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -180,7 +180,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
       handleHideRepl();
     }
 
-    // Disable draggable REPL when on the stepper tab,
+    // Disable draggable REPL when on the stepper tab.
     if (
       newTabId === SideContentType.substVisualizer ||
       (prevTabId === SideContentType.substVisualizer &&

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -161,22 +161,26 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
   };
 
   const handleTabChangeForRepl = (newTabId: SideContentType, prevTabId: SideContentType) => {
-    // Evaluate program upon pressing the 'Run' tab on mobile
+    // Evaluate program upon pressing the run tab.
+    if (newTabId === SideContentType.mobileEditorRun) {
+      props.editorProps?.handleEditorEval();
+    }
+
+    // Show the REPL upon pressing the run tab if the previous tab is not listed below.
     if (
-      (prevTabId === SideContentType.substVisualizer ||
+      newTabId === SideContentType.mobileEditorRun &&
+      !(
+        prevTabId === SideContentType.substVisualizer ||
         prevTabId === SideContentType.autograder ||
-        prevTabId === SideContentType.testcases) &&
-      newTabId === SideContentType.mobileEditorRun
+        prevTabId === SideContentType.testcases
+      )
     ) {
-      props.editorProps?.handleEditorEval();
-    } else if (newTabId === SideContentType.mobileEditorRun) {
-      props.editorProps?.handleEditorEval();
       handleShowRepl(-300);
     } else {
       handleHideRepl();
     }
 
-    // Disable draggable Repl when on stepper tab
+    // Disable draggable REPL when on the stepper tab,
     if (
       newTabId === SideContentType.substVisualizer ||
       (prevTabId === SideContentType.substVisualizer &&

--- a/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
+++ b/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
@@ -19,8 +19,6 @@ type DispatchProps = {
     prevTabId: SideContentType,
     event: React.MouseEvent<HTMLElement>
   ) => void;
-
-  handleEditorEval: () => void;
 };
 
 type StateProps = {
@@ -37,13 +35,7 @@ type MobileControlBarProps = {
   mobileControlBarProps: ControlBarProps;
 };
 
-type OwnProps = {
-  handleShowRepl: () => void;
-  handleHideRepl: () => void;
-  disableRepl: (newState: boolean) => void;
-};
-
-const MobileSideContent: React.FC<MobileSideContentProps & OwnProps> = props => {
+const MobileSideContent: React.FC<MobileSideContentProps> = props => {
   const { tabs, selectedTabId, onChange } = props;
   const [dynamicTabs, setDynamicTabs] = React.useState(tabs);
   const isIOS = /iPhone|iPod/.test(navigator.platform);
@@ -167,34 +159,8 @@ const MobileSideContent: React.FC<MobileSideContentProps & OwnProps> = props => 
         onChange(newTabId, prevTabId, event);
         resetAlert(prevTabId);
       }
-
-      // Evaluate program upon pressing the 'Run' tab on mobile
-      if (
-        (prevTabId === SideContentType.substVisualizer ||
-          prevTabId === SideContentType.autograder ||
-          prevTabId === SideContentType.testcases) &&
-        newTabId === SideContentType.mobileEditorRun
-      ) {
-        props.handleEditorEval();
-      } else if (newTabId === SideContentType.mobileEditorRun) {
-        props.handleEditorEval();
-        props.handleShowRepl();
-      } else {
-        props.handleHideRepl();
-      }
-
-      // Disable draggable Repl when on stepper tab
-      if (
-        newTabId === SideContentType.substVisualizer ||
-        (prevTabId === SideContentType.substVisualizer &&
-          newTabId === SideContentType.mobileEditorRun)
-      ) {
-        props.disableRepl(true);
-      } else {
-        props.disableRepl(false);
-      }
     },
-    [onChange, props]
+    [onChange]
   );
 
   return (

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -779,8 +779,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
       selectedTabId: selectedTab,
       onChange: onChangeTabs,
       tabs: mobileTabs,
-      workspaceLocation: isSicpEditor ? 'sicp' : 'playground',
-      handleEditorEval: props.handleEditorEval
+      workspaceLocation: isSicpEditor ? 'sicp' : 'playground'
     }
   };
 

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -338,8 +338,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
       selectedTabId: selectedTab,
       onChange: onChangeTabs,
       tabs: tabs,
-      workspaceLocation: 'sourcecast',
-      handleEditorEval: props.handleEditorEval
+      workspaceLocation: 'sourcecast'
     }
   };
 


### PR DESCRIPTION
### Description

The `MobileSideContent` component already takes in an `onChange` function that is called within the `changeTabsCallback`. Rather than handling the logic for displaying & disabling the draggable REPL inside `MobileSideContent`, we can wrap `props.mobileSideContentProps.onChange` in a new function in `MobileWorkspace` that also handles the draggable REPL logic. This new function is then passed into `MobileSideContent` as `onChange`. This helps to decouple `MobileSideContent` from `MobileWorkspace`, making it more extensible for future additions.

Part of the refactoring for https://github.com/source-academy/frontend/issues/2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

Use developer tools to set the screen resolution to one that triggers the mobile view and check that the behaviour is unchanged when switching between tabs.