### PR TITLE
Specify non-dynamic tab positions relative to dynamic tabs

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -683,13 +683,20 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
         setSelectedTab(newTabId);
       }
     };
+
+    const sideContent = sideContentProps(props, questionId);
+
     return {
       mobileControlBarProps: {
         ...controlBarProps(questionId)
       },
-      ...sideContentProps(props, questionId),
+      ...sideContent,
       onChange: onChangeTabs,
       selectedTabId: selectedTab,
+      tabs: {
+        beforeDynamicTabs: sideContent.tabs,
+        afterDynamicTabs: []
+      },
       handleEditorEval: handleEval
     };
   };

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -522,7 +522,10 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
 
     return {
       selectedTabId: selectedTab,
-      tabs,
+      tabs: {
+        beforeDynamicTabs: tabs,
+        afterDynamicTabs: []
+      },
       onChange: onChangeTabs,
       workspaceLocation: 'assessment'
     };
@@ -684,19 +687,13 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
       }
     };
 
-    const sideContent = sideContentProps(props, questionId);
-
     return {
       mobileControlBarProps: {
         ...controlBarProps(questionId)
       },
-      ...sideContent,
+      ...sideContentProps(props, questionId),
       onChange: onChangeTabs,
       selectedTabId: selectedTab,
-      tabs: {
-        beforeDynamicTabs: sideContent.tabs,
-        afterDynamicTabs: []
-      },
       handleEditorEval: handleEval
     };
   };

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -608,7 +608,10 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
       ];
     }
 
-    return { handleActiveTabChange: this.handleActiveTabChange, tabs };
+    return {
+      handleActiveTabChange: this.handleActiveTabChange,
+      tabs: { beforeDynamicTabs: tabs, afterDynamicTabs: [] }
+    };
   };
 
   /** Pre-condition: IAssessment has been loaded */

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -225,7 +225,13 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
         props.mobileSideContentProps.onChange(newTabId, prevTabId, event);
         handleTabChangeForRepl(newTabId, prevTabId);
       },
-      tabs: [mobileEditorTab, ...props.mobileSideContentProps.tabs, mobileRunTab]
+      tabs: {
+        beforeDynamicTabs: [
+          mobileEditorTab,
+          ...props.mobileSideContentProps.tabs.beforeDynamicTabs
+        ],
+        afterDynamicTabs: [...props.mobileSideContentProps.tabs.afterDynamicTabs, mobileRunTab]
+      }
     };
   };
 

--- a/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
+++ b/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx
@@ -25,7 +25,10 @@ type StateProps = {
   animate?: boolean;
   selectedTabId: SideContentType;
   renderActiveTabPanelOnly?: boolean;
-  tabs: SideContentTab[];
+  tabs: {
+    beforeDynamicTabs: SideContentTab[];
+    afterDynamicTabs: SideContentTab[];
+  };
   workspaceLocation?: WorkspaceLocation;
   width?: number;
   height?: number;
@@ -37,7 +40,9 @@ type MobileControlBarProps = {
 
 const MobileSideContent: React.FC<MobileSideContentProps> = props => {
   const { tabs, selectedTabId, onChange } = props;
-  const [dynamicTabs, setDynamicTabs] = React.useState(tabs);
+  const [dynamicTabs, setDynamicTabs] = React.useState(
+    tabs.beforeDynamicTabs.concat(tabs.afterDynamicTabs)
+  );
   const isIOS = /iPhone|iPod/.test(navigator.platform);
 
   // Fetch debuggerContext from store
@@ -47,12 +52,9 @@ const MobileSideContent: React.FC<MobileSideContentProps> = props => {
   );
 
   React.useEffect(() => {
-    // Ensures that the 'Run' tab is at the end of the resulting array
-    const copy = [...tabs];
-    const runTab = copy.pop();
-
-    const allActiveTabs = copy.concat(getDynamicTabs(debuggerContext || ({} as DebuggerContext)));
-    allActiveTabs.push(runTab!);
+    const allActiveTabs = tabs.beforeDynamicTabs
+      .concat(getDynamicTabs(debuggerContext || ({} as DebuggerContext)))
+      .concat(tabs.afterDynamicTabs);
     setDynamicTabs(allActiveTabs);
   }, [tabs, debuggerContext]);
 

--- a/src/commons/sideContent/SideContent.tsx
+++ b/src/commons/sideContent/SideContent.tsx
@@ -41,7 +41,10 @@ type StateProps = {
   animate?: boolean;
   selectedTabId?: SideContentType; // Optional due to uncontrolled tab component in EditingWorkspace
   renderActiveTabPanelOnly?: boolean;
-  tabs: SideContentTab[];
+  tabs: {
+    beforeDynamicTabs: SideContentTab[];
+    afterDynamicTabs: SideContentTab[];
+  };
   workspaceLocation?: WorkspaceLocation;
   editorWidth?: string;
   sideContentHeight?: number;
@@ -49,7 +52,9 @@ type StateProps = {
 
 const SideContent = (props: SideContentProps) => {
   const { tabs, onChange } = props;
-  const [dynamicTabs, setDynamicTabs] = React.useState(tabs);
+  const [dynamicTabs, setDynamicTabs] = React.useState(
+    tabs.beforeDynamicTabs.concat(tabs.afterDynamicTabs)
+  );
 
   // Fetch debuggerContext from store
   const debuggerContext = useSelector(
@@ -57,7 +62,9 @@ const SideContent = (props: SideContentProps) => {
       props.workspaceLocation && state.workspaces[props.workspaceLocation].debuggerContext
   );
   React.useEffect(() => {
-    const allActiveTabs = tabs.concat(getDynamicTabs(debuggerContext || ({} as DebuggerContext)));
+    const allActiveTabs = tabs.beforeDynamicTabs
+      .concat(getDynamicTabs(debuggerContext || ({} as DebuggerContext)))
+      .concat(tabs.afterDynamicTabs);
     setDynamicTabs(allActiveTabs);
   }, [tabs, debuggerContext]);
 

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -385,7 +385,10 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
         }
         this.setState({ selectedTab: newTabId });
       },
-      tabs,
+      tabs: {
+        beforeDynamicTabs: tabs,
+        afterDynamicTabs: []
+      },
       workspaceLocation: 'grading'
     };
 

--- a/src/pages/academy/sourcereel/Sourcereel.tsx
+++ b/src/pages/academy/sourcereel/Sourcereel.tsx
@@ -308,56 +308,59 @@ class Sourcereel extends React.Component<SourcereelProps, State> {
          * This is a known issue with ag-grid, and is okay since only staff and admins have
          * access to Sourcereel. For more info, see issue #1152 in frontend.
          */
-        tabs: [
-          {
-            label: 'Recording Panel',
-            iconName: IconNames.COMPASS,
-            body: (
-              <div>
-                <span className="Multi-line">
-                  <Pre> {INTRODUCTION} </Pre>
-                </span>
-                <SourcereelControlbar
-                  currentPlayerTime={this.props.currentPlayerTime}
-                  editorValue={this.props.editorValue}
-                  getTimerDuration={this.getTimerDuration}
-                  playbackData={this.props.playbackData}
-                  handleRecordInit={this.handleRecordInit}
-                  handleRecordPause={this.handleRecordPause}
-                  handleResetInputs={this.props.handleResetInputs}
-                  handleSaveSourcecastData={this.props.handleSaveSourcecastData}
-                  handleSetSourcecastData={this.props.handleSetSourcecastData}
-                  handleSetEditorReadonly={this.props.handleSetEditorReadonly}
-                  handleTimerPause={this.props.handleTimerPause}
-                  handleTimerReset={this.props.handleTimerReset}
-                  handleTimerResume={this.props.handleTimerResume}
-                  handleTimerStart={this.props.handleTimerStart}
-                  handleTimerStop={this.props.handleTimerStop}
-                  recordingStatus={this.props.recordingStatus}
-                />
-              </div>
-            ),
-            id: SideContentType.sourcereel,
-            toSpawn: () => true
-          },
-          {
-            label: 'Sourcecast Table',
-            iconName: IconNames.EDIT,
-            body: (
-              <div>
-                <SourcecastTable
-                  handleDeleteSourcecastEntry={this.props.handleDeleteSourcecastEntry}
-                  sourcecastIndex={this.props.sourcecastIndex}
-                  courseId={this.props.courseId}
-                />
-              </div>
-            ),
-            id: SideContentType.introduction,
-            toSpawn: () => true
-          },
-          dataVisualizerTab,
-          envVisualizerTab
-        ],
+        tabs: {
+          beforeDynamicTabs: [
+            {
+              label: 'Recording Panel',
+              iconName: IconNames.COMPASS,
+              body: (
+                <div>
+                  <span className="Multi-line">
+                    <Pre> {INTRODUCTION} </Pre>
+                  </span>
+                  <SourcereelControlbar
+                    currentPlayerTime={this.props.currentPlayerTime}
+                    editorValue={this.props.editorValue}
+                    getTimerDuration={this.getTimerDuration}
+                    playbackData={this.props.playbackData}
+                    handleRecordInit={this.handleRecordInit}
+                    handleRecordPause={this.handleRecordPause}
+                    handleResetInputs={this.props.handleResetInputs}
+                    handleSaveSourcecastData={this.props.handleSaveSourcecastData}
+                    handleSetSourcecastData={this.props.handleSetSourcecastData}
+                    handleSetEditorReadonly={this.props.handleSetEditorReadonly}
+                    handleTimerPause={this.props.handleTimerPause}
+                    handleTimerReset={this.props.handleTimerReset}
+                    handleTimerResume={this.props.handleTimerResume}
+                    handleTimerStart={this.props.handleTimerStart}
+                    handleTimerStop={this.props.handleTimerStop}
+                    recordingStatus={this.props.recordingStatus}
+                  />
+                </div>
+              ),
+              id: SideContentType.sourcereel,
+              toSpawn: () => true
+            },
+            {
+              label: 'Sourcecast Table',
+              iconName: IconNames.EDIT,
+              body: (
+                <div>
+                  <SourcecastTable
+                    handleDeleteSourcecastEntry={this.props.handleDeleteSourcecastEntry}
+                    sourcecastIndex={this.props.sourcecastIndex}
+                    courseId={this.props.courseId}
+                  />
+                </div>
+              ),
+              id: SideContentType.introduction,
+              toSpawn: () => true
+            },
+            dataVisualizerTab,
+            envVisualizerTab
+          ],
+          afterDynamicTabs: []
+        },
         workspaceLocation: 'sourcereel'
       }
     };

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -1010,13 +1010,19 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
       }
     };
 
+    const sideContent = sideContentProps(props);
+
     return {
       mobileControlBarProps: {
         ...controlBarProps()
       },
-      ...sideContentProps(props),
+      ...sideContent,
       onChange: onChangeTabs,
       selectedTabId: selectedTab,
+      tabs: {
+        beforeDynamicTabs: sideContent.tabs,
+        afterDynamicTabs: []
+      },
       handleEditorEval: handleEval
     };
   };

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -875,7 +875,10 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
 
     return {
       selectedTabId: selectedTab,
-      tabs,
+      tabs: {
+        beforeDynamicTabs: tabs,
+        afterDynamicTabs: []
+      },
       onChange: onChangeTabs,
       workspaceLocation: 'githubAssessment'
     };
@@ -1019,10 +1022,6 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
       ...sideContent,
       onChange: onChangeTabs,
       selectedTabId: selectedTab,
-      tabs: {
-        beforeDynamicTabs: sideContent.tabs,
-        afterDynamicTabs: []
-      },
       handleEditorEval: handleEval
     };
   };

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -778,7 +778,10 @@ const Playground: React.FC<PlaygroundProps> = props => {
       },
       selectedTabId: selectedTab,
       onChange: onChangeTabs,
-      tabs: mobileTabs,
+      tabs: {
+        beforeDynamicTabs: mobileTabs,
+        afterDynamicTabs: []
+      },
       workspaceLocation: isSicpEditor ? 'sicp' : 'playground'
     }
   };

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -754,7 +754,10 @@ const Playground: React.FC<PlaygroundProps> = props => {
     sideContentProps: {
       selectedTabId: selectedTab,
       onChange: onChangeTabs,
-      tabs,
+      tabs: {
+        beforeDynamicTabs: tabs,
+        afterDynamicTabs: []
+      },
       workspaceLocation: isSicpEditor ? 'sicp' : 'playground',
       sideContentHeight: props.sideContentHeight,
       editorWidth: props.editorWidth

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -316,7 +316,10 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
     sideContentProps: {
       selectedTabId: selectedTab,
       onChange: onChangeTabs,
-      tabs: tabs,
+      tabs: {
+        beforeDynamicTabs: tabs,
+        afterDynamicTabs: []
+      },
       workspaceLocation: 'sourcecast',
       sideContentHeight: props.sideContentHeight,
       editorWidth: props.editorWidth

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -337,7 +337,10 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
       },
       selectedTabId: selectedTab,
       onChange: onChangeTabs,
-      tabs: tabs,
+      tabs: {
+        beforeDynamicTabs: tabs,
+        afterDynamicTabs: []
+      },
       workspaceLocation: 'sourcecast'
     }
   };


### PR DESCRIPTION
### Context

The side content tabs can be categorised into 2 kinds:
* Non-dynamic tabs
  * These tabs are always spawned for a particular language.
* Dynamic tabs
  * These tabs are conditionally spawned based on the contents of the program. Examples of these include the runes tab and the curves tab.

### Description

Previously in the `MobileSideContent` component, there was an implicit precondition that the last tab in the `tabs` array is the mobile run tab:
https://github.com/source-academy/frontend/blob/505c1a5ac5573a5fcbc9693ea22e4c1f124f0c9a/src/commons/mobileWorkspace/mobileSideContent/MobileSideContent.tsx#L59-L67
Specifically, `copy.pop()` returns the last tab in the array which might not necessarily be the mobile run tab.

Instead of taking in an array of tabs, we now take in two different arrays corresponding to the tabs that should come before any dynamic tabs, and those that should come after:
```typescript
tabs: {
  beforeDynamicTabs: SideContentTab[];
  afterDynamicTabs: SideContentTab[];
}
```
Fundamentally, all we need to do is to specify where amongst the non-dynamic tabs we want the dynamic tabs to be inserted. By using the representation above, we can achieve this as well as make it clear to the users of the interface to the `MobileSideContent` component as to what this distinction is about.

For consistency, this change was also ported over to the `SideContent` component, which does not require the functionality of having non-dynamic tabs that spawn after the dynamic tabs at this point in time.

This PR is a continuation of the refactoring done in #2197 and #2206. With this, the `MobileSideContent` component no longer has any implicit dependencies on its parent components which should make the addition of future side content tabs much easier.

Part of the refactoring for https://github.com/source-academy/frontend/issues/2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

1. Use developer tools to set the screen resolution to one that triggers the mobile view.
1. Run a Source program that will spawn dynamic tabs. For example:
   ```javascript
   import { show, circle } from "rune";

   show(circle);
   ```
1. Verify that the tab spawning behavior is unchanged; the mobile run tab will appear after any dynamic tabs, which will appear after the other non-dynamic tabs.