### PR TITLE
Fix error & injection of iframe on hot reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,11 +125,17 @@
     "husky": "^8.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
+    "react-error-overlay": "6.0.9",
     "react-scripts": "^4.0.3",
     "react-test-renderer": "^18.2.0",
     "redux-saga-test-plan": "^4.0.5",
     "sass": "^1.54.0",
     "typescript": "~4.7.4"
+  },
+  "resolutions": {
+    "//": "See https://github.com/facebook/create-react-app/issues/11773 for more information.",
+    "//": "FIXME: Remove this selective dependency resolution (along with the devDependency) once react-scripts is updated past 4.0.3.",
+    "react-error-overlay": "6.0.9"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -11218,10 +11218,10 @@ react-dropzone@^14.2.2:
     file-selector "^0.6.0"
     prop-types "^15.8.1"
 
-react-error-overlay@^6.0.9:
-  version "6.0.10"
-  resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz"
-  integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-fast-compare@^3.0.1:
   version "3.2.0"


### PR DESCRIPTION
### Description

Fixes #2213.

Same issue as https://github.com/facebook/create-react-app/issues/11773.

There are two solutions outlined in the CRA issue above:
1. Upgrade `react-scripts` to v5.x.
1. Specify v6.0.9 of `react-error-overlay` via [selective dependency resolution](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).

Unfortunately, we cannot upgrade `react-scripts` (CRA) to v5.0x because another dependency that we use, Create React App Configuration Override (CRACO) does not have a stable version that supports CRA v5.x yet:
> ℹ️ The latest CRACO release does not support CRA 5, but alpha builds will be regularly released over the next few days.
>
> -- https://github.com/dilanx/craco (as of 13 September 2022)

Attempting to do so results in errors when starting the frontend. As such, we have no choice but to go with the second option for now.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Launch the frontend with developer tools open.
1. Make a change in the codebase to trigger a hot reload.
1. Check that the error described in the issue was not thrown, and that no iframe was injected.