### PR TITLE
Improve Functionality of Remote Execution Device Dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-latex-next": "^2.1.0",
     "react-mde": "^11.5.0",
     "react-papaparse": "^4.0.2",
+    "react-qr-reader": "^3.0.0-beta-1",
     "react-redux": "^8.0.2",
     "react-responsive": "^9.0.0-beta.10",
     "react-router-dom": "^5.3.0",

--- a/src/commons/sideContent/SideContentRemoteExecution.tsx
+++ b/src/commons/sideContent/SideContentRemoteExecution.tsx
@@ -9,7 +9,7 @@ import {
   Spinner
 } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React from 'react';
+import React, { SetStateAction } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 import { Dispatch } from 'redux';
@@ -26,6 +26,7 @@ import { WorkspaceLocation } from '../workspace/WorkspaceTypes';
 export interface SideContentRemoteExecutionProps {
   workspace: WorkspaceLocation;
   secretParams?: string;
+  callbackFunction?: React.Dispatch<SetStateAction<string | undefined>>;
 }
 
 interface DeviceMenuItemButtonsProps {
@@ -220,6 +221,9 @@ const SideContentRemoteExecution: React.FC<SideContentRemoteExecutionProps> = pr
         onClose={() => {
           setDialogState(undefined);
           setSecretParams(undefined);
+          if (props.callbackFunction) {
+            props.callbackFunction(undefined);
+          }
         }}
       />
     </div>

--- a/src/commons/sideContent/SideContentRemoteExecution.tsx
+++ b/src/commons/sideContent/SideContentRemoteExecution.tsx
@@ -25,6 +25,7 @@ import { WorkspaceLocation } from '../workspace/WorkspaceTypes';
 
 export interface SideContentRemoteExecutionProps {
   workspace: WorkspaceLocation;
+  secretParams?: string;
 }
 
 interface DeviceMenuItemButtonsProps {
@@ -116,7 +117,10 @@ const DeviceContent = ({ session }: { session?: DeviceSession }) => {
 };
 
 const SideContentRemoteExecution: React.FC<SideContentRemoteExecutionProps> = props => {
-  const [dialogState, setDialogState] = React.useState<Device | true | undefined>(undefined);
+  const [dialogState, setDialogState] = React.useState<Device | true | undefined>(
+    props.secretParams ? true : undefined
+  );
+  const [secretParams, setSecretParams] = React.useState(props.secretParams);
 
   const [isLoggedIn, devices, currentSession]: [
     boolean,
@@ -212,7 +216,11 @@ const SideContentRemoteExecution: React.FC<SideContentRemoteExecutionProps> = pr
       <RemoteExecutionAddDeviceDialog
         isOpen={!!dialogState}
         deviceToEdit={typeof dialogState === 'object' ? dialogState : undefined}
-        onClose={() => setDialogState(undefined)}
+        defaultSecret={dialogState === true ? secretParams : undefined}
+        onClose={() => {
+          setDialogState(undefined);
+          setSecretParams(undefined);
+        }}
       />
     </div>
   );

--- a/src/features/remoteExecution/RemoteExecutionDeviceDialog.tsx
+++ b/src/features/remoteExecution/RemoteExecutionDeviceDialog.tsx
@@ -7,8 +7,10 @@ import {
   HTMLSelect,
   InputGroup
 } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import classNames from 'classnames';
 import React from 'react';
+import { QrReader } from 'react-qr-reader';
 import { useDispatch } from 'react-redux';
 
 import { editDevice, registerDevice } from '../../commons/sagas/RequestsSaga';
@@ -39,6 +41,7 @@ export default function RemoteExecutionDeviceDialog({
 
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>();
+  const [showScanner, setShowScanner] = React.useState(false);
 
   const onSubmit = async () => {
     const fields = collectFieldValues(nameField, typeField, secretField);
@@ -66,6 +69,12 @@ export default function RemoteExecutionDeviceDialog({
     onClose();
     setIsSubmitting(false);
   };
+
+  const scanButton = (
+    <Tooltip2 content="Scan QR Code">
+      <Button minimal icon="clip" onClick={() => setShowScanner(() => !showScanner)} />
+    </Tooltip2>
+  );
 
   return (
     <Dialog
@@ -129,9 +138,30 @@ export default function RemoteExecutionDeviceDialog({
             onChange={secretField.onChange}
             disabled={isSubmitting}
             readOnly={!!deviceToEdit}
-            {...(deviceToEdit ? { value: deviceToEdit.secret } : undefined)}
+            {...(deviceToEdit ? { value: deviceToEdit.secret } : { rightElement: scanButton })}
           />
         </FormGroup>
+
+        {showScanner && (
+          <QrReader
+            onResult={(result, err) => {
+              if (result) {
+                setShowScanner(false);
+                const element = secretField.ref.current;
+                if (element) {
+                  element.value = result.getText();
+                }
+              }
+            }}
+            constraints={{
+              aspectRatio: 1,
+              frameRate: { ideal: 12 },
+              deviceId: { ideal: '0' }
+            }}
+            containerStyle={{ width: '50%', marginInline: 'auto' }}
+            videoStyle={{ borderRadius: '0.3em' }}
+          />
+        )}
 
         {errorMessage && <Callout intent="danger">{errorMessage}</Callout>}
       </div>

--- a/src/features/remoteExecution/RemoteExecutionDeviceDialog.tsx
+++ b/src/features/remoteExecution/RemoteExecutionDeviceDialog.tsx
@@ -1,4 +1,12 @@
-import { Button, Callout, Classes, Dialog, FormGroup, HTMLSelect } from '@blueprintjs/core';
+import {
+  Button,
+  Callout,
+  Classes,
+  Dialog,
+  FormGroup,
+  HTMLSelect,
+  InputGroup
+} from '@blueprintjs/core';
 import classNames from 'classnames';
 import React from 'react';
 import { useDispatch } from 'react-redux';
@@ -113,15 +121,11 @@ export default function RemoteExecutionDeviceDialog({
         </FormGroup>
 
         <FormGroup label="Secret" labelFor="sa-remote-execution-secret">
-          <input
+          <InputGroup
             id="sa-remote-execution-secret"
-            className={classNames(
-              Classes.INPUT,
-              Classes.FILL,
-              secretField.isValid || Classes.INTENT_DANGER
-            )}
+            className={classNames(Classes.FILL, secretField.isValid || Classes.INTENT_DANGER)}
             type="text"
-            ref={secretField.ref}
+            inputRef={secretField.ref}
             onChange={secretField.onChange}
             disabled={isSubmitting}
             readOnly={!!deviceToEdit}

--- a/src/features/remoteExecution/RemoteExecutionDeviceDialog.tsx
+++ b/src/features/remoteExecution/RemoteExecutionDeviceDialog.tsx
@@ -27,12 +27,14 @@ export interface RemoteExecutionDeviceDialogProps {
   isOpen: boolean;
   onClose: () => void;
   deviceToEdit?: Device;
+  defaultSecret?: string;
 }
 
 export default function RemoteExecutionDeviceDialog({
   isOpen,
   onClose,
-  deviceToEdit
+  deviceToEdit,
+  defaultSecret
 }: RemoteExecutionDeviceDialogProps) {
   const dispatch = useDispatch();
   const nameField = useField<HTMLInputElement>(validateNotEmpty);
@@ -138,6 +140,7 @@ export default function RemoteExecutionDeviceDialog({
             onChange={secretField.onChange}
             disabled={isSubmitting}
             readOnly={!!deviceToEdit}
+            defaultValue={defaultSecret}
             {...(deviceToEdit ? { value: deviceToEdit.secret } : { rightElement: scanButton })}
           />
         </FormGroup>

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -809,7 +809,9 @@ const Playground: React.FC<PlaygroundProps> = props => {
   };
 
   return isMobileBreakpoint ? (
-    <MobileWorkspace {...mobileWorkspaceProps} />
+    <div className={classNames('Playground', Classes.DARK, isGreen ? 'GreenScreen' : undefined)}>
+      <MobileWorkspace {...mobileWorkspaceProps} />
+    </div>
   ) : (
     <HotKeys
       className={classNames('Playground', Classes.DARK, isGreen ? 'GreenScreen' : undefined)}

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -206,6 +206,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         <SideContentRemoteExecution
           workspace="playground"
           secretParams={deviceSecret || undefined}
+          callbackFunction={setDeviceSecret}
         />
       ),
       id: SideContentType.remoteExecution,

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -249,13 +249,9 @@ const Playground: React.FC<PlaygroundProps> = props => {
    * Handles toggling of relevant SideContentTabs when mobile breakpoint it hit
    */
   React.useEffect(() => {
-    if (isMobileBreakpoint && selectedTab === SideContentType.introduction) {
+    if (isMobileBreakpoint && desktopOnlyTabIds.includes(selectedTab)) {
       setSelectedTab(SideContentType.mobileEditor);
-    } else if (
-      !isMobileBreakpoint &&
-      (selectedTab === SideContentType.mobileEditor ||
-        selectedTab === SideContentType.mobileEditorRun)
-    ) {
+    } else if (!isMobileBreakpoint && mobileOnlyTabIds.includes(selectedTab)) {
       setSelectedTab(SideContentType.introduction);
     }
   }, [isMobileBreakpoint, selectedTab]);
@@ -625,7 +621,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
   ]);
 
   // Remove Intro and Remote Execution tabs for mobile
-  const mobileTabs = [...tabs].filter(x => x !== playgroundIntroductionTab);
+  const mobileTabs = [...tabs].filter(({ id }) => !(id && desktopOnlyTabIds.includes(id)));
 
   const onLoadMethod = React.useCallback(
     (editor: Ace.Editor) => {
@@ -823,6 +819,12 @@ const Playground: React.FC<PlaygroundProps> = props => {
     </HotKeys>
   );
 };
+
+const mobileOnlyTabIds: readonly SideContentType[] = [
+  SideContentType.mobileEditor,
+  SideContentType.mobileEditorRun
+];
+const desktopOnlyTabIds: readonly SideContentType[] = [SideContentType.introduction];
 
 const dataVisualizerTab: SideContentTab = {
   label: 'Data Visualizer',

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -249,11 +249,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
    * Handles toggling of relevant SideContentTabs when mobile breakpoint it hit
    */
   React.useEffect(() => {
-    if (
-      isMobileBreakpoint &&
-      (selectedTab === SideContentType.introduction ||
-        selectedTab === SideContentType.remoteExecution)
-    ) {
+    if (isMobileBreakpoint && selectedTab === SideContentType.introduction) {
       setSelectedTab(SideContentType.mobileEditor);
     } else if (
       !isMobileBreakpoint &&
@@ -629,9 +625,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
   ]);
 
   // Remove Intro and Remote Execution tabs for mobile
-  const mobileTabs = [...tabs].filter(
-    x => x !== playgroundIntroductionTab && x !== remoteExecutionTab
-  );
+  const mobileTabs = [...tabs].filter(x => x !== playgroundIntroductionTab);
 
   const onLoadMethod = React.useCallback(
     (editor: Ace.Editor) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2761,6 +2761,27 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zxing/browser@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@zxing/browser/-/browser-0.0.7.tgz#5fa7680a867b660f48d3288fdf63e0174ad531c7"
+  integrity sha512-AepzMgDnD6EjxewqmXpHJsi4S3Gw9ilZJLIbTf6fWuWySEcHBodnGu3p7FWlgq1Sd5QyfPhTum5z3CBkkhMVng==
+  optionalDependencies:
+    "@zxing/text-encoding" "^0.9.0"
+
+"@zxing/library@^0.18.3":
+  version "0.18.6"
+  resolved "https://registry.yarnpkg.com/@zxing/library/-/library-0.18.6.tgz#717af8c6c1fd982865e21051afdd7b470ae6674c"
+  integrity sha512-bulZ9JHoLFd9W36pi+7e7DnEYNJhljYjZ1UTsKPOoLMU3qtC+REHITeCRNx40zTRJZx18W5TBRXt5pq2Uopjsw==
+  dependencies:
+    ts-custom-error "^3.0.0"
+  optionalDependencies:
+    "@zxing/text-encoding" "~0.9.0"
+
+"@zxing/text-encoding@^0.9.0", "@zxing/text-encoding@~0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz"
@@ -11304,6 +11325,15 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
+react-qr-reader@^3.0.0-beta-1:
+  version "3.0.0-beta-1"
+  resolved "https://registry.yarnpkg.com/react-qr-reader/-/react-qr-reader-3.0.0-beta-1.tgz#e04a20876409313439959d8e0ea6df3ba6e36d68"
+  integrity sha512-5HeFH9x/BlziRYQYGK2AeWS9WiKYZtGGMs9DXy3bcySTX3C9UJL9EwcPnWw8vlf7JP4FcrAlr1SnZ5nsWLQGyw==
+  dependencies:
+    "@zxing/browser" "0.0.7"
+    "@zxing/library" "^0.18.3"
+    rollup "^2.67.2"
+
 react-reconciler@~0.26.2:
   version "0.26.2"
   resolved "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.26.2.tgz"
@@ -12004,6 +12034,13 @@ rollup@^1.31.1:
     "@types/estree" "*"
     "@types/node" "*"
     acorn "^7.1.0"
+
+rollup@^2.67.2:
+  version "2.78.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.78.0.tgz#00995deae70c0f712ea79ad904d5f6b033209d9e"
+  integrity sha512-4+YfbQC9QEVvKTanHhIAFVUFSRsezvQF8vFOJwtGfb9Bb+r014S+qryr9PSmw8x6sMnPkmFBGAvIFVQxvJxjtg==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -13280,6 +13317,11 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-custom-error@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.2.0.tgz#ff8f80a3812bab9dc448536312da52dce1b720fb"
+  integrity sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A==
 
 ts-node@^10.4.0:
   version "10.4.0"


### PR DESCRIPTION
### Description

Added a new dependency: `"react-qr-reader": "^3.0.0-beta-1"`

This MR includes various enhancements to the remote execution UI. Mainly, it is done to improve quality-of-life and the out-of-the box experience when pairing with a new device.

Summary of changes:
* Add ability to scan a QR code from the dialog in lieu of manually pasting/typing out the device secret
* Add support for "deep links", where a dialog box (pre-filled) with the device secret will pop up when the accessing SA via the deep link
* Enable the "remote execution" tab in the mobile workspace
* Minor refactoring, code quality improvements and UI fixes

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

* http://localhost:8000/playground should retain existing behaviour, the only difference being on mobile, where the button to show the remote execution tab would also be visible
* http://localhost:8000/playground?add_device=some_string_here_a7Gxa should open the playground directly into the remote execution tab (instead of the home tab), as well as automatically pop-up the add device dialog, pre-filled with the token (`some_string_here_a7Gxa`). At the same time, the address bar will not show the query parameter in the URL.
  * Closing/cancelling/confirming the dialog (or refreshing the page) should not cause it the dialog to pop up again. There was a bug whereby this would happen after resizing a window, when the playground switches between and mobile and desktop workspaces. This was fixed in commit e9d81fb3ca4dc885f980e80f1f3390ae4830095b.
* The add device dialog should now have a button to scan a QR code:
  <img width="554" alt="image" src="https://user-images.githubusercontent.com/34370238/190265760-f1da4e71-49f5-43ba-a830-4530c44f1b3a.png">
  This button should not be visible when editing a device, as the secret token is not editable in the case of editing. After clicking the button and accepting camera permissions, a camera window is shown, and the user can then start to scan the QR code. Clicking the button again will stop the camera. The camera will also auto-close once it detects and scans a QR code.
  <img width="566" alt="image" src="https://user-images.githubusercontent.com/34370238/190266136-b1989916-b8d8-4805-8189-ff8ad4fa539a.png">
  Once the camera has scanned a QR code, it will pre-fill the value into the 'secret' field, overriding any previous value that may be there. This field should remain editable by the user.

### Checklist

- [x] I have tested this code
- [ ] ~~I have updated the documentation~~ (not applicable)
