### PR TITLE
Remove unnecessary toSpawn property on SideContentTab type

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -375,15 +375,13 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
             label: `Task ${questionId + 1}`,
             iconName: IconNames.NINJA,
             body: <Markdown content={props.assessment!.questions[questionId].content} />,
-            id: SideContentType.questionOverview,
-            toSpawn: () => true
+            id: SideContentType.questionOverview
           },
           {
             label: `Contest Voting Briefing`,
             iconName: IconNames.BRIEFCASE,
             body: <Markdown content={props.assessment!.longSummary} />,
-            id: SideContentType.briefing,
-            toSpawn: () => true
+            id: SideContentType.briefing
           },
           {
             label: 'Contest Voting',
@@ -404,8 +402,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
                 }
               />
             ),
-            id: SideContentType.contestVoting,
-            toSpawn: () => true
+            id: SideContentType.contestVoting
           },
           {
             label: 'Contest Leaderboard',
@@ -419,8 +416,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
                 }
               />
             ),
-            id: SideContentType.contestLeaderboard,
-            toSpawn: () => false
+            id: SideContentType.contestLeaderboard
           }
         ]
       : [
@@ -433,8 +429,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
                 content={props.assessment!.questions[questionId].content}
               />
             ),
-            id: SideContentType.questionOverview,
-            toSpawn: () => true
+            id: SideContentType.questionOverview
           },
           {
             label: `Briefing`,
@@ -442,8 +437,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
             body: (
               <Markdown className="sidecontent-overview" content={props.assessment!.longSummary} />
             ),
-            id: SideContentType.briefing,
-            toSpawn: () => true
+            id: SideContentType.briefing
           },
           {
             label: `Autograder`,
@@ -461,8 +455,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
                 workspaceLocation="assessment"
               />
             ),
-            id: SideContentType.autograder,
-            toSpawn: () => true
+            id: SideContentType.autograder
           }
         ];
 
@@ -479,8 +472,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
             comments={props.assessment!.questions[questionId].comments}
           />
         ),
-        id: SideContentType.grading,
-        toSpawn: () => true
+        id: SideContentType.grading
       });
     }
 
@@ -491,8 +483,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
         label: `Tone Matrix`,
         iconName: IconNames.GRID_VIEW,
         body: <SideContentToneMatrix />,
-        id: SideContentType.toneMatrix,
-        toSpawn: () => true
+        id: SideContentType.toneMatrix
       });
     }
 
@@ -504,8 +495,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
         label: 'Video Display',
         iconName: IconNames.MOBILE_VIDEO,
         body: <SideContentVideoDisplay replChange={props.handleSendReplInputToOutput} />,
-        id: SideContentType.videoDisplay,
-        toSpawn: () => true
+        id: SideContentType.videoDisplay
       });
     }
 

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -462,15 +462,13 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               updateAssessment={this.updateEditAssessmentState}
             />
           ),
-          id: SideContentType.editorQuestionOverview,
-          toSpawn: () => true
+          id: SideContentType.editorQuestionOverview
         },
         {
           label: `Question Template`,
           iconName: IconNames.DOCUMENT,
           body: questionTemplateTab,
-          id: SideContentType.editorQuestionTemplate,
-          toSpawn: () => true
+          id: SideContentType.editorQuestionTemplate
         },
         {
           label: `Manage Local Deployment`,
@@ -485,8 +483,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               isOptionalDeployment={true}
             />
           ),
-          id: SideContentType.editorLocalDeployment,
-          toSpawn: () => true
+          id: SideContentType.editorLocalDeployment
         },
         {
           label: `Manage Local Grader Deployment`,
@@ -502,8 +499,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               isOptionalDeployment={true}
             />
           ),
-          id: SideContentType.editorLocalGraderDeployment,
-          toSpawn: () => true
+          id: SideContentType.editorLocalGraderDeployment
         },
         {
           label: `Grading`,
@@ -515,8 +511,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               updateAssessment={this.updateEditAssessmentState}
             />
           ),
-          id: SideContentType.editorGrading,
-          toSpawn: () => true
+          id: SideContentType.editorGrading
         }
       ];
       if (qnType === 'programming') {
@@ -531,8 +526,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               updateAssessment={this.updateEditAssessmentState}
             />
           ),
-          id: SideContentType.editorAutograder,
-          toSpawn: () => true
+          id: SideContentType.editorAutograder
         });
       }
       const functionsAttached = assessment!.globalDeployment!.external.symbols;
@@ -541,8 +535,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
           label: `Tone Matrix`,
           iconName: IconNames.GRID_VIEW,
           body: <SideContentToneMatrix />,
-          id: SideContentType.toneMatrix,
-          toSpawn: () => true
+          id: SideContentType.toneMatrix
         });
       }
     } else {
@@ -557,8 +550,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               updateAssessment={this.updateEditAssessmentState}
             />
           ),
-          id: SideContentType.editorBriefing,
-          toSpawn: () => true
+          id: SideContentType.editorBriefing
         },
         {
           label: `Manage Question`,
@@ -571,8 +563,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               updateAssessment={this.updateAndSaveAssessment}
             />
           ),
-          id: SideContentType.editorManageQuestion,
-          toSpawn: () => true
+          id: SideContentType.editorManageQuestion
         },
         {
           label: `Manage Global Deployment`,
@@ -587,8 +578,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               isOptionalDeployment={false}
             />
           ),
-          id: SideContentType.editorGlobalDeployment,
-          toSpawn: () => true
+          id: SideContentType.editorGlobalDeployment
         },
         {
           label: `Manage Global Grader Deployment`,
@@ -603,8 +593,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
               isOptionalDeployment={true}
             />
           ),
-          id: SideContentType.editorGlobalGraderDeployment,
-          toSpawn: () => true
+          id: SideContentType.editorGlobalGraderDeployment
         }
       ];
     }

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -197,8 +197,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
       label: 'Editor',
       iconName: IconNames.EDIT,
       body: null,
-      id: SideContentType.mobileEditor,
-      toSpawn: () => true
+      id: SideContentType.mobileEditor
     }),
     []
   );
@@ -208,8 +207,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
       label: 'Run',
       iconName: IconNames.PLAY,
       body: null,
-      id: SideContentType.mobileEditorRun,
-      toSpawn: () => true
+      id: SideContentType.mobileEditorRun
     }),
     []
   );

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -80,12 +80,3 @@ export type ModuleSideContent = {
   body: (props: any) => JSX.Element;
   toSpawn: (context: DebuggerContext) => boolean;
 };
-
-/**
- * Module imported from js-slang
- *
- * @propety functions from the imported module
- *
- * @property sideContents an array of side content tabs to display on the front end
- */
-export type Modules = (React: any) => ModuleSideContent;

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -56,7 +56,6 @@ export type SideContentTab = {
   label: string;
   iconName: IconName;
   body: JSX.Element | null;
-  toSpawn: (context: DebuggerContext) => boolean;
   id?: SideContentType;
   disabled?: boolean;
 };

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -324,15 +324,13 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
             }
           />
         ),
-        id: SideContentType.grading,
-        toSpawn: () => true
+        id: SideContentType.grading
       },
       {
         label: `Task ${questionId + 1}`,
         iconName: IconNames.NINJA,
         body: <Markdown content={props.grading![questionId].question.content} />,
-        id: SideContentType.questionOverview,
-        toSpawn: () => true
+        id: SideContentType.questionOverview
       },
       {
         label: `Autograder`,
@@ -345,8 +343,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
             workspaceLocation="grading"
           />
         ),
-        id: SideContentType.autograder,
-        toSpawn: () => true
+        id: SideContentType.autograder
       }
     ];
 
@@ -357,8 +354,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
         label: `Tone Matrix`,
         iconName: IconNames.GRID_VIEW,
         body: <SideContentToneMatrix />,
-        id: SideContentType.toneMatrix,
-        toSpawn: () => true
+        id: SideContentType.toneMatrix
       });
     }
 
@@ -370,8 +366,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
         label: 'Video Display',
         iconName: IconNames.MOBILE_VIDEO,
         body: <SideContentVideoDisplay replChange={props.handleSendReplInputToOutput} />,
-        id: SideContentType.videoDisplay,
-        toSpawn: () => true
+        id: SideContentType.videoDisplay
       });
     }
 

--- a/src/pages/academy/sourcereel/Sourcereel.tsx
+++ b/src/pages/academy/sourcereel/Sourcereel.tsx
@@ -338,8 +338,7 @@ class Sourcereel extends React.Component<SourcereelProps, State> {
                   />
                 </div>
               ),
-              id: SideContentType.sourcereel,
-              toSpawn: () => true
+              id: SideContentType.sourcereel
             },
             {
               label: 'Sourcecast Table',
@@ -353,8 +352,7 @@ class Sourcereel extends React.Component<SourcereelProps, State> {
                   />
                 </div>
               ),
-              id: SideContentType.introduction,
-              toSpawn: () => true
+              id: SideContentType.introduction
             },
             dataVisualizerTab,
             envVisualizerTab
@@ -415,16 +413,14 @@ const dataVisualizerTab: SideContentTab = {
   label: 'Data Visualizer',
   iconName: IconNames.EYE_OPEN,
   body: <SideContentDataVisualizer />,
-  id: SideContentType.dataVisualizer,
-  toSpawn: () => true
+  id: SideContentType.dataVisualizer
 };
 
 const envVisualizerTab: SideContentTab = {
   label: 'Env Visualizer',
   iconName: IconNames.GLOBE,
   body: <SideContentEnvVisualizer />,
-  id: SideContentType.envVisualizer,
-  toSpawn: () => true
+  id: SideContentType.envVisualizer
 };
 
 export default Sourcereel;

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -817,8 +817,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
             setTaskDescriptions={setTaskDescriptions}
           />
         ),
-        id: SideContentType.questionOverview,
-        toSpawn: () => true
+        id: SideContentType.questionOverview
       },
       {
         label: 'Briefing',
@@ -830,8 +829,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
             setContent={setBriefingContentWrapper}
           />
         ),
-        id: SideContentType.briefing,
-        toSpawn: () => true
+        id: SideContentType.briefing
       }
     ];
 
@@ -853,8 +851,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
           handleTestcaseEval={props.handleTestcaseEval}
         />
       ),
-      id: SideContentType.testcases,
-      toSpawn: () => true
+      id: SideContentType.testcases
     });
 
     if (isTeacherMode) {
@@ -868,8 +865,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
             setMissionMetadata={setMissionMetadataWrapper}
           />
         ),
-        id: SideContentType.missionMetadata,
-        toSpawn: () => true
+        id: SideContentType.missionMetadata
       });
     }
 

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -534,8 +534,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
           openLinksInNewWindow={true}
         />
       ),
-      id: SideContentType.introduction,
-      toSpawn: () => true
+      id: SideContentType.introduction
     }),
     [props.playgroundSourceChapter, props.playgroundSourceVariant]
   );
@@ -572,8 +571,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
         label: 'Stepper',
         iconName: IconNames.FLOW_REVIEW,
         body: <SideContentSubstVisualizer content={processStepperOutput(props.output)} />,
-        id: SideContentType.substVisualizer,
-        toSpawn: () => true
+        id: SideContentType.substVisualizer
       });
     }
 
@@ -802,24 +800,21 @@ const dataVisualizerTab: SideContentTab = {
   label: 'Data Visualizer',
   iconName: IconNames.EYE_OPEN,
   body: <SideContentDataVisualizer />,
-  id: SideContentType.dataVisualizer,
-  toSpawn: () => true
+  id: SideContentType.dataVisualizer
 };
 
 const envVisualizerTab: SideContentTab = {
   label: 'Env Visualizer',
   iconName: IconNames.GLOBE,
   body: <SideContentEnvVisualizer />,
-  id: SideContentType.envVisualizer,
-  toSpawn: () => true
+  id: SideContentType.envVisualizer
 };
 
 const remoteExecutionTab: SideContentTab = {
   label: 'Remote Execution',
   iconName: IconNames.SATELLITE,
   body: <SideContentRemoteExecution workspace="playground" />,
-  id: SideContentType.remoteExecution,
-  toSpawn: () => true
+  id: SideContentType.remoteExecution
 };
 
 export default Playground;

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -253,8 +253,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
           />
         </div>
       ),
-      id: SideContentType.introduction,
-      toSpawn: () => true
+      id: SideContentType.introduction
     },
     dataVisualizerTab,
     envVisualizerTab
@@ -385,16 +384,14 @@ const dataVisualizerTab: SideContentTab = {
   label: 'Data Visualizer',
   iconName: IconNames.EYE_OPEN,
   body: <SideContentDataVisualizer />,
-  id: SideContentType.dataVisualizer,
-  toSpawn: () => true
+  id: SideContentType.dataVisualizer
 };
 
 const envVisualizerTab: SideContentTab = {
   label: 'Env Visualizer',
   iconName: IconNames.GLOBE,
   body: <SideContentEnvVisualizer />,
-  id: SideContentType.envVisualizer,
-  toSpawn: () => true
+  id: SideContentType.envVisualizer
 };
 
 export default Sourcecast;


### PR DESCRIPTION
### Context

To support multiple files & directories, there is a need for a file system view in the user interface. In the desktop view, this will be in the form of a sidebar on the left edge of the Source Academy that can be toggled open (much like most IDEs). Due to a lack of space in the mobile view, the file system UI will have to be a side content tab. Given the very similar purposes of the to-be-added sidebar and the existing side content tabs, I have been looking closely at the implementation of the latter so as to keep the interfaces consistent and interoperable.

One thing that stood out was the fact that the `SideContentTab` type has a `toSpawn` property of type `(context: DebuggerContext) => boolean`. However, all of the instances of `SideContentTab` in the frontend have `toSpawn` set to be the value `() => true`, which is a huge code smell.

Digging through the git history, I found that the `toSpawn` property was first introduced in #1352 to support the dynamic spawning of side content tabs. In #1617 however, a new `ModuleSideContent` type was introduced that corresponded to side content tabs from the [new modules system](https://github.com/source-academy/modules). The process of loading dynamic module tabs is as follows:
1. Using the debugger context, an array of `ModuleSideContent` is retrieved based on the modules imported.
1. Then, the array of `ModuleSideContent` is converted into an array of `SideContentTab`.
1. Finally, the `toSpawn` property (which is part of both `SideContentTab` and `ModuleSideContent`) is used to filter out the module tabs based on more granular rules specified within each module.
   * For example, the `rune` module will not spawn a tab if `show` is not called.

Given that the side content tabs declared in the frontend are static (i.e., will always be loaded), there is no reason for `SideContentTab` to have the `toSpawn` property. We can remove the property if we swap steps 2 and 3 above since the `ModuleSideContent` type already has the `toSpawn` property and represents dynamic module tabs (which should be the only side content tabs in which the `toSpawn` property is necessary).

### Description

Reorder the steps taken when processing the dynamic module tabs and remove the unnecessary `toSpawn` property on the `SideContentTab` type.

Also remove the unused `Modules` type. #2102 removed the only instance in which it was used but did not remove the type.

Part of the refactoring for #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

Run Source programs that result in the loading of dynamic modules and verify that the behaviour is unchanged. For example, the following cases can be tested:
* Run a Source program that does not load any modules.
  ```javascript
  const x = 10;
  x * 3;
  ```
* Run a Source program that loads a module and should display a corresponding side content tab.
  ```javascript
  import { show, heart } from "rune";
  show(heart);
  ```
* Run a Source program that loads a module but should not display a corresponding side content tab.
  ```javascript
  import { show, heart } from "rune";
  ```