### PR TITLE
Add resizing of sidebar

### DIFF
--- a/src/commons/sideBar/SideBar.tsx
+++ b/src/commons/sideBar/SideBar.tsx
@@ -9,21 +9,27 @@ export type SideBarTab = {
 
 export type SideBarProps = {
   tabs: SideBarTab[];
+  isExpanded: boolean;
+  expandSideBar: () => void;
+  collapseSideBar: () => void;
 };
 
 const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
-  const { tabs } = props;
+  const { tabs, isExpanded, expandSideBar, collapseSideBar } = props;
 
   const [selectedTabIndex, setSelectedTabIndex] = React.useState<number>(0);
-  const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
 
   const handleTabSelection = (tabIndex: number) => {
     if (selectedTabIndex === tabIndex) {
-      setIsExpanded(!isExpanded);
+      if (isExpanded) {
+        collapseSideBar();
+      } else {
+        expandSideBar();
+      }
       return;
     }
     setSelectedTabIndex(tabIndex);
-    setIsExpanded(true);
+    expandSideBar();
   };
 
   // Do not render the sidebar if there are no tabs.

--- a/src/commons/sideBar/SideBar.tsx
+++ b/src/commons/sideBar/SideBar.tsx
@@ -26,7 +26,7 @@ const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
 
   // Do not render the sidebar if there are no tabs.
   if (tabs.length === 0) {
-    return <></>;
+    return <div className="sidebar-container" />;
   }
 
   return (

--- a/src/commons/sideBar/SideBar.tsx
+++ b/src/commons/sideBar/SideBar.tsx
@@ -14,14 +14,16 @@ export type SideBarProps = {
 const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
   const { tabs } = props;
 
-  const [selectedTabIndex, setSelectedTabIndex] = React.useState<number | null>(null);
+  const [selectedTabIndex, setSelectedTabIndex] = React.useState<number>(0);
+  const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
 
   const handleTabSelection = (tabIndex: number) => {
     if (selectedTabIndex === tabIndex) {
-      setSelectedTabIndex(null);
+      setIsExpanded(!isExpanded);
       return;
     }
     setSelectedTabIndex(tabIndex);
+    setIsExpanded(true);
   };
 
   // Do not render the sidebar if there are no tabs.
@@ -35,7 +37,7 @@ const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
         {tabs.map((tab, index) => (
           <Card
             key={index}
-            className={classNames('tab', { selected: selectedTabIndex === index })}
+            className={classNames('tab', { selected: isExpanded && selectedTabIndex === index })}
             onClick={() => handleTabSelection(index)}
           >
             {tab.label}

--- a/src/commons/sideBar/SideBar.tsx
+++ b/src/commons/sideBar/SideBar.tsx
@@ -12,6 +12,8 @@ export type SideBarProps = {
 };
 
 const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
+  const { tabs } = props;
+
   const [selectedTabIndex, setSelectedTabIndex] = React.useState<number | null>(null);
 
   const handleTabSelection = (tabIndex: number) => {
@@ -23,14 +25,14 @@ const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
   };
 
   // Do not render the sidebar if there are no tabs.
-  if (props.tabs.length === 0) {
+  if (tabs.length === 0) {
     return <></>;
   }
 
   return (
     <div className="sidebar-container">
       <div className="tab-container">
-        {props.tabs.map((tab, index) => (
+        {tabs.map((tab, index) => (
           <Card
             key={index}
             className={classNames('tab', { selected: selectedTabIndex === index })}
@@ -40,9 +42,7 @@ const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
           </Card>
         ))}
       </div>
-      {selectedTabIndex !== null && (
-        <Card className="panel">{props.tabs[selectedTabIndex].body}</Card>
-      )}
+      {selectedTabIndex !== null && <Card className="panel">{tabs[selectedTabIndex].body}</Card>}
     </div>
   );
 };

--- a/src/commons/utils/Hooks.ts
+++ b/src/commons/utils/Hooks.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { RefObject } from 'react';
 
 import { readLocalStorage, setLocalStorage } from './LocalStorageHelper';
 
@@ -99,3 +99,40 @@ export function useLocalStorageState<T>(
 
   return [value, setValue];
 }
+
+/**
+ * Dynamically returns the dimensions (width & height) of an HTML element, updating whenever the
+ * element is loaded or resized.
+ *
+ * @param ref A reference to the underlying HTML element.
+ */
+export const useDimensions = (ref: RefObject<HTMLElement>): [width: number, height: number] => {
+  const [width, setWidth] = React.useState<number>(0);
+  const [height, setHeight] = React.useState<number>(0);
+
+  const resizeObserver = React.useMemo(
+    () =>
+      new ResizeObserver((entries: ResizeObserverEntry[], observer: ResizeObserver) => {
+        if (entries.length !== 1) {
+          throw new Error(
+            'Expected only a single HTML element to be observed by the ResizeObserver.'
+          );
+        }
+        const contentRect = entries[0].contentRect;
+        setWidth(contentRect.width);
+        setHeight(contentRect.height);
+      }),
+    []
+  );
+
+  React.useEffect(() => {
+    const htmlElement = ref.current;
+    if (htmlElement === null) {
+      return;
+    }
+    resizeObserver.observe(htmlElement);
+    return () => resizeObserver.disconnect();
+  }, [ref, resizeObserver]);
+
+  return [width, height];
+};

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -1,5 +1,6 @@
 import { FocusStyleManager } from '@blueprintjs/core';
-import { Resizable, ResizableProps, ResizeCallback } from 're-resizable';
+import { NumberSize, Resizable, ResizableProps, ResizeCallback } from 're-resizable';
+import { Direction } from 're-resizable/lib/resizer';
 import * as React from 'react';
 import { Prompt } from 'react-router';
 
@@ -32,6 +33,7 @@ type StateProps = {
 };
 
 const Workspace: React.FC<WorkspaceProps> = props => {
+  const sideBarResizable = React.useRef<Resizable | null>(null);
   const contentContainerDiv = React.useRef<HTMLDivElement | null>(null);
   const editorDividerDiv = React.useRef<HTMLDivElement | null>(null);
   const leftParentResizable = React.useRef<Resizable | null>(null);
@@ -56,7 +58,9 @@ const Workspace: React.FC<WorkspaceProps> = props => {
     return {
       enable: isSideBarRendered ? rightResizeOnly : noResize,
       minWidth: isSideBarRendered ? 40 : 0,
-      maxWidth: '50%'
+      maxWidth: '50%',
+      onResize: toggleSideBarDividerDisplay,
+      ref: sideBarResizable
     } as ResizableProps;
   };
 
@@ -82,6 +86,23 @@ const Workspace: React.FC<WorkspaceProps> = props => {
       onResize: toggleDividerDisplay,
       onResizeStop
     } as ResizableProps;
+  };
+
+  const toggleSideBarDividerDisplay: ResizeCallback = (
+    event: MouseEvent | TouchEvent,
+    direction: Direction,
+    elementRef: HTMLElement,
+    delta: NumberSize
+  ) => {
+    const minWidthThreshold = 100;
+    const sideBarWidth = elementRef.clientWidth;
+    if (sideBarWidth < minWidthThreshold) {
+      const sideBar = sideBarResizable.current;
+      if (sideBar === null) {
+        throw Error('Reference to SideBar not found when resizing.');
+      }
+      sideBar.updateSize({ width: 40, height: '100%' });
+    }
   };
 
   /**

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -53,18 +53,6 @@ const Workspace: React.FC<WorkspaceProps> = props => {
 
   const sideBarResizableProps = () => {
     return {
-      handleStyles: {
-        // Necessary for the resize component to be positioned at the gap between the sidebar and the editor.
-        // This is because the gap is created using a left margin on the editor. Replacing the left margin on the
-        // editor with a right margin on the sidebar results in more edge cases to handle since the sidebar is
-        // conditionally rendered (i.e., it does not display when there are no sidebar tabs).
-        right: {
-          // Move the resize component 0.5rem (the left margin of the editor) to the right (default value is -5px).
-          right: 'calc(-5px - 0.5rem)',
-          // Render the resize component above the editor so that it can be selected.
-          zIndex: 1
-        }
-      },
       enable: rightResizeOnly,
       maxWidth: '50%'
     } as ResizableProps;
@@ -109,12 +97,6 @@ const Workspace: React.FC<WorkspaceProps> = props => {
       leftParentResizable.current!.updateSize({ width: '100%', height: '100%' });
     } else if (editorWidthPercentage < leftThreshold) {
       leftParentResizable.current!.updateSize({ width: '0%', height: '100%' });
-    }
-    // Update divider margin
-    if (editorWidthPercentage < leftThreshold) {
-      editorDividerDiv.current!.style.marginRight = '0.5rem';
-    } else {
-      editorDividerDiv.current!.style.marginRight = '0';
     }
   };
 

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -53,7 +53,8 @@ const Workspace: React.FC<WorkspaceProps> = props => {
 
   const sideBarResizableProps = () => {
     return {
-      enable: rightResizeOnly
+      enable: rightResizeOnly,
+      maxWidth: '50%'
     } as ResizableProps;
   };
 

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -9,6 +9,7 @@ import McqChooser, { McqChooserProps } from '../mcqChooser/McqChooser';
 import Repl, { ReplProps } from '../repl/Repl';
 import SideBar, { SideBarProps } from '../sideBar/SideBar';
 import SideContent, { SideContentProps } from '../sideContent/SideContent';
+import { useDimensions } from '../utils/Hooks';
 
 export type WorkspaceProps = DispatchProps & StateProps;
 
@@ -31,10 +32,12 @@ type StateProps = {
 };
 
 const Workspace: React.FC<WorkspaceProps> = props => {
+  const contentContainerDiv = React.useRef<HTMLDivElement | null>(null);
   const editorDividerDiv = React.useRef<HTMLDivElement | null>(null);
   const leftParentResizable = React.useRef<Resizable | null>(null);
   const maxDividerHeight = React.useRef<number | null>(null);
   const sideDividerDiv = React.useRef<HTMLDivElement | null>(null);
+  const [contentContainerWidth] = useDimensions(contentContainerDiv);
 
   FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -80,7 +83,8 @@ const Workspace: React.FC<WorkspaceProps> = props => {
   const toggleEditorDividerDisplay: ResizeCallback = (_a, _b, ref) => {
     const leftThreshold = 5;
     const rightThreshold = 95;
-    const editorWidthPercentage = ((ref as HTMLDivElement).clientWidth / window.innerWidth) * 100;
+    const editorWidthPercentage =
+      ((ref as HTMLDivElement).clientWidth / contentContainerWidth) * 100;
     // update resizable size
     if (editorWidthPercentage > rightThreshold) {
       leftParentResizable.current!.updateSize({ width: '100%', height: '100%' });
@@ -145,7 +149,7 @@ const Workspace: React.FC<WorkspaceProps> = props => {
       <ControlBar {...controlBarProps()} />
       <div className="workspace-parent">
         <SideBar {...props.sideBarProps} />
-        <div className="row content-parent">
+        <div className="row content-parent" ref={contentContainerDiv}>
           <div className="editor-divider" ref={editorDividerDiv} />
           <Resizable {...editorResizableProps()}>{createWorkspaceInput(props)}</Resizable>
           <div className="right-parent">

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -51,6 +51,12 @@ const Workspace: React.FC<WorkspaceProps> = props => {
     return { ...props.controlBarProps };
   };
 
+  const sideBarResizableProps = () => {
+    return {
+      enable: rightResizeOnly
+    } as ResizableProps;
+  };
+
   const editorResizableProps = () => {
     return {
       className: 'resize-editor left-parent',
@@ -148,7 +154,9 @@ const Workspace: React.FC<WorkspaceProps> = props => {
       ) : null}
       <ControlBar {...controlBarProps()} />
       <div className="workspace-parent">
-        <SideBar {...props.sideBarProps} />
+        <Resizable {...sideBarResizableProps()}>
+          <SideBar {...props.sideBarProps} />
+        </Resizable>
         <div className="row content-parent" ref={contentContainerDiv}>
           <div className="editor-divider" ref={editorDividerDiv} />
           <Resizable {...editorResizableProps()}>{createWorkspaceInput(props)}</Resizable>

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -90,14 +90,15 @@ const Workspace: React.FC<WorkspaceProps> = props => {
       }
     };
     const isSideBarRendered = props.sideBarProps.tabs.length !== 0;
+    const minWidth = isSideBarRendered ? sideBarCollapsedWidth : 'auto';
     return {
       enable: isSideBarRendered ? rightResizeOnly : noResize,
-      minWidth: isSideBarRendered ? sideBarCollapsedWidth : 0,
+      minWidth,
       maxWidth: '50%',
       onResize: toggleSideBarDividerDisplay,
       onResizeStop,
       ref: sideBarResizable,
-      defaultSize: { width: sideBarCollapsedWidth, height: '100%' }
+      defaultSize: { width: minWidth, height: '100%' }
     } as ResizableProps;
   };
 

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -52,8 +52,10 @@ const Workspace: React.FC<WorkspaceProps> = props => {
   };
 
   const sideBarResizableProps = () => {
+    const isSideBarRendered = props.sideBarProps.tabs.length !== 0;
     return {
-      enable: props.sideBarProps.tabs.length === 0 ? noResize : rightResizeOnly,
+      enable: isSideBarRendered ? rightResizeOnly : noResize,
+      minWidth: isSideBarRendered ? 40 : 0,
       maxWidth: '50%'
     } as ResizableProps;
   };

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -53,6 +53,18 @@ const Workspace: React.FC<WorkspaceProps> = props => {
 
   const sideBarResizableProps = () => {
     return {
+      handleStyles: {
+        // Necessary for the resize component to be positioned at the gap between the sidebar and the editor.
+        // This is because the gap is created using a left margin on the editor. Replacing the left margin on the
+        // editor with a right margin on the sidebar results in more edge cases to handle since the sidebar is
+        // conditionally rendered (i.e., it does not display when there are no sidebar tabs).
+        right: {
+          // Move the resize component 0.5rem (the left margin of the editor) to the right (default value is -5px).
+          right: 'calc(-5px - 0.5rem)',
+          // Render the resize component above the editor so that it can be selected.
+          zIndex: 1
+        }
+      },
       enable: rightResizeOnly,
       maxWidth: '50%'
     } as ResizableProps;

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -53,7 +53,7 @@ const Workspace: React.FC<WorkspaceProps> = props => {
 
   const sideBarResizableProps = () => {
     return {
-      enable: rightResizeOnly,
+      enable: props.sideBarProps.tabs.length === 0 ? noResize : rightResizeOnly,
       maxWidth: '50%'
     } as ResizableProps;
   };
@@ -165,6 +165,17 @@ const Workspace: React.FC<WorkspaceProps> = props => {
       </div>
     </div>
   );
+};
+
+const noResize = {
+  top: false,
+  right: false,
+  bottom: false,
+  left: false,
+  topRight: false,
+  bottomRight: false,
+  bottomLeft: false,
+  topLeft: false
 };
 
 const rightResizeOnly = {

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -794,10 +794,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     handleSideContentHeightChange: props.handleSideContentHeightChange,
     replProps: replProps,
     sideBarProps: {
-      tabs: [
-        { label: 'Files', body: <FileSystemView basePath="/playground" /> },
-        { label: 'Test', body: <></> }
-      ]
+      tabs: [{ label: 'Files', body: <FileSystemView basePath="/playground" /> }]
     },
     sideContentHeight: props.sideContentHeight,
     sideContentProps: {

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -794,7 +794,10 @@ const Playground: React.FC<PlaygroundProps> = props => {
     handleSideContentHeightChange: props.handleSideContentHeightChange,
     replProps: replProps,
     sideBarProps: {
-      tabs: [{ label: 'Files', body: <FileSystemView basePath="/playground" /> }]
+      tabs: [
+        { label: 'Files', body: <FileSystemView basePath="/playground" /> },
+        { label: 'Test', body: <></> }
+      ]
     },
     sideContentHeight: props.sideContentHeight,
     sideContentProps: {

--- a/src/styles/_sideBar.scss
+++ b/src/styles/_sideBar.scss
@@ -1,6 +1,7 @@
 .sidebar-container {
   height: 100%;
   padding-bottom: 0.6rem;
+  padding-right: 0.5rem;
   display: flex;
   flex-direction: row;
   column-gap: 8px;

--- a/src/styles/_sideBar.scss
+++ b/src/styles/_sideBar.scss
@@ -1,4 +1,5 @@
 .sidebar-container {
+  height: 100%;
   padding-bottom: 0.6rem;
   display: flex;
   flex-direction: row;
@@ -44,6 +45,8 @@
 .panel {
   // !important is necessary to override the default Card background-color property.
   background-color: $cadet-color-2 !important;
-  width: 200px;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
   padding: 0;
 }

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -710,7 +710,7 @@ $code-color-error: #ff4444;
 
     .Editor {
       flex: 1 1 auto;
-      margin: 0 0.5rem 0 0.5rem;
+      margin: 0 0.5rem 0 0;
       padding: 0;
     }
 


### PR DESCRIPTION
### Description

![vmconnect_JPUJvc2G44](https://user-images.githubusercontent.com/5585517/196027079-7d3dd043-1634-4de1-9dae-fe85d9dcd536.gif)

Also update the editor resize calculations to not depend on the width of the window through the introduction of the `useDimensions` hook.

Part of #2176.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

To test with multiple sidebar tabs, add the deleted lines in https://github.com/source-academy/frontend/commit/e51d0fe244f4dbacc6fb02c76c8c563f35a58be2 to your local `src/pages/playground/Playground.tsx`.

* On a page where the sidebar is disabled, test that the behaviour is the same as before.
* On a page where the sidebar is enabled (currently only playground), test that you can properly resize both the sidebar and the editor.
  * When the sidebar is collapsed and expanded, it will take on the last non-collapsed width that it had at rest.