### PR TITLE
Hook up sidebar tabs to mobile view & add icons to sidebar tabs

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -807,15 +807,16 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
     externalLibrary: question?.library?.external?.name || 'NONE',
     replButtons: replButtons()
   };
+  const sideBarProps = {
+    tabs: []
+  };
   const workspaceProps: WorkspaceProps = {
     controlBarProps: controlBarProps(questionId),
     editorProps: editorProps,
     handleSideContentHeightChange: props.handleSideContentHeightChange,
     hasUnsavedChanges: props.hasUnsavedChanges,
     mcqProps: mcqProps,
-    sideBarProps: {
-      tabs: []
-    },
+    sideBarProps: sideBarProps,
     sideContentHeight: props.sideContentHeight,
     sideContentProps: sideContentProps(props, questionId),
     replProps: replProps
@@ -825,6 +826,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
     hasUnsavedChanges: props.hasUnsavedChanges,
     mcqProps: mcqProps,
     replProps: replProps,
+    sideBarProps: sideBarProps,
     mobileSideContentProps: mobileSideContentProps(questionId)
   };
 

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -196,6 +196,9 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
     }
   };
 
+  // Convert sidebar tabs with a side content tab ID into side content tabs.
+  const sideBarTabs: SideContentTab[] = props.sideBarProps.tabs.filter(tab => tab.id !== undefined);
+
   const mobileEditorTab: SideContentTab = React.useMemo(
     () => ({
       label: 'Editor',
@@ -229,6 +232,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
       },
       tabs: {
         beforeDynamicTabs: [
+          ...sideBarTabs,
           mobileEditorTab,
           ...props.mobileSideContentProps.tabs.beforeDynamicTabs
         ],

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -10,6 +10,7 @@ import ControlBar from '../controlBar/ControlBar';
 import Editor, { EditorProps } from '../editor/Editor';
 import McqChooser, { McqChooserProps } from '../mcqChooser/McqChooser';
 import { ReplProps } from '../repl/Repl';
+import { SideBarTab } from '../sideBar/SideBar';
 import { SideContentTab, SideContentType } from '../sideContent/SideContentTypes';
 import DraggableRepl from './DraggableRepl';
 import MobileKeyboard from './MobileKeyboard';
@@ -33,6 +34,9 @@ type StateProps = {
   hasUnsavedChanges?: boolean; // Not used in Playground
   mcqProps?: McqChooserProps; // Not used in Playground
   replProps: ReplProps;
+  sideBarProps: {
+    tabs: SideBarTab[];
+  };
   mobileSideContentProps: MobileSideContentProps;
 };
 

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -184,8 +184,9 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
       handleHideRepl();
     }
 
-    // Disable draggable REPL when on the stepper tab.
+    // Disable draggable REPL when on the files & stepper tab.
     if (
+      newTabId === SideContentType.files ||
       newTabId === SideContentType.substVisualizer ||
       (prevTabId === SideContentType.substVisualizer &&
         newTabId === SideContentType.mobileEditorRun)

--- a/src/commons/sideBar/SideBar.tsx
+++ b/src/commons/sideBar/SideBar.tsx
@@ -2,10 +2,20 @@ import { Card, Icon, IconName } from '@blueprintjs/core';
 import classNames from 'classnames';
 import React from 'react';
 
+import { SideContentType } from '../sideContent/SideContentTypes';
+
+/**
+ * @property label The displayed name of the tab.
+ * @property body The element to be rendered inside the sidebar tab.
+ * @property iconName The name of the displayed icon.
+ * @property id The ID of the tab when displayed as a side content on the mobile view.
+ *              Omit if the tab should only be shown in the sidebar on the desktop view.
+ */
 export type SideBarTab = {
   label: string;
   body: JSX.Element;
   iconName: IconName;
+  id?: SideContentType;
 };
 
 export type SideBarProps = {

--- a/src/commons/sideBar/SideBar.tsx
+++ b/src/commons/sideBar/SideBar.tsx
@@ -1,10 +1,11 @@
-import { Card } from '@blueprintjs/core';
+import { Card, Icon, IconName } from '@blueprintjs/core';
 import classNames from 'classnames';
 import React from 'react';
 
 export type SideBarTab = {
   label: string;
   body: JSX.Element;
+  iconName: IconName;
 };
 
 export type SideBarProps = {
@@ -46,6 +47,7 @@ const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
             className={classNames('tab', { selected: isExpanded && selectedTabIndex === index })}
             onClick={() => handleTabSelection(index)}
           >
+            <Icon className="tab-icon" icon={tab.iconName} size={14} />
             {tab.label}
           </Card>
         ))}

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -21,6 +21,7 @@ export enum SideContentType {
   editorQuestionOverview = 'editor_question_overview',
   editorQuestionTemplate = 'editor_question_template',
   envVisualizer = 'env_visualizer',
+  files = 'files',
   grading = 'grading',
   introduction = 'introduction',
   module = 'module',

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -1084,15 +1084,16 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
     externalLibrary: ExternalLibraryName.NONE,
     replButtons: replButtons()
   };
+  const sideBarProps = {
+    tabs: []
+  };
   const workspaceProps: WorkspaceProps = {
     controlBarProps: controlBarProps(),
     editorProps: currentTaskIsMCQ && displayMCQInEditor ? undefined : editorProps,
     handleSideContentHeightChange: props.handleSideContentHeightChange,
     hasUnsavedChanges: hasUnsavedChanges,
     mcqProps: mcqProps,
-    sideBarProps: {
-      tabs: []
-    },
+    sideBarProps: sideBarProps,
     sideContentHeight: props.sideContentHeight,
     sideContentProps: sideContentProps(props),
     replProps: replProps
@@ -1100,6 +1101,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
   const mobileWorkspaceProps: MobileWorkspaceProps = {
     editorProps: currentTaskIsMCQ && displayMCQInEditor ? undefined : editorProps,
     replProps: replProps,
+    sideBarProps: sideBarProps,
     hasUnsavedChanges: hasUnsavedChanges,
     mcqProps: mcqProps,
     mobileSideContentProps: mobileSideContentProps()

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -774,6 +774,10 @@ const Playground: React.FC<PlaygroundProps> = props => {
     disableScrolling: isSicpEditor
   };
 
+  const sideBarProps = {
+    tabs: [{ label: 'Files', body: <FileSystemView basePath="/playground" /> }]
+  };
+
   const workspaceProps: WorkspaceProps = {
     controlBarProps: {
       editorButtons: [
@@ -793,9 +797,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
     editorProps: editorProps,
     handleSideContentHeightChange: props.handleSideContentHeightChange,
     replProps: replProps,
-    sideBarProps: {
-      tabs: [{ label: 'Files', body: <FileSystemView basePath="/playground" /> }]
-    },
+    sideBarProps: sideBarProps,
     sideContentHeight: props.sideContentHeight,
     sideContentProps: {
       selectedTabId: selectedTab,
@@ -813,6 +815,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
   const mobileWorkspaceProps: MobileWorkspaceProps = {
     editorProps: editorProps,
     replProps: replProps,
+    sideBarProps: sideBarProps,
     mobileSideContentProps: {
       mobileControlBarProps: {
         editorButtons: [

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -775,7 +775,13 @@ const Playground: React.FC<PlaygroundProps> = props => {
   };
 
   const sideBarProps = {
-    tabs: [{ label: 'Files', body: <FileSystemView basePath="/playground" /> }]
+    tabs: [
+      {
+        label: 'Files',
+        body: <FileSystemView basePath="/playground" />,
+        iconName: IconNames.FOLDER_CLOSE
+      }
+    ]
   };
 
   const workspaceProps: WorkspaceProps = {

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -779,7 +779,8 @@ const Playground: React.FC<PlaygroundProps> = props => {
       {
         label: 'Files',
         body: <FileSystemView basePath="/playground" />,
-        iconName: IconNames.FOLDER_CLOSE
+        iconName: IconNames.FOLDER_CLOSE,
+        id: SideContentType.files
       }
     ]
   };

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -296,6 +296,10 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
     replButtons: [evalButton, clearButton]
   };
 
+  const sideBarProps = {
+    tabs: []
+  };
+
   const workspaceProps: WorkspaceProps = {
     controlBarProps: {
       editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect]
@@ -303,9 +307,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
     customEditor: <SourceRecorderEditor {...editorProps} />,
     handleSideContentHeightChange: props.handleSideContentHeightChange,
     replProps: replProps,
-    sideBarProps: {
-      tabs: []
-    },
+    sideBarProps: sideBarProps,
     sideContentHeight: props.sideContentHeight,
     sideContentProps: {
       selectedTabId: selectedTab,
@@ -327,6 +329,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
       />
     ),
     replProps: replProps,
+    sideBarProps: sideBarProps,
     mobileSideContentProps: {
       mobileControlBarProps: {
         editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect]

--- a/src/styles/_sideBar.scss
+++ b/src/styles/_sideBar.scss
@@ -36,11 +36,20 @@
   // !important is necessary to override the default Card background-color property.
   background-color: $cadet-color-2 !important;
   user-select: none;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  column-gap: 6px;
+  text-align: center;
 
   &.selected {
     // !important is necessary to override the default Card background-color property.
     background-color: $cadet-color-1 !important;
   }
+}
+
+.tab-icon {
+  transform: rotate(90deg);
 }
 
 .panel {


### PR DESCRIPTION
### Description

Hook up sidebar tabs to the mobile view.
![image](https://user-images.githubusercontent.com/5585517/196104929-79e28141-5c81-4d26-9652-b66f9d4d3ba9.png)
Sidebar tabs are only displayed in the mobile view (as normal side content tabs) if they have an `id` specified:
https://github.com/source-academy/frontend/blob/7748c8a8c6ac447c1f48128fe8cc70be23b3e247/src/commons/mobileWorkspace/MobileWorkspace.tsx#L200-L201

Also add icons to sidebar tabs (since side content tabs require them anyway).
![image](https://user-images.githubusercontent.com/5585517/196105311-080d1337-f30d-42f2-99c2-5140f76b3454.png)

In the mobile view, long presses are converted into the equivalent of right clicks on the desktop view by most browsers.

Part of #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Use the developer tools to force the mobile view and verify that the file system view has all of the functionality of the desktop view as described in #2236.