### PR TITLE
Fix GitHub persistence feature only retrieving 30 repositories

### DIFF
--- a/src/commons/sagas/GitHubPersistenceSaga.ts
+++ b/src/commons/sagas/GitHubPersistenceSaga.ts
@@ -77,6 +77,7 @@ function* githubOpenFile(): any {
   const userRepos: ListForAuthenticatedUserData = yield call(
     async () =>
       await octokit.paginate(octokit.repos.listForAuthenticatedUser, {
+        // 100 is the maximum number of results that can be retrieved per page.
         per_page: 100
       })
   );
@@ -146,6 +147,7 @@ function* githubSaveFileAs(): any {
   const userRepos: ListForAuthenticatedUserData = yield call(
     async () =>
       await octokit.paginate(octokit.repos.listForAuthenticatedUser, {
+        // 100 is the maximum number of results that can be retrieved per page.
         per_page: 100
       })
   );

--- a/src/commons/sagas/GitHubPersistenceSaga.ts
+++ b/src/commons/sagas/GitHubPersistenceSaga.ts
@@ -66,10 +66,10 @@ function* githubLogoutSaga() {
 }
 
 function* githubOpenFile(): any {
-  const octokit = GitHubUtils.getGitHubOctokitInstance() || {
-    users: { getAuthenticated: () => {} },
-    repos: { listForAuthenticatedUser: () => {} }
-  };
+  const octokit = GitHubUtils.getGitHubOctokitInstance();
+  if (octokit === undefined) {
+    return;
+  }
 
   type ListForAuthenticatedUserData = GetResponseDataTypeFromEndpointMethod<
     typeof octokit.repos.listForAuthenticatedUser
@@ -135,10 +135,10 @@ function* githubSaveFile(): any {
 }
 
 function* githubSaveFileAs(): any {
-  const octokit = GitHubUtils.getGitHubOctokitInstance() || {
-    users: { getAuthenticated: () => {} },
-    repos: { listForAuthenticatedUser: () => {} }
-  };
+  const octokit = GitHubUtils.getGitHubOctokitInstance();
+  if (octokit === undefined) {
+    return;
+  }
 
   type ListForAuthenticatedUserData = GetResponseDataTypeFromEndpointMethod<
     typeof octokit.repos.listForAuthenticatedUser

--- a/src/commons/sagas/GitHubPersistenceSaga.ts
+++ b/src/commons/sagas/GitHubPersistenceSaga.ts
@@ -71,17 +71,15 @@ function* githubOpenFile(): any {
     repos: { listForAuthenticatedUser: () => {} }
   };
 
-  type ListForAuthenticatedUserResponse = GetResponseTypeFromEndpointMethod<
-    typeof octokit.repos.listForAuthenticatedUser
-  >;
-  const results: ListForAuthenticatedUserResponse = yield call(
-    octokit.repos.listForAuthenticatedUser
-  );
-
   type ListForAuthenticatedUserData = GetResponseDataTypeFromEndpointMethod<
     typeof octokit.repos.listForAuthenticatedUser
   >;
-  const userRepos: ListForAuthenticatedUserData = results.data;
+  const userRepos: ListForAuthenticatedUserData = yield call(
+    async () =>
+      await octokit.paginate(octokit.repos.listForAuthenticatedUser, {
+        per_page: 100
+      })
+  );
 
   const getRepoName = async () =>
     await promisifyDialog<RepositoryDialogProps, string>(RepositoryDialog, resolve => ({
@@ -142,17 +140,15 @@ function* githubSaveFileAs(): any {
     repos: { listForAuthenticatedUser: () => {} }
   };
 
-  type ListForAuthenticatedUserResponse = GetResponseTypeFromEndpointMethod<
-    typeof octokit.repos.listForAuthenticatedUser
-  >;
-  const results: ListForAuthenticatedUserResponse = yield call(
-    octokit.repos.listForAuthenticatedUser
-  );
-
   type ListForAuthenticatedUserData = GetResponseDataTypeFromEndpointMethod<
     typeof octokit.repos.listForAuthenticatedUser
   >;
-  const userRepos: ListForAuthenticatedUserData = results.data;
+  const userRepos: ListForAuthenticatedUserData = yield call(
+    async () =>
+      await octokit.paginate(octokit.repos.listForAuthenticatedUser, {
+        per_page: 100
+      })
+  );
 
   const getRepoName = async () =>
     await promisifyDialog<RepositoryDialogProps, string>(RepositoryDialog, resolve => ({


### PR DESCRIPTION
### Description

By default, [GitHub's API for listing the repositories for the authenticated user](https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user) retrieves only 30 results per page, sorted by repository name. This means that GitHub accounts with more than 30 repositories will only be able to choose between a subset of the available repositories when using the GitHub persistence feature.

The Source Academy makes use of the [GitHub SDK octokit.js](https://github.com/octokit/octokit.js). As such, we can easily query for all results of any particular API endpoint using the [pagination API](https://github.com/octokit/octokit.js#pagination). Since API calls using the pagination API is sequential (i.e., the previous API response needs to be received before the pagination API knows whether it needs to query for the next page of results), we also increase the number of results per page to 100 (the maximum allowed) so as to speed up the retrieving of repositories.

Fixes #2245.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Follow the instructions [here](https://github.com/source-academy/frontend/wiki/GitHub-Integration:-Initial-Set-up) to set up OAuth for `localhost`.
1. Login to a GitHub account with more than 30 repositories.
1. Verify that all repositories appear in the user's repository lists.

Example network log (with the results per page temporarily set to 30 instead of 100 to show that the pagination is working):
![image](https://user-images.githubusercontent.com/5585517/199939276-fb2f1052-4d98-4b0a-8468-1ed67107dcbe.png)