### PR TITLE
Make editor value non-nullable

### DIFF
--- a/src/commons/assessment/AssessmentTypes.ts
+++ b/src/commons/assessment/AssessmentTypes.ts
@@ -129,7 +129,7 @@ export type BaseQuestion = {
   answer: string | number | ContestEntry[] | null;
   comments?: string;
   content: string;
-  editorValue?: string | null;
+  editorValue?: string;
   gradedAt?: string;
   grader?: {
     name: string;

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -110,7 +110,7 @@ export type StateProps = {
   assessment?: Assessment;
   autogradingResults: AutogradingResult[];
   editorPrepend: string;
-  editorValue: string | null;
+  editorValue: string;
   editorPostpend: string;
   editorTestcases: Testcase[];
   breakpoints: string[];
@@ -580,7 +580,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
     };
 
     const onClickSave = () =>
-      props.handleSave(props.assessment!.questions[questionId].id, props.editorValue!);
+      props.handleSave(props.assessment!.questions[questionId].id, props.editorValue);
 
     const onClickResetTemplate = () => {
       setShowResetTemplateOverlay(true);
@@ -771,7 +771,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
     question.type === QuestionTypes.programming || question.type === QuestionTypes.voting
       ? {
           editorSessionId: '',
-          editorValue: props.editorValue!,
+          editorValue: props.editorValue,
           sourceChapter: question.library.chapter || Chapter.SOURCE_4,
           sourceVariant: question.library.variant ?? Variant.DEFAULT,
           externalLibrary: question.library.external.name || 'NONE',

--- a/src/commons/assessmentWorkspace/__tests__/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/__tests__/AssessmentWorkspace.tsx
@@ -27,7 +27,7 @@ const defaultProps: AssessmentWorkspaceProps = {
     earlySubmissionXp: 200
   },
   editorPrepend: '',
-  editorValue: null,
+  editorValue: '',
   editorPostpend: '',
   editorTestcases: [],
   breakpoints: [],

--- a/src/commons/controlBar/ControlBarSessionButton.tsx
+++ b/src/commons/controlBar/ControlBarSessionButton.tsx
@@ -16,7 +16,7 @@ type DispatchProps = {
 
 type StateProps = {
   editorSessionId?: string;
-  editorValue?: string | null;
+  editorValue: string;
   sharedbConnected?: boolean;
   key: string;
 };

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -93,7 +93,7 @@ export type OwnProps = {
 };
 
 export type StateProps = {
-  editorValue: string | null;
+  editorValue: string;
   breakpoints: string[];
   highlightedLines: HighlightedLines[];
   hasUnsavedChanges: boolean;

--- a/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentProgrammingQuestionTemplateTab.tsx
+++ b/src/commons/editingWorkspaceSideContent/EditingWorkspaceSideContentProgrammingQuestionTemplateTab.tsx
@@ -19,7 +19,7 @@ type DispatchProps = {
 
 type StateProps = {
   assessment: Assessment;
-  editorValue: string | null;
+  editorValue: string;
   questionId: number;
 };
 

--- a/src/commons/sagas/GitHubPersistenceSaga.ts
+++ b/src/commons/sagas/GitHubPersistenceSaga.ts
@@ -159,7 +159,7 @@ function* githubSaveFileAs(): any {
     }));
   const repoName = yield call(getRepoName);
 
-  const editorContent = store.getState().workspaces.playground.editorValue || '';
+  const editorContent = store.getState().workspaces.playground.editorValue;
 
   if (repoName !== '') {
     const pickerType = 'Save';

--- a/src/commons/sagas/PlaygroundSaga.ts
+++ b/src/commons/sagas/PlaygroundSaga.ts
@@ -55,14 +55,13 @@ export default function* PlaygroundSaga(): SagaIterator {
 }
 
 function* updateQueryString() {
-  const code: string | null = yield select(
+  const code: string = yield select(
     (state: OverallState) => state.workspaces.playground.editorValue
   );
   if (!code || code === defaultEditorValue) {
     yield put(changeQueryString(''));
     return;
   }
-  const codeString: string = code as string;
   const chapter: Chapter = yield select(
     (state: OverallState) => state.workspaces.playground.context.chapter
   );
@@ -76,7 +75,7 @@ function* updateQueryString() {
     (state: OverallState) => state.workspaces.playground.execTime
   );
   const newQueryString: string = qs.stringify({
-    prgrm: compressToEncodedURIComponent(codeString),
+    prgrm: compressToEncodedURIComponent(code),
     chap: chapter,
     variant,
     ext: external,

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -113,7 +113,7 @@ export default function* WorkspaceSaga(): SagaIterator {
 
       const code: string = yield select((state: OverallState) => {
         const prependCode = state.workspaces[workspaceLocation].editorPrepend;
-        const editorCode = state.workspaces[workspaceLocation].editorValue!;
+        const editorCode = state.workspaces[workspaceLocation].editorValue;
         return [prependCode, editorCode] as [string, string];
       });
       const [prepend, editorValue] = code;
@@ -544,7 +544,7 @@ export function* evalEditor(
     DeviceSession | undefined
   ] = yield select((state: OverallState) => [
     state.workspaces[workspaceLocation].editorPrepend,
-    state.workspaces[workspaceLocation].editorValue!,
+    state.workspaces[workspaceLocation].editorValue,
     state.workspaces[workspaceLocation].execTime,
     state.session.remoteExecutionSession
   ]);
@@ -608,7 +608,7 @@ export function* runTestCase(
   const [prepend, value, postpend, testcase]: [string, string, string, string] = yield select(
     (state: OverallState) => {
       const prepend = state.workspaces[workspaceLocation].editorPrepend;
-      const value = state.workspaces[workspaceLocation].editorValue!;
+      const value = state.workspaces[workspaceLocation].editorValue;
       const postpend = state.workspaces[workspaceLocation].editorPostpend;
       const testcase = state.workspaces[workspaceLocation].editorTestcases[index].program;
       return [prepend, value, postpend, testcase] as [string, string, string, string];

--- a/src/commons/workspace/WorkspaceTypes.ts
+++ b/src/commons/workspace/WorkspaceTypes.ts
@@ -85,7 +85,7 @@ export type WorkspaceState = {
   readonly editorPrepend: string;
   readonly editorReadonly: boolean;
   readonly editorSessionId: string;
-  readonly editorValue: string | null;
+  readonly editorValue: string;
   readonly editorPostpend: string;
   readonly editorTestcases: Testcase[];
   readonly execTime: number;

--- a/src/features/github/GitHubUtils.tsx
+++ b/src/features/github/GitHubUtils.tsx
@@ -206,7 +206,7 @@ export async function performOverwritingSave(
   githubName: string | null,
   githubEmail: string | null,
   commitMessage: string,
-  content: string | null
+  content: string
 ) {
   if (octokit === undefined) return;
 
@@ -261,7 +261,7 @@ export async function performCreatingSave(
   githubName: string | null,
   githubEmail: string | null,
   commitMessage: string,
-  content: string | null
+  content: string
 ) {
   if (octokit === undefined) return;
 

--- a/src/pages/academy/grading/subcomponents/GradingEditor.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingEditor.tsx
@@ -182,7 +182,7 @@ class GradingEditor extends React.Component<GradingEditorProps, State> {
 
         <div className="react-mde-parent">
           <ReactMde
-            value={this.state.editorValue || ''}
+            value={this.state.editorValue}
             onChange={this.handleEditorValueChange}
             selectedTab={this.state.selectedTab}
             onTabChange={onTabChange}

--- a/src/pages/academy/grading/subcomponents/GradingEditor.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingEditor.tsx
@@ -275,7 +275,7 @@ class GradingEditor extends React.Component<GradingEditorProps, State> {
           this.props.submissionId,
           this.props.questionId,
           xpAdjustmentInput,
-          this.state.editorValue!
+          this.state.editorValue
         );
       }
     };

--- a/src/pages/academy/grading/subcomponents/GradingEditor.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingEditor.tsx
@@ -47,7 +47,7 @@ type OwnProps = {
   xpAdjustment: number;
   maxXp: number;
   studentName: string;
-  comments?: string;
+  comments: string;
   graderName?: string;
   gradedAt?: string;
 };
@@ -78,7 +78,7 @@ type OwnProps = {
  */
 type State = {
   xpAdjustmentInput: string | null;
-  editorValue?: string;
+  editorValue: string;
   selectedTab: ReactMdeProps['selectedTab'];
   currentlySaving: boolean;
 };
@@ -322,7 +322,7 @@ class GradingEditor extends React.Component<GradingEditorProps, State> {
         {
           ...this.state,
           xpAdjustmentInput: this.props.xpAdjustment!.toString(),
-          editorValue: this.props.comments || ''
+          editorValue: this.props.comments
         },
         () => {
           showSuccessMessage('Discarded!', 1000);

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -75,7 +75,7 @@ export type StateProps = {
   autogradingResults: AutogradingResult[];
   grading?: Grading;
   editorPrepend: string;
-  editorValue: string | null;
+  editorValue: string;
   editorPostpend: string;
   editorTestcases: Testcase[];
   breakpoints: string[];
@@ -188,7 +188,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
         question.type === QuestionTypes.programming || question.type === QuestionTypes.voting
           ? {
               editorSessionId: '',
-              editorValue: this.props.editorValue!,
+              editorValue: this.props.editorValue,
               handleDeclarationNavigate: this.props.handleDeclarationNavigate,
               handleEditorEval: this.handleEval,
               handleEditorValueChange: this.props.handleEditorValueChange,

--- a/src/pages/academy/sourcereel/SourcereelContainer.ts
+++ b/src/pages/academy/sourcereel/SourcereelContainer.ts
@@ -64,7 +64,7 @@ const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => 
   codeDeltasToApply: state.workspaces.sourcecast.codeDeltasToApply,
   breakpoints: state.workspaces.sourcereel.breakpoints,
   editorReadonly: state.workspaces.sourcereel.editorReadonly,
-  editorValue: state.workspaces.sourcereel.editorValue!,
+  editorValue: state.workspaces.sourcereel.editorValue,
   enableDebugging: state.workspaces.sourcereel.enableDebugging,
   externalLibraryName: state.workspaces.sourcereel.externalLibrary,
   highlightedLines: state.workspaces.sourcereel.highlightedLines,

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -108,7 +108,7 @@ export type DispatchProps = {
 
 export type StateProps = {
   editorPrepend: string;
-  editorValue: string | null;
+  editorValue: string;
   editorTestcases: Testcase[];
   editorPostpend: string;
   breakpoints: string[];
@@ -1060,7 +1060,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
 
   const editorProps = {
     editorSessionId: '',
-    editorValue: props.editorValue!,
+    editorValue: props.editorValue,
     handleDeclarationNavigate: props.handleDeclarationNavigate,
     handleEditorEval: handleEval,
     handleEditorValueChange: onEditorValueChange,

--- a/src/pages/localStorage.ts
+++ b/src/pages/localStorage.ts
@@ -10,7 +10,7 @@ import { AchievementItem } from '../features/achievement/AchievementTypes';
 export type SavedState = {
   session: Partial<SessionState>;
   achievements: AchievementItem[];
-  playgroundEditorValue: string | null;
+  playgroundEditorValue: string;
   playgroundIsEditorAutorun: boolean;
   playgroundSourceChapter: number;
   playgroundSourceVariant: Variant;

--- a/src/pages/playground/PlaygroundContainer.ts
+++ b/src/pages/playground/PlaygroundContainer.ts
@@ -61,7 +61,7 @@ import Playground, { DispatchProps, StateProps } from './Playground';
 
 const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => ({
   editorSessionId: state.workspaces.playground.editorSessionId,
-  editorValue: state.workspaces.playground.editorValue!,
+  editorValue: state.workspaces.playground.editorValue,
   execTime: state.workspaces.playground.execTime,
   stepLimit: state.workspaces.playground.stepLimit,
   isEditorAutorun: state.workspaces.playground.isEditorAutorun,

--- a/src/pages/sicp/subcomponents/SicpWorkspaceContainer.tsx
+++ b/src/pages/sicp/subcomponents/SicpWorkspaceContainer.tsx
@@ -63,7 +63,7 @@ import Playground, { DispatchProps, StateProps } from '../../playground/Playgrou
 
 const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => ({
   editorSessionId: state.workspaces.sicp.editorSessionId,
-  editorValue: state.workspaces.sicp.editorValue!,
+  editorValue: state.workspaces.sicp.editorValue,
   execTime: state.workspaces.sicp.execTime,
   stepLimit: state.workspaces.sicp.stepLimit,
   isEditorAutorun: state.workspaces.sicp.isEditorAutorun,

--- a/src/pages/sourcecast/SourcecastContainer.ts
+++ b/src/pages/sourcecast/SourcecastContainer.ts
@@ -54,7 +54,7 @@ const mapStateToProps: MapStateToProps<StateProps, {}, OverallState> = state => 
   title: state.workspaces.sourcecast.title,
   description: state.workspaces.sourcecast.description,
   editorReadonly: state.workspaces.sourcecast.editorReadonly,
-  editorValue: state.workspaces.sourcecast.editorValue!,
+  editorValue: state.workspaces.sourcecast.editorValue,
   externalLibraryName: state.workspaces.sourcecast.externalLibrary,
   isEditorAutorun: state.workspaces.sourcecast.isEditorAutorun,
   inputToApply: state.workspaces.sourcecast.inputToApply,


### PR DESCRIPTION
### Description

There is no reason for the editor value to be nullable. Semantically, there is no difference between an editor value that is `null` and the empty string because the editor is always present. In future, to have multiple-files support, there can be any number of editors (including 0), but there should only ever be one and only one editor value for every editor.

The very fact that non-null assertions are placed in all of the workspace containers is a huge code smell that indicates that the `editorValue` field should not be nullable.

Part of the refactoring for #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

There should not be any change in behaviour.