### PR TITLE
Add Source 1 Typed variant

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -110,6 +110,7 @@ export interface SALanguage extends Language {
 }
 
 const variantDisplay: Map<Variant, string> = new Map([
+  [Variant.TYPED, 'Typed'],
   [Variant.WASM, 'WebAssembly'],
   [Variant.NON_DET, 'Non-Det'],
   [Variant.CONCURRENT, 'Concurrent'],
@@ -145,6 +146,7 @@ export const styliseSublanguage = (chapter: Chapter, variant: Variant = Variant.
 
 export const sublanguages: Language[] = [
   { chapter: Chapter.SOURCE_1, variant: Variant.DEFAULT },
+  { chapter: Chapter.SOURCE_1, variant: Variant.TYPED },
   { chapter: Chapter.SOURCE_1, variant: Variant.WASM },
   { chapter: Chapter.SOURCE_1, variant: Variant.LAZY },
   { chapter: Chapter.SOURCE_1, variant: Variant.NATIVE },


### PR DESCRIPTION
### Description

Adds Source 1 Typed variant to the frontend.

PR marked as draft until source-academy/js-slang#1314 is merged and js-slang version is bumped. For now, this PR serves to aid in the testing of source-academy/js-slang#1314.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Checkout js-slang to source-academy/js-slang#1314, [link local js-slang to local frontend](https://github.com/source-academy/js-slang#using-your-js-slang-in-your-local-source-academy), and start the frontend locally. The Source 1 Typed variant should now be available as a selection. Switch to Source 1 Typed and test by writing code with typed syntax.

![image](https://user-images.githubusercontent.com/54243224/205575488-6e492551-be76-4025-88c4-7cb3d8ccb727.png)