### PR TITLE
Add type checking to pre-push hook

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,11 +7,13 @@ main() {
     echo "  If you cancel this pre-push hook, use \`git stash pop\` to retrieve your"
     echo "  unstaged changes."
 
+    tsc="yarn run tsc"
     eslint="yarn run eslint"
     prettier_ts="yarn run format:tsx"
     prettier_scss="yarn run format:scss"
     jest_ts="yarn test"
 
+    run_cmd "${tsc}"; tsc_exit=$?
     run_cmd "${eslint}"; eslint_exit=$?
     run_cmd "${prettier_ts}"; prettier_ts_exit=$?
     run_cmd "${prettier_scss}"; prettier_scss_exit=$?
@@ -21,6 +23,7 @@ main() {
 
     ( >&2
         echo -ne "\033[0;31m"
+        [ "${tsc_exit}" -eq "0" ] || echo "TSC failed"
         [ "${eslint_exit}" -eq "0" ] || echo "ESLint failed"
         [ "${prettier_ts_exit}" -eq "0" ] || echo "Prettier failed for *.{ts,tsx}"
         [ "${prettier_scss_exit}" -eq "0" ] || echo "Prettier failed for *.scss"
@@ -28,7 +31,7 @@ main() {
         echo -ne "\033[0m"
     )
 
-    [[ $(( eslint_exit + prettier_ts_exit + prettier_scss_exit + jest_ts_exit )) -eq "0" ]]
+    [[ $(( tsc_exit + eslint_exit + prettier_ts_exit + prettier_scss_exit + jest_ts_exit )) -eq "0" ]]
 }
 
 run_cmd() {


### PR DESCRIPTION
### Description

The current CI pipeline type checks all files:
https://github.com/source-academy/frontend/blob/91aaaffce1fd34fd10d4b5cefd0b1b7794f79a00/.github/workflows/ci.yml#L28-L39

But the Git pre-push hook does not:
https://github.com/source-academy/frontend/blob/91aaaffce1fd34fd10d4b5cefd0b1b7794f79a00/scripts/test.sh#L10-L18

This leads to type errors in tests that do not otherwise affect the correctness of the tests not being caught by the pre-push hook. To align the pre-push hook behaviour with that of the CI pipeline, we run the TypeScript compiler to check for type errors in all files before a `git push`.

Resolves #2266.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

On the `master` branch, make a temporary commit that contains a type error in any test file. The commit is necessary because the pre-push hook stashes uncommitted changes before running the checks. Then, run:
```bash
./.husky/pre-push; echo $?
```

This will manually trigger the pre-push hook. The return value of the hook, as printed to console by `echo $?`, should be 0, indicating that the type error in the test file was not caught.

Repeat the steps above, but on the branch associated with this PR. The return value should now be a non-zero value.