### PR TITLE
Do not reset breakpoints on program evaluation

### DIFF
--- a/src/commons/workspace/WorkspaceReducer.ts
+++ b/src/commons/workspace/WorkspaceReducer.ts
@@ -354,9 +354,7 @@ export const WorkspaceReducer: Reducer<WorkspaceManagerState> = (
           output: newOutput,
           isRunning: false,
           // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-          editorTabs: [
-            { ...state[workspaceLocation].editorTabs[0], highlightedLines: [], breakpoints: [] }
-          ]
+          editorTabs: [{ ...state[workspaceLocation].editorTabs[0], highlightedLines: [] }]
         }
       };
     case EVAL_TESTCASE_SUCCESS:

--- a/src/commons/workspace/__tests__/WorkspaceReducer.ts
+++ b/src/commons/workspace/__tests__/WorkspaceReducer.ts
@@ -685,7 +685,7 @@ describe('EVAL_INTERPRETER_SUCCESS', () => {
         [location]: {
           ...evalEditorDefaultState[location],
           isRunning: false,
-          editorTabs: [{ highlightedLines: [], breakpoints: [] }],
+          editorTabs: [{ ...evalEditorDefaultState[location].editorTabs[0], highlightedLines: [] }],
           output: [
             {
               ...outputWithRunningOutput[0]
@@ -720,7 +720,7 @@ describe('EVAL_INTERPRETER_SUCCESS', () => {
         [location]: {
           ...evalEditorDefaultState[location],
           isRunning: false,
-          editorTabs: [{ highlightedLines: [], breakpoints: [] }],
+          editorTabs: [{ ...evalEditorDefaultState[location].editorTabs[0], highlightedLines: [] }],
           output: [
             {
               ...outputWithRunningAndCodeOutput[0]


### PR DESCRIPTION
### Description

Prior to the refactoring in #2269, the `WorkspaceReducer` logic for the `EVAL_INTERPRETER_SUCCESS` action resets the state of `breakpoints` to an empty array:
https://github.com/source-academy/frontend/blob/78ff16511385a31e8e66fbfd72a3e201cbbbe8bc/src/commons/workspace/WorkspaceReducer.ts#L334-L358

As part of the refactoring in @2269, the returned state was updated to move `breakpoints` into the `editorTabs` array in preparation for multiple editor tabs:
https://github.com/source-academy/frontend/blob/9d11d8ac0e80779c3c906e7235a51145a389ebb2/src/commons/workspace/WorkspaceReducer.ts#L335-L361

However, because the `breakpoints` state did not previously go through the Redux store, this clearing of `breakpoints` state had no effect on behaviour. Now, all breakpoints are cleared whenever the program is evaluated. I checked with Prof @martin-henz who has determined that this behaviour is not desired and should be reverted. As such, the `WorkspaceReducer` logic for the `EVAL_INTERPRETER_SUCCESS` action no longer resets the state of `breakpoints` to an empty array.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Add breakpoints to a program.
1. Run the program.
1. Check that the breakpoints still exist, either by inspecting the Redux store state, or by running the program again to verify that the breakpoints are hit.