### PR TITLE
Decouple highlighted lines state from EVAL_INTERPRETER_SUCCESS action & make updating of highlighted lines go through Redux store

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -221,7 +221,6 @@ export default function* WorkspaceSaga(): SagaIterator {
     yield put(actions.clearReplOutput(workspaceLocation));
     yield put(actions.highlightEditorLine([], workspaceLocation));
     highlightLine(undefined);
-    yield put(actions.clearReplOutput(workspaceLocation));
     context.runtime.break = false;
     lastDebuggerResult = undefined;
   });

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -58,6 +58,7 @@ import {
   getDifferenceInMethods,
   getRestoreExtraMethodsString,
   getStoreExtraMethodsString,
+  highlightClean,
   highlightLine,
   makeElevatedContext,
   visualizeEnv
@@ -220,7 +221,6 @@ export default function* WorkspaceSaga(): SagaIterator {
     context = yield select((state: OverallState) => state.workspaces[workspaceLocation].context);
     yield put(actions.clearReplOutput(workspaceLocation));
     yield put(actions.highlightEditorLine([], workspaceLocation));
-    highlightLine(undefined);
     context.runtime.break = false;
     lastDebuggerResult = undefined;
   });
@@ -228,8 +228,12 @@ export default function* WorkspaceSaga(): SagaIterator {
   yield takeEvery(
     HIGHLIGHT_LINE,
     function* (action: ReturnType<typeof actions.highlightEditorLine>) {
-      const workspaceLocation = action.payload.highlightedLines;
-      highlightLine(workspaceLocation[0]);
+      const highlightedLines = action.payload.highlightedLines;
+      if (highlightedLines.length === 0) {
+        highlightClean();
+      } else {
+        highlightLine(highlightedLines[0]);
+      }
       yield;
     }
   );

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -219,6 +219,7 @@ export default function* WorkspaceSaga(): SagaIterator {
     const workspaceLocation = action.payload.workspaceLocation;
     context = yield select((state: OverallState) => state.workspaces[workspaceLocation].context);
     yield put(actions.clearReplOutput(workspaceLocation));
+    yield put(actions.highlightEditorLine([], workspaceLocation));
     highlightLine(undefined);
     yield put(actions.clearReplOutput(workspaceLocation));
     context.runtime.break = false;

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -295,7 +295,7 @@ describe('DEBUG_RESUME', () => {
 });
 
 describe('DEBUG_RESET', () => {
-  test('puts clearReplOutput correctly', () => {
+  test('puts clearReplOutput and highlightEditorLine correctly', () => {
     const workspaceLocation = 'assessment';
     const newDefaultState = generateDefaultState(workspaceLocation, {
       editorTabs: [{ value: 'test-value' }]
@@ -304,6 +304,7 @@ describe('DEBUG_RESET', () => {
     return expectSaga(workspaceSaga)
       .withState(newDefaultState)
       .put(clearReplOutput(workspaceLocation))
+      .put(highlightEditorLine([], workspaceLocation))
       .dispatch({
         type: DEBUG_RESET,
         payload: { workspaceLocation }

--- a/src/commons/utils/JsSlangHelper.ts
+++ b/src/commons/utils/JsSlangHelper.ts
@@ -98,10 +98,16 @@ export function visualizeEnv({ context }: { context: Context }) {
   }
 }
 
-export function highlightLine(line: number | undefined) {
+export function highlightClean() {
   if ((window as any).Inspector) {
     (window as any).Inspector.highlightClean();
-    // if number is undefined it just clears the highlighting.
+  } else {
+    throw new Error('Inspector not loaded');
+  }
+}
+
+export function highlightLine(line: number) {
+  if ((window as any).Inspector) {
     (window as any).Inspector.highlightLine(line);
   } else {
     throw new Error('Inspector not loaded');

--- a/src/commons/workspace/WorkspaceReducer.ts
+++ b/src/commons/workspace/WorkspaceReducer.ts
@@ -352,9 +352,7 @@ export const WorkspaceReducer: Reducer<WorkspaceManagerState> = (
         [workspaceLocation]: {
           ...state[workspaceLocation],
           output: newOutput,
-          isRunning: false,
-          // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-          editorTabs: [{ ...state[workspaceLocation].editorTabs[0], highlightedLines: [] }]
+          isRunning: false
         }
       };
     case EVAL_TESTCASE_SUCCESS:

--- a/src/commons/workspace/__tests__/WorkspaceReducer.ts
+++ b/src/commons/workspace/__tests__/WorkspaceReducer.ts
@@ -685,7 +685,6 @@ describe('EVAL_INTERPRETER_SUCCESS', () => {
         [location]: {
           ...evalEditorDefaultState[location],
           isRunning: false,
-          editorTabs: [{ ...evalEditorDefaultState[location].editorTabs[0], highlightedLines: [] }],
           output: [
             {
               ...outputWithRunningOutput[0]
@@ -720,7 +719,6 @@ describe('EVAL_INTERPRETER_SUCCESS', () => {
         [location]: {
           ...evalEditorDefaultState[location],
           isRunning: false,
-          editorTabs: [{ ...evalEditorDefaultState[location].editorTabs[0], highlightedLines: [] }],
           output: [
             {
               ...outputWithRunningAndCodeOutput[0]


### PR DESCRIPTION
### Description

While refactoring the `EVAL_INTERPRETER_SUCCESS` action in the `WorkspaceReducer` to not make use of a hardcoded editor tab state, I had to figure out why there was a need to reset the `highlightedLines` state. As it turns out, there is no reason for that.

The `highlightedLines` state is necessary for the painting of the blue lines whenever a breakpoint is hit in Source 3+. From tracing the code, it is correctly reset when the debugger resumes normal evaluation after all breakpoints have been hit within the `DEBUG_RESUME` saga in line 214:
https://github.com/source-academy/frontend/blob/78ff16511385a31e8e66fbfd72a3e201cbbbe8bc/src/commons/sagas/WorkspaceSaga.ts#L202-L216

![image](https://user-images.githubusercontent.com/5585517/206969002-d494ebde-6735-4f41-a344-706933474983.png)
However, when the debugger is stopped prematurely via the "Stop Debugger" button instead, the `highlightedLines` state is not correctly reset. This is because whoever wrote the `DEBUG_RESET` saga decided to bypass the Redux store and call the code that handles the painting and clearing of lines in `public/externalLibs/inspector/inspector.js` directly as seen in line 222 below:
https://github.com/source-academy/frontend/blob/78ff16511385a31e8e66fbfd72a3e201cbbbe8bc/src/commons/sagas/WorkspaceSaga.ts#L218-L226

Not to mention, lines 221 and 223 perform the same action twice...

Part of the refactoring for #2176.

### Changes made

All changes to the highlighted lines now go through the Redux store. The `highlightLine` function in `src/commons/utils/JsSlangHelper.ts` was also split up into a `highlightLine` and a `highlightClean` function so as to enforce single responsibility, as well as have safer typing & more readable code through the omission of `undefined`. Finally, the highlighted lines state is no longer changed by the `EVAL_INTERPRETER_SUCCESS` action because there is no reason for this coupling.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->