### PR TITLE
Handle editor variants inside EditorContainer & align editor event listener types

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -50,7 +50,10 @@ import { ControlBarResetButton } from '../controlBar/ControlBarResetButton';
 import { ControlBarRunButton } from '../controlBar/ControlBarRunButton';
 import { ControlButtonSaveButton } from '../controlBar/ControlBarSaveButton';
 import controlButton from '../ControlButton';
-import { convertEditorTabStateToProps } from '../editor/EditorContainer';
+import {
+  convertEditorTabStateToProps,
+  NormalEditorContainerProps
+} from '../editor/EditorContainer';
 import { Position } from '../editor/EditorTypes';
 import Markdown from '../Markdown';
 import { MobileSideContentProps } from '../mobileWorkspace/mobileSideContent/MobileSideContent';
@@ -772,14 +775,15 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
       ? props.assessment.questions.length - 1
       : props.questionId;
   const question: Question = props.assessment.questions[questionId];
-  const editorContainerProps =
+  const editorContainerProps: NormalEditorContainerProps | undefined =
     question.type === QuestionTypes.programming || question.type === QuestionTypes.voting
       ? {
+          editorVariant: 'normal',
           editorTabs: props.editorTabs.map(convertEditorTabStateToProps),
           editorSessionId: '',
           sourceChapter: question.library.chapter || Chapter.SOURCE_4,
           sourceVariant: question.library.variant ?? Variant.DEFAULT,
-          externalLibrary: question.library.external.name || 'NONE',
+          externalLibraryName: question.library.external.name || 'NONE',
           handleDeclarationNavigate: props.handleDeclarationNavigate,
           handleEditorEval: handleEval,
           handleEditorValueChange: props.handleEditorValueChange,

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -170,6 +170,7 @@ class EditingWorkspace extends React.Component<EditingWorkspaceProps, State> {
       editorContainerProps:
         question.type === QuestionTypes.programming
           ? {
+              editorVariant: 'normal',
               editorTabs: this.props.editorTabs
                 .map(convertEditorTabStateToProps)
                 .map((editorTabStateProps, index) => {

--- a/src/commons/editor/EditorContainer.tsx
+++ b/src/commons/editor/EditorContainer.tsx
@@ -1,3 +1,7 @@
+// Necessary to prevent "ReferenceError: ace is not defined" error.
+// See https://github.com/securingsincity/react-ace/issues/1233 (although there is no explanation).
+import 'ace-builds/src-noconflict/ace';
+
 import _ from 'lodash';
 import React from 'react';
 

--- a/src/commons/editor/EditorContainer.tsx
+++ b/src/commons/editor/EditorContainer.tsx
@@ -1,12 +1,26 @@
 import _ from 'lodash';
 import React from 'react';
 
+import SourcecastEditor, {
+  SourceRecorderEditorProps
+} from '../sourceRecorder/SourceRecorderEditor';
 import { EditorTabState } from '../workspace/WorkspaceTypes';
 import Editor, { EditorProps, EditorTabStateProps } from './Editor';
 
-export type EditorContainerProps = Omit<EditorProps, keyof EditorTabStateProps> & {
+export type NormalEditorContainerProps = Omit<EditorProps, keyof EditorTabStateProps> & {
+  editorVariant: 'normal';
   editorTabs: EditorTabStateProps[];
 };
+
+export type SourcecastEditorContainerProps = Omit<
+  SourceRecorderEditorProps,
+  keyof EditorTabStateProps
+> & {
+  editorVariant: 'sourcecast';
+  editorTabs: EditorTabStateProps[];
+};
+
+export type EditorContainerProps = NormalEditorContainerProps | SourcecastEditorContainerProps;
 
 export const convertEditorTabStateToProps = (editorTab: EditorTabState): EditorTabStateProps => {
   return {
@@ -15,10 +29,29 @@ export const convertEditorTabStateToProps = (editorTab: EditorTabState): EditorT
   };
 };
 
+const createNormalEditorTab =
+  (editorProps: Omit<EditorProps, keyof EditorTabStateProps>) =>
+  (editorTabStateProps: EditorTabStateProps) => {
+    return <Editor {...editorProps} {...editorTabStateProps} />;
+  };
+
+const createSourcecastEditorTab =
+  (editorProps: Omit<SourceRecorderEditorProps, keyof EditorTabStateProps>) =>
+  (editorTabStateProps: EditorTabStateProps) => {
+    return <SourcecastEditor {...editorProps} {...editorTabStateProps} />;
+  };
+
 const EditorContainer: React.FC<EditorContainerProps> = (props: EditorContainerProps) => {
-  const { editorTabs, ...editorProps } = props;
+  let createEditorTab;
+  if (props.editorVariant === 'sourcecast') {
+    const { editorVariant, editorTabs, ...editorProps } = props;
+    createEditorTab = createSourcecastEditorTab(editorProps);
+  } else {
+    const { editorVariant, editorTabs, ...editorProps } = props;
+    createEditorTab = createNormalEditorTab(editorProps);
+  }
   // TODO: Implement editor tabs.
-  return <Editor {...editorProps} {...editorTabs[0]}></Editor>;
+  return createEditorTab(props.editorTabs[0]);
 };
 
 export default EditorContainer;

--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -7,11 +7,7 @@ import { useMediaQuery } from 'react-responsive';
 import { Prompt } from 'react-router';
 
 import ControlBar from '../controlBar/ControlBar';
-import EditorContainer, {
-  EditorContainerProps,
-  NormalEditorContainerProps,
-  SourcecastEditorContainerProps
-} from '../editor/EditorContainer';
+import EditorContainer, { EditorContainerProps } from '../editor/EditorContainer';
 import McqChooser, { McqChooserProps } from '../mcqChooser/McqChooser';
 import { ReplProps } from '../repl/Repl';
 import { SideBarTab } from '../sideBar/SideBar';
@@ -93,9 +89,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
 
   const clearTargetKeyboardInput = () => setTargetKeyboardInput(null);
 
-  const enableMobileKeyboardForEditor = (
-    props: NormalEditorContainerProps
-  ): NormalEditorContainerProps => {
+  const enableMobileKeyboardForEditor = (props: EditorContainerProps): EditorContainerProps => {
     const onFocus = (event: any, editor?: Ace.Editor) => {
       if (props.onFocus) {
         props.onFocus(event, editor);
@@ -108,9 +102,6 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
     const onBlur = (event: any, editor?: Ace.Editor) => {
       if (props.onBlur) {
         props.onBlur(event, editor);
-      }
-      if (!editor) {
-        return;
       }
       clearTargetKeyboardInput();
     };
@@ -141,25 +132,14 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
     };
   };
 
-  const enableMobileKeyboardForCustomEditor = (
-    props: SourcecastEditorContainerProps
-  ): SourcecastEditorContainerProps => {
-    return {
-      ...props,
-      onFocus: (editor: Ace.Editor) => setTargetKeyboardInput(editor),
-      onBlur: () => clearTargetKeyboardInput()
-    };
-  };
-
   const createWorkspaceInput = () => {
-    if (props.editorContainerProps?.editorVariant === 'sourcecast') {
-      return (
-        <EditorContainer
-          {...enableMobileKeyboardForCustomEditor(props.editorContainerProps)}
-          setDraggableReplPosition={() => handleShowRepl(-100)}
-        />
-      );
-    } else if (props.editorContainerProps) {
+    if (props.editorContainerProps) {
+      const editorContainerProps = {
+        ...props.editorContainerProps
+      };
+      if (editorContainerProps.editorVariant === 'sourcecast') {
+        editorContainerProps.setDraggableReplPosition = () => handleShowRepl(-100);
+      }
       return <EditorContainer {...enableMobileKeyboardForEditor(props.editorContainerProps)} />;
     } else {
       return <McqChooser {...props.mcqProps!} />;

--- a/src/commons/sourceRecorder/SourceRecorderEditor.tsx
+++ b/src/commons/sourceRecorder/SourceRecorderEditor.tsx
@@ -14,7 +14,8 @@ import {
   KeyboardCommand,
   SelectionRange
 } from '../../features/sourceRecorder/SourceRecorderTypes';
-import { HighlightedLines, Position } from '../editor/EditorTypes';
+import { EditorTabStateProps } from '../editor/Editor';
+import { Position } from '../editor/EditorTypes';
 
 /**
  * @property editorValue - The string content of the react-ace editor
@@ -24,7 +25,10 @@ import { HighlightedLines, Position } from '../editor/EditorTypes';
  *           of the editor's content, using `slang`
  * @property isEditorReadonly - Used for sourcecast only
  */
-export type SourceRecorderEditorProps = DispatchProps & StateProps & OwnProps;
+export type SourceRecorderEditorProps = DispatchProps &
+  EditorStateProps &
+  EditorTabStateProps &
+  OwnProps;
 
 type DispatchProps = {
   getTimerDuration?: () => number;
@@ -38,18 +42,14 @@ type DispatchProps = {
   onBlur?: () => void;
 };
 
-type StateProps = {
-  breakpoints: string[];
+type EditorStateProps = {
   codeDeltasToApply?: CodeDelta[] | null;
   editorSessionId: string;
-  editorValue: string;
-  highlightedLines: HighlightedLines[];
   isEditorAutorun: boolean;
   isEditorReadonly: boolean;
   inputToApply?: Input | null;
   isPlaying?: boolean;
   isRecording?: boolean;
-  newCursorPosition?: Position;
 };
 
 type OwnProps = {

--- a/src/commons/sourceRecorder/SourceRecorderEditor.tsx
+++ b/src/commons/sourceRecorder/SourceRecorderEditor.tsx
@@ -38,8 +38,8 @@ type DispatchProps = {
   handleEditorUpdateBreakpoints: (breakpoints: string[]) => void;
   handleRecordInput?: (input: Input) => void;
   handleUpdateHasUnsavedChanges?: (hasUnsavedChanges: boolean) => void;
-  onFocus?: (editor: Ace.Editor) => void;
-  onBlur?: () => void;
+  onFocus?: (event: any, editor?: Ace.Editor) => void;
+  onBlur?: (event: any, editor?: Ace.Editor) => void;
 };
 
 type EditorStateProps = {
@@ -172,10 +172,10 @@ class SourcecastEditor extends React.PureComponent<SourceRecorderEditorProps, {}
 
     const { onFocus, onBlur } = this.props;
     if (onFocus) {
-      editor.on('focus', () => onFocus(editor));
+      editor.on('focus', (event: Event) => onFocus(event, editor));
     }
     if (onBlur) {
-      editor.on('blur', onBlur);
+      editor.on('blur', (event: Event) => onBlur(event, editor));
     }
   }
 

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -21,7 +21,6 @@ type DispatchProps = {
 type StateProps = {
   // Either editorProps or mcqProps must be provided
   controlBarProps: ControlBarProps;
-  customEditor?: JSX.Element;
   editorContainerProps?: EditorContainerProps;
   hasUnsavedChanges?: boolean;
   mcqProps?: McqChooserProps;
@@ -187,9 +186,7 @@ const Workspace: React.FC<WorkspaceProps> = props => {
    * XOR `props.mcq` are defined.
    */
   const createWorkspaceInput = (props: WorkspaceProps) => {
-    if (props.customEditor) {
-      return props.customEditor;
-    } else if (props.editorContainerProps) {
+    if (props.editorContainerProps) {
       return <EditorContainer {...props.editorContainerProps} />;
     } else {
       return <McqChooser {...props.mcqProps!} />;

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -184,6 +184,7 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
       editorContainerProps:
         question.type === QuestionTypes.programming || question.type === QuestionTypes.voting
           ? {
+              editorVariant: 'normal',
               editorTabs: this.props.editorTabs.map(convertEditorTabStateToProps),
               editorSessionId: '',
               handleDeclarationNavigate: this.props.handleDeclarationNavigate,

--- a/src/pages/academy/sourcereel/Sourcereel.tsx
+++ b/src/pages/academy/sourcereel/Sourcereel.tsx
@@ -11,6 +11,10 @@ import { ControlBarChapterSelect } from '../../../commons/controlBar/ControlBarC
 import { ControlBarClearButton } from '../../../commons/controlBar/ControlBarClearButton';
 import { ControlBarEvalButton } from '../../../commons/controlBar/ControlBarEvalButton';
 import { ControlBarExternalLibrarySelect } from '../../../commons/controlBar/ControlBarExternalLibrarySelect';
+import {
+  convertEditorTabStateToProps,
+  SourcecastEditorContainerProps
+} from '../../../commons/editor/EditorContainer';
 import { Position } from '../../../commons/editor/EditorTypes';
 import SideContentDataVisualizer from '../../../commons/sideContent/SideContentDataVisualizer';
 import SideContentEnvVisualizer from '../../../commons/sideContent/SideContentEnvVisualizer';
@@ -18,9 +22,6 @@ import { SideContentTab, SideContentType } from '../../../commons/sideContent/Si
 import SourceRecorderControlBar, {
   SourceRecorderControlBarProps
 } from '../../../commons/sourceRecorder/SourceRecorderControlBar';
-import SourcecastEditor, {
-  SourceRecorderEditorProps
-} from '../../../commons/sourceRecorder/SourceRecorderEditor';
 import SourcecastTable from '../../../commons/sourceRecorder/SourceRecorderTable';
 import Workspace, { WorkspaceProps } from '../../../commons/workspace/Workspace';
 import { EditorTabState } from '../../../commons/workspace/WorkspaceTypes';
@@ -239,11 +240,11 @@ class Sourcereel extends React.Component<SourcereelProps, State> {
       />
     );
 
-    const editorProps: SourceRecorderEditorProps = {
+    const editorContainerProps: SourcecastEditorContainerProps = {
+      editorVariant: 'sourcecast',
+      editorTabs: this.props.editorTabs.map(convertEditorTabStateToProps),
       codeDeltasToApply: this.props.codeDeltasToApply,
       isEditorReadonly: this.props.isEditorReadonly,
-      // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-      editorValue: this.props.editorTabs[0].value,
       editorSessionId: '',
       getTimerDuration: this.getTimerDuration,
       handleDeclarationNavigate: this.props.handleDeclarationNavigate,
@@ -253,10 +254,6 @@ class Sourcereel extends React.Component<SourcereelProps, State> {
       inputToApply: this.props.inputToApply,
       isPlaying: this.props.playbackStatus === PlaybackStatus.playing,
       isRecording: this.props.recordingStatus === RecordingStatus.recording,
-      // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-      highlightedLines: this.props.editorTabs[0].highlightedLines,
-      breakpoints: this.props.editorTabs[0].breakpoints,
-      newCursorPosition: this.props.editorTabs[0].newCursorPosition,
       handleEditorUpdateBreakpoints: this.props.handleEditorUpdateBreakpoints,
       handleRecordInput: this.props.handleRecordInput
     };
@@ -277,7 +274,7 @@ class Sourcereel extends React.Component<SourcereelProps, State> {
       controlBarProps: {
         editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect]
       },
-      customEditor: <SourcecastEditor {...editorProps} />,
+      editorContainerProps: editorContainerProps,
       handleSideContentHeightChange: this.props.handleSideContentHeightChange,
       replProps: {
         output: this.props.output,

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -32,7 +32,10 @@ import { ControlButtonSaveButton } from '../../commons/controlBar/ControlBarSave
 import { ControlBarDisplayMCQButton } from '../../commons/controlBar/github/ControlBarDisplayMCQButton';
 import { ControlBarTaskAddButton } from '../../commons/controlBar/github/ControlBarTaskAddButton';
 import { ControlBarTaskDeleteButton } from '../../commons/controlBar/github/ControlBarTaskDeleteButton';
-import { convertEditorTabStateToProps } from '../../commons/editor/EditorContainer';
+import {
+  convertEditorTabStateToProps,
+  NormalEditorContainerProps
+} from '../../commons/editor/EditorContainer';
 import { Position } from '../../commons/editor/EditorTypes';
 import {
   GitHubMissionCreateDialog,
@@ -1062,7 +1065,8 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
       : undefined;
   }, [currentTaskIsMCQ, displayMCQInEditor, mcqQuestion, handleMCQSubmit]);
 
-  const editorContainerProps = {
+  const editorContainerProps: NormalEditorContainerProps = {
+    editorVariant: 'normal',
     editorTabs: props.editorTabs.map(convertEditorTabStateToProps),
     editorSessionId: '',
     handleDeclarationNavigate: props.handleDeclarationNavigate,

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -79,7 +79,10 @@ import { ControlBarSessionButtons } from '../../commons/controlBar/ControlBarSes
 import { ControlBarShareButton } from '../../commons/controlBar/ControlBarShareButton';
 import { ControlBarStepLimit } from '../../commons/controlBar/ControlBarStepLimit';
 import { ControlBarGitHubButtons } from '../../commons/controlBar/github/ControlBarGitHubButtons';
-import { convertEditorTabStateToProps } from '../../commons/editor/EditorContainer';
+import {
+  convertEditorTabStateToProps,
+  NormalEditorContainerProps
+} from '../../commons/editor/EditorContainer';
 import { Position } from '../../commons/editor/EditorTypes';
 import Markdown from '../../commons/Markdown';
 import MobileWorkspace, {
@@ -725,8 +728,9 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
     props.playgroundSourceVariant === Variant.CONCURRENT ||
     usingRemoteExecution;
 
-  const editorContainerProps = {
+  const editorContainerProps: NormalEditorContainerProps = {
     ..._.pick(props, 'editorSessionId', 'isEditorAutorun'),
+    editorVariant: 'normal',
     editorTabs: props.editorTabs.map(convertEditorTabStateToProps),
     handleDeclarationNavigate: (cursorPosition: Position) =>
       dispatch(navigateToDeclaration(workspaceLocation, cursorPosition)),

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -13,6 +13,10 @@ import { ControlBarChapterSelect } from '../../commons/controlBar/ControlBarChap
 import { ControlBarClearButton } from '../../commons/controlBar/ControlBarClearButton';
 import { ControlBarEvalButton } from '../../commons/controlBar/ControlBarEvalButton';
 import { ControlBarExternalLibrarySelect } from '../../commons/controlBar/ControlBarExternalLibrarySelect';
+import {
+  convertEditorTabStateToProps,
+  SourcecastEditorContainerProps
+} from '../../commons/editor/EditorContainer';
 import { Position } from '../../commons/editor/EditorTypes';
 import MobileWorkspace, {
   MobileWorkspaceProps
@@ -23,9 +27,6 @@ import { SideContentTab, SideContentType } from '../../commons/sideContent/SideC
 import SourceRecorderControlBar, {
   SourceRecorderControlBarProps
 } from '../../commons/sourceRecorder/SourceRecorderControlBar';
-import SourceRecorderEditor, {
-  SourceRecorderEditorProps
-} from '../../commons/sourceRecorder/SourceRecorderEditor';
 import SourceRecorderTable from '../../commons/sourceRecorder/SourceRecorderTable';
 import Constants from '../../commons/utils/Constants';
 import Workspace, { WorkspaceProps } from '../../commons/workspace/Workspace';
@@ -264,11 +265,11 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
     setSelectedTab(newTabId);
   };
 
-  const editorProps: SourceRecorderEditorProps = {
+  const editorContainerProps: SourcecastEditorContainerProps = {
+    editorVariant: 'sourcecast',
+    editorTabs: props.editorTabs.map(convertEditorTabStateToProps),
     codeDeltasToApply: props.codeDeltasToApply,
     isEditorReadonly: props.isEditorReadonly,
-    // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-    editorValue: props.editorTabs[0].value,
     editorSessionId: '',
     handleDeclarationNavigate: props.handleDeclarationNavigate,
     handleEditorEval: props.handleEditorEval,
@@ -276,10 +277,6 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
     isEditorAutorun: props.isEditorAutorun,
     inputToApply: props.inputToApply,
     isPlaying: props.playbackStatus === PlaybackStatus.playing,
-    // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-    highlightedLines: props.editorTabs[0].highlightedLines,
-    breakpoints: props.editorTabs[0].breakpoints,
-    newCursorPosition: props.editorTabs[0].newCursorPosition,
     handleEditorUpdateBreakpoints: props.handleEditorUpdateBreakpoints
   };
 
@@ -304,7 +301,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
     controlBarProps: {
       editorButtons: [autorunButtons, chapterSelect, externalLibrarySelect]
     },
-    customEditor: <SourceRecorderEditor {...editorProps} />,
+    editorContainerProps: editorContainerProps,
     handleSideContentHeightChange: props.handleSideContentHeightChange,
     replProps: replProps,
     sideBarProps: sideBarProps,
@@ -321,16 +318,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
     }
   };
   const mobileWorkspaceProps: MobileWorkspaceProps = {
-    customEditor: (
-      handleShowDraggableRepl: () => void,
-      overrideEditorProps: Partial<SourceRecorderEditorProps>
-    ) => (
-      <SourceRecorderEditor
-        {...editorProps}
-        {...overrideEditorProps}
-        setDraggableReplPosition={handleShowDraggableRepl}
-      />
-    ),
+    editorContainerProps: editorContainerProps,
     replProps: replProps,
     sideBarProps: sideBarProps,
     mobileSideContentProps: {


### PR DESCRIPTION
### Description

The `Sourcecast` & `Sourcereel` workspaces make use of the `SourcecastEditor` instead of the `Editor`. To allow for this, both `Workspace` and `MobileWorkspace` take in an optional `customEditor` prop of type `JSX.Element`, which is rendered instead of the normal editor if the prop is present.

This is however quite problematic as the creation of `SourcecastEditor` is already done before the `Workspace`/`MobileWorkspace` component is called, as opposed to the `Editor` which is created in `Workspace`/`MobileWorkspace`. In order to support multiple editor tabs for both the `Editor` and the `SourcecastEditor` without having to duplicate similar logic, `EditorContainer` was updated to make use of a discriminated union as its prop. I initially tried playing around with generics to get something like this:
```ts
export type EditorContainerProps<T> = Omit<T, keyof EditorTabStateProps> & {
  renderEditor: (editorProps: T) => void;
  editorTabs: EditorTabStateProps[];
};
....
const EditorContainer = <T extends EditorTabStateProps>(props: EditorContainerProps<T>) => {
  const { editorVariant, editorTabs, ...editorProps } = props;
  // TODO: Implement editor tabs.
  const editorTabProps: T = {
    ...editorProps,
    ...editorTabs[0]
  };
  return renderEditor(editorTabProps);
```
Unfortunately, TypeScript is unable to infer the type of `editorTabProps` correctly here unless I perform type casts (which are evil). On top of that, using generics results in all of the parent states also becoming generic, which is rather ugly as even the top-level `WorkspaceState` requires a type variable to represent the editor variant.

By making use of discriminated unions, we can remove the `customEditor` prop in `Workspace` and `MobileWorkspace`. Regardless of which editor variant should be used, `EditorContainer` will be rendered. This allows the future multiple editor tabs logic to work for both kinds of editors, as well as makes the handling of both editor variants consistent.

Additionally, I also aligned the event listener prop type signatures between `SourcecastEditor` and `Editor` so that `enableMobileKeyboardForEditor` can be used for both editor variants in `MobileWorkspace`.

Part of the refactoring for #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

There should be no change in behaviour.