### PR TITLE
Add Source 2 Typed variant

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -150,6 +150,7 @@ export const sublanguages: Language[] = [
   { chapter: Chapter.SOURCE_1, variant: Variant.WASM },
   { chapter: Chapter.SOURCE_1, variant: Variant.LAZY },
   { chapter: Chapter.SOURCE_1, variant: Variant.NATIVE },
+  { chapter: Chapter.SOURCE_2, variant: Variant.TYPED },
   { chapter: Chapter.SOURCE_2, variant: Variant.DEFAULT },
   { chapter: Chapter.SOURCE_2, variant: Variant.LAZY },
   { chapter: Chapter.SOURCE_2, variant: Variant.NATIVE },


### PR DESCRIPTION
### Description

Adds Source 2 Typed variant to the frontend.

PR marked as draft until source-academy/js-slang#1320 is merged and js-slang version is bumped. For now, this PR serves to aid in the testing of source-academy/js-slang#1320.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Checkout js-slang to source-academy/js-slang#1320, [link local js-slang to local frontend](https://github.com/source-academy/js-slang#using-your-js-slang-in-your-local-source-academy), and start the frontend locally. The Source 2 Typed variant should now be available as a selection. Switch to Source 2 Typed and test by writing Source 2 code with types.
