### PR TITLE
hotfix: stepper

### DIFF
--- a/src/commons/workspace/WorkspaceReducer.ts
+++ b/src/commons/workspace/WorkspaceReducer.ts
@@ -335,9 +335,10 @@ export const WorkspaceReducer: Reducer<WorkspaceManagerState> = (
         }
       };
     case EVAL_INTERPRETER_SUCCESS:
+      const execType = state[workspaceLocation].context.executionMethod;
       const newOutputEntry: Partial<ResultOutput> = {
         type: action.payload.type as 'result' | undefined,
-        value: stringify(action.payload.value)
+        value: execType === 'interpreter' ? action.payload.value : stringify(action.payload.value)
       };
 
       lastOutput = state[workspaceLocation].output.slice(-1)[0];


### PR DESCRIPTION
## Description

This is a hotfix for the stepper after #2304.

The issue lies in how the stepper and REPL output uses the same workspace output state (`WorkspaceState["output"]`). Therefore, we cannot `stringify` all outputs as the stepper UI relies on a array of steps.

There will be a future PR (#2306) to address this issue properly with a separation of state between the output of REPL, stepper and other debuggers