### PR TITLE
Fix duplicate errors when evaluating Source programs

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -527,6 +527,8 @@ export function* evalEditor(
         }
       }
     }
+    // Clear the errors on the context before any further evaluation.
+    context.errors = [];
 
     // Evaluate the prepend silently with a privileged context, if it exists
     if (prepend.length) {


### PR DESCRIPTION
### Description

Before evaluating the program, we make sure that the `errors` array on the `context` object that is passed into js-slang is empty. The reason why we do not just clear the `errors` array within js-slang is because js-slang should only add errors to the array and leave existing errors untouched. This is so that errors that do not originate from js-slang are preserved during program evaluation (although I don't think any exist currently).

I would add a test case for this regression, but it's not exactly something that's easy to test + I will likely have to refactor away instances of `parse` being called from the frontend anyway (see the linked issue for more context) which means that the affected parts of the codebase will likely be rewritten.

Fixes https://github.com/source-academy/js-slang/issues/1349.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Run the following program and verify that the error message appears only once:
```
const x = 1;
const x = 1;
```