### PR TITLE
stepper's step limit restricted to even number

### DIFF
--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -16,14 +16,14 @@ type StateProps = {
 };
 
 export const ControlBarStepLimit: React.FC<ControlBarStepLimitProps> = props => {
-   /**
-   * Scale the odd stepLimit into the next even integer. 
+  /**
+   * Scale the odd stepLimit into the next even integer.
    * Triggered when the input box lost focus.
    */
-   const onBlurAutoScale = ()=>{
+  const onBlurAutoScale = () => {
     props.handleOnBlurAutoScale != undefined
-    ? props.handleOnBlurAutoScale(Number(props.stepLimit))
-    : console.log('undefined');
+      ? props.handleOnBlurAutoScale(Number(props.stepLimit))
+      : console.log('undefined');
   };
 
   return (

--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -21,10 +21,10 @@ export const ControlBarStepLimit: React.FC<ControlBarStepLimitProps> = props => 
    * Triggered when the input box lost focus.
    */
    const onBlurAutoScale = ()=>{
-    props.handleOnBlurAutoScale!=undefined
+    props.handleOnBlurAutoScale != undefined
     ? props.handleOnBlurAutoScale(Number(props.stepLimit))
-    : console.log('undefined')
-  }
+    : console.log('undefined');
+  };
 
   return (
     <Tooltip2 content="Step Limit" placement={Position.TOP}>

--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -21,7 +21,7 @@ export const ControlBarStepLimit: React.FC<ControlBarStepLimitProps> = props => 
    * Triggered when the input box lost focus.
    */
   const onBlurAutoScale = () => {
-    props.handleOnBlurAutoScale != undefined
+    props.handleOnBlurAutoScale !== undefined
       ? props.handleOnBlurAutoScale(Number(props.stepLimit))
       : console.log('undefined');
   };

--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -21,8 +21,8 @@ export const ControlBarStepLimit: React.FC<ControlBarStepLimitProps> = props => 
    * Triggered when the input box lost focus.
    */
   const onBlurAutoScale = () => {
-    if(props.handleOnBlurAutoScale !== undefined) {
-      props.handleOnBlurAutoScale(Number(props.stepLimit))
+    if (props.handleOnBlurAutoScale !== undefined) {
+      props.handleOnBlurAutoScale(Number(props.stepLimit));
     }
   };
 

--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -7,6 +7,7 @@ type ControlBarStepLimitProps = DispatchProps & StateProps;
 
 type DispatchProps = {
   handleChangeStepLimit?: (stepLimit: number) => void;
+  handleOnBlurAutoScale?: (stepLimit: number) => void;
 };
 
 type StateProps = {
@@ -15,6 +16,16 @@ type StateProps = {
 };
 
 export const ControlBarStepLimit: React.FC<ControlBarStepLimitProps> = props => {
+   /**
+   * Scale the odd stepLimit into the next even integer. 
+   * Triggered when the input box lost focus.
+   */
+   const onBlurAutoScale = ()=>{
+    props.handleOnBlurAutoScale!=undefined
+    ? props.handleOnBlurAutoScale(Number(props.stepLimit))
+    : console.log('undefined')
+  }
+
   return (
     <Tooltip2 content="Step Limit" placement={Position.TOP}>
       <NumericInput
@@ -23,6 +34,8 @@ export const ControlBarStepLimit: React.FC<ControlBarStepLimitProps> = props => 
         min={500}
         max={5000}
         value={props.stepLimit}
+        stepSize={2}
+        onBlur={onBlurAutoScale}
         onValueChange={props.handleChangeStepLimit}
       />
     </Tooltip2>

--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -21,9 +21,9 @@ export const ControlBarStepLimit: React.FC<ControlBarStepLimitProps> = props => 
    * Triggered when the input box lost focus.
    */
   const onBlurAutoScale = () => {
-    props.handleOnBlurAutoScale !== undefined
-      ? props.handleOnBlurAutoScale(Number(props.stepLimit))
-      : console.log('undefined');
+    if(props.handleOnBlurAutoScale !== undefined) {
+      props.handleOnBlurAutoScale(Number(props.stepLimit))
+    }
   };
 
   return (

--- a/src/commons/controlBar/ControlBarStepLimit.tsx
+++ b/src/commons/controlBar/ControlBarStepLimit.tsx
@@ -21,9 +21,7 @@ export const ControlBarStepLimit: React.FC<ControlBarStepLimitProps> = props => 
    * Triggered when the input box lost focus.
    */
   const onBlurAutoScale = () => {
-    if (props.handleOnBlurAutoScale !== undefined) {
-      props.handleOnBlurAutoScale(Number(props.stepLimit));
-    }
+    props.handleOnBlurAutoScale?.(Number(props.stepLimit));
   };
 
   return (

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -541,6 +541,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
       <ControlBarStepLimit
         stepLimit={props.stepLimit}
         handleChangeStepLimit={limit => dispatch(changeStepLimit(limit, workspaceLocation))}
+        handleOnBlurAutoScale={limit => {limit % 2 === 0 ? dispatch(changeStepLimit(limit, workspaceLocation)) : dispatch(changeStepLimit(limit+1, workspaceLocation))}}
         key="step_limit"
       />
     ),

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -541,7 +541,11 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
       <ControlBarStepLimit
         stepLimit={props.stepLimit}
         handleChangeStepLimit={limit => dispatch(changeStepLimit(limit, workspaceLocation))}
-        handleOnBlurAutoScale={limit => {limit % 2 === 0 ? dispatch(changeStepLimit(limit, workspaceLocation)) : dispatch(changeStepLimit(limit+1, workspaceLocation))}}
+        handleOnBlurAutoScale={limit => {
+          limit % 2 === 0
+            ? dispatch(changeStepLimit(limit, workspaceLocation))
+            : dispatch(changeStepLimit(limit + 1, workspaceLocation));
+        }}
         key="step_limit"
       />
     ),


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Summary of change:
1. StepSize of stepper's step limit changed to 2.
2. auto-scale the odd step limit into the next even integer when the input box lost focus.

Motivation:
From the discussion in issue #1345, we decided that it would be more consistent with the current definition of stepper and makes the user experience less confusing to restrict the change of step limit to even numbers at the frontend.
