### PR TITLE
Fix playground editor bugging out due to unnecessary updates

### DIFF
--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -780,15 +780,25 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
     ..._.pick(props, 'editorSessionId', 'isEditorAutorun'),
     editorVariant: 'normal',
     editorTabs: props.editorTabs.map(convertEditorTabStateToProps),
-    handleDeclarationNavigate: (cursorPosition: Position) =>
-      dispatch(navigateToDeclaration(workspaceLocation, cursorPosition)),
+    handleDeclarationNavigate: React.useCallback(
+      (cursorPosition: Position) =>
+        dispatch(navigateToDeclaration(workspaceLocation, cursorPosition)),
+      [dispatch, workspaceLocation]
+    ),
     handleEditorEval,
-    handlePromptAutocomplete: (row: number, col: number, callback: any) =>
-      dispatch(promptAutocomplete(workspaceLocation, row, col, callback)),
-    handleSendReplInputToOutput: (code: string) =>
-      dispatch(sendReplInputToOutput(code, workspaceLocation)),
-    handleSetSharedbConnected: (connected: boolean) =>
-      dispatch(setSharedbConnected(workspaceLocation, connected)),
+    handlePromptAutocomplete: React.useCallback(
+      (row: number, col: number, callback: any) =>
+        dispatch(promptAutocomplete(workspaceLocation, row, col, callback)),
+      [dispatch, workspaceLocation]
+    ),
+    handleSendReplInputToOutput: React.useCallback(
+      (code: string) => dispatch(sendReplInputToOutput(code, workspaceLocation)),
+      [dispatch, workspaceLocation]
+    ),
+    handleSetSharedbConnected: React.useCallback(
+      (connected: boolean) => dispatch(setSharedbConnected(workspaceLocation, connected)),
+      [dispatch, workspaceLocation]
+    ),
     onChange: onChangeMethod,
     onCursorChange: onCursorChangeMethod,
     onSelectionChange: onSelectionChangeMethod,
@@ -802,10 +812,18 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
 
   const replProps = {
     ..._.pick(props, 'output', 'replValue', 'handleReplEval', 'usingSubst'),
-    handleBrowseHistoryDown: () => dispatch(browseReplHistoryDown(workspaceLocation)),
-    handleBrowseHistoryUp: () => dispatch(browseReplHistoryUp(workspaceLocation)),
-    handleReplValueChange: (newValue: string) =>
-      dispatch(updateReplValue(newValue, workspaceLocation)),
+    handleBrowseHistoryDown: React.useCallback(
+      () => dispatch(browseReplHistoryDown(workspaceLocation)),
+      [dispatch, workspaceLocation]
+    ),
+    handleBrowseHistoryUp: React.useCallback(
+      () => dispatch(browseReplHistoryUp(workspaceLocation)),
+      [dispatch, workspaceLocation]
+    ),
+    handleReplValueChange: React.useCallback(
+      (newValue: string) => dispatch(updateReplValue(newValue, workspaceLocation)),
+      [dispatch, workspaceLocation]
+    ),
     sourceChapter: props.playgroundSourceChapter,
     sourceVariant: props.playgroundSourceVariant,
     externalLibrary: ExternalLibraryName.NONE, // temporary placeholder as we phase out libraries
@@ -844,8 +862,10 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
       ]
     },
     editorContainerProps: editorContainerProps,
-    handleSideContentHeightChange: change =>
-      dispatch(changeSideContentHeight(change, workspaceLocation)),
+    handleSideContentHeightChange: React.useCallback(
+      change => dispatch(changeSideContentHeight(change, workspaceLocation)),
+      [dispatch, workspaceLocation]
+    ),
     replProps: replProps,
     sideBarProps: sideBarProps,
     sideContentHeight: props.sideContentHeight,


### PR DESCRIPTION
### Description

This bug's existence negatively affects the CS4215 homework experience because undoing/redoing sends you to the bottom of a 1000+ line program, among other annoying issues...

![kGqRRF8OcW](https://user-images.githubusercontent.com/5585517/219868213-62356ed3-04cb-46f2-997d-d7d8497246eb.gif)

I was unable to figure out what was causing the bug from just the profiler alone, so I had to binary search the git history to find the offending PR. Then, I binary searched the git history of the unsquashed branch to find that the offending commit is https://github.com/source-academy/frontend/commit/037d9c957e22a8097660b5f76a214553fddebf04.

Because some of these callback functions being passed into child components used to be declared in the `PlaygroundContainer`, the `Playground` re-rendering would not cause these functions to be recreated. After the refactoring in #2257, this was no longer the case and every re-render of the `Playground` meant that these callback functions would be recreated. To fix this issue, I memoize these callback functions using the `useCallback` hook.

Fixes #2337.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

See the linked issue for steps to replicate. Alternatively, see https://github.com/source-academy/frontend/pull/2346#issuecomment-1433319375 to test with the new shifting breakpoints.