### PR TITLE
Make the retrieval of breakpoint line numbers more robust

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -145,27 +145,18 @@ const makeHandleGutterClick =
  * Returns an array of breakpoint line numbers from the Ace Editor's breakpoint
  * array representation.
  *
- * In JavaScript, arrays are just objects. As a result, the Ace Editor's breakpoint
- * array has empty slots (i.e., array indices which are not defined at all). Breakpoints
- * are represented in the Ace Editor's breakpoints array as key-value pairs where the
- * key is a string representation of the line number it is on, and the value is
- * 'ace_breakpoint'.
- *
- * However, because the JSON-serialised representation of empty slots in a JavaScript
- * array is the same as that of the 'null', we cannot simply parse all keys of the object
- * as integers to get the breakpoint line numbers. Instead, we need to:
- * (1) Find all entries in the object which has 'ace_breakpoint' as its value; then
- * (2) Parse the keys of all such entries to integers to get our breakpoint line numbers.
+ * Breakpoints are elements in the array with the value 'ace_breakpoint' where
+ * the associated line number is the index of the element in the array.
  *
  * @param breakpoints The Ace Editor's breakpoint representation.
  */
 const getBreakpointLineNumbers = (breakpoints: string[]): number[] => {
   const breakpointLineNumbers: number[] = [];
-  Object.entries(breakpoints).forEach(([key, value]: [string, string]): void => {
+  breakpoints.forEach((value: string, index: number) => {
     if (value !== 'ace_breakpoint') {
       return;
     }
-    breakpointLineNumbers.push(parseInt(key));
+    breakpointLineNumbers.push(index);
   });
   return breakpointLineNumbers;
 };

--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -149,13 +149,26 @@ const makeHandleGutterClick =
  * array has empty slots (i.e., array indices which are not defined at all). Breakpoints
  * are represented in the Ace Editor's breakpoints array as key-value pairs where the
  * key is a string representation of the line number it is on, and the value is
- * 'ace_breakpoint'. As such, to get an array of breakpoint line numbers, we need to
- * get the keys of the Ace Editor's breakpoint array/object and parse them as integers.
+ * 'ace_breakpoint'.
+ *
+ * However, because the JSON-serialised representation of empty slots in a JavaScript
+ * array is the same as that of the 'null', we cannot simply parse all keys of the object
+ * as integers to get the breakpoint line numbers. Instead, we need to:
+ * (1) Find all entries in the object which has 'ace_breakpoint' as its value; then
+ * (2) Parse the keys of all such entries to integers to get our breakpoint line numbers.
  *
  * @param breakpoints The Ace Editor's breakpoint representation.
  */
-const getBreakpointLineNumbers = (breakpoints: string[]): number[] =>
-  Object.keys(breakpoints).map(breakpointIndex => parseInt(breakpointIndex));
+const getBreakpointLineNumbers = (breakpoints: string[]): number[] => {
+  const breakpointLineNumbers: number[] = [];
+  Object.entries(breakpoints).forEach(([key, value]: [string, string]): void => {
+    if (value !== 'ace_breakpoint') {
+      return;
+    }
+    breakpointLineNumbers.push(parseInt(key));
+  });
+  return breakpointLineNumbers;
+};
 
 /**
  * Shifts breakpoints in accordance to changes in the code. This is a quality-of-life


### PR DESCRIPTION
### Description

The JSON-serialised representation of the breakpoints array in the localstorage is unable to distinguish between empty slots, and slots where the value is `null`. As a result, after serialising into JSON and deserialising back to JavaScript, the empty slots of an array are now filled with `null`. This breaks the invariant that only line numbers with a breakpoint are non-empty slots that was previously relied on in `getBreakpointLineNumbers`.

~~To resolve this issue, we now check that the value corresponding to the line number is the string `'ace_breakpoint'` to determine whether the line number has a breakpoint set or not.~~
To resolve this issue, we now define a breakpoint as follows:
> Breakpoints are elements in the array with the value 'ace_breakpoint' where the associated line number is the index of the element in the array.

By making use of array semantics instead of object semantics, we have a cleaner definition & implementation.

Fixes #2362.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Follow the steps to replicate in the linked issue.