### PR TITLE
Clear breakpoints when following share links

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -335,6 +335,14 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
     handlePromptAutocompleteRef.current = props.handlePromptAutocomplete;
   }, [props.handleEditorUpdateBreakpoints, props.handlePromptAutocomplete]);
 
+  React.useEffect(() => {
+    const editor = reactAceRef.current?.editor;
+    if (editor === undefined) {
+      return;
+    }
+    displayBreakpoints(editor, props.breakpoints);
+  }, [props.breakpoints]);
+
   // Handles input into AceEditor causing app to scroll to the top on iOS Safari
   React.useEffect(() => {
     const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent);
@@ -443,7 +451,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
     }
   }
 
-  const { onChange, onLoad } = aceEditorProps;
+  const { onChange } = aceEditorProps;
 
   aceEditorProps.onChange = React.useCallback(
     (newCode: string, delta: Ace.Delta) => {
@@ -470,16 +478,6 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
       onChange,
       handleEditorEval
     ]
-  );
-
-  aceEditorProps.onLoad = React.useCallback(
-    (editor: IAceEditor) => {
-      displayBreakpoints(editor, props.breakpoints);
-      if (onLoad !== undefined) {
-        onLoad(editor);
-      }
-    },
-    [props.breakpoints, onLoad]
   );
 
   aceEditorProps.commands = Object.entries(keyHandlers)

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -184,6 +184,7 @@ export async function handleHash(hash: string, props: PlaygroundProps) {
     const program = programLz && decompressFromEncodedURIComponent(programLz);
     if (program) {
       props.handleEditorValueChange(program);
+      props.handleEditorUpdateBreakpoints([]);
     }
     const variant: Variant =
       sourceLanguages.find(


### PR DESCRIPTION
### Description

Prior to #2269, the breakpoints state in the Redux store was defined but never used. As such, even though shared links never explicitly cleared the breakpoints state, the breakpoints did not persist. Now that the breakpoints state is actually used, this becomes an issue.

There are 2 steps to this fix:
1. Clear breakpoints state when loading a program from query string.
1. Force the editor to update the breakpoints display whenever the breakpoints state changes instead of just doing it once when the editor first loads. This more closely couples the breakpoints display with its state in the Redux store.

Fixes #2369.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Replicate the steps in the linked issue. If you do not wish to set up the link shortener, manually inputting the query string (which the shortened link maps to) works too for testing.