### PR TITLE
Expand sidebar by default

### DIFF
--- a/src/commons/assessmentWorkspace/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
+++ b/src/commons/assessmentWorkspace/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
@@ -230,7 +230,7 @@ exports[`AssessmentWorkspace page with ContestVoting question renders correctly 
           <div className=\\"workspace-parent\\">
             <Resizable enable={{...}} minWidth=\\"auto\\" maxWidth=\\"50%\\" onResize={[Function: toggleSideBarDividerDisplay]} onResizeStop={[Function: onResizeStop]} size={{...}} defaultSize={{...}} as=\\"div\\" onResizeStart={[Function: onResizeStart]} style={{...}} grid={{...}} lockAspectRatio={false} lockAspectRatioExtraWidth={0} lockAspectRatioExtraHeight={0} scale={1} resizeRatio={1} snapGap={0}>
               <div style={{...}} className={[undefined]}>
-                <SideBar tabs={{...}} isExpanded={false} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
+                <SideBar tabs={{...}} isExpanded={true} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
                   <div className=\\"sidebar-container\\" />
                 </SideBar>
                 <div className={[undefined]} style={[undefined]} />
@@ -982,7 +982,7 @@ exports[`AssessmentWorkspace page with MCQ question renders correctly 1`] = `
           <div className=\\"workspace-parent\\">
             <Resizable enable={{...}} minWidth=\\"auto\\" maxWidth=\\"50%\\" onResize={[Function: toggleSideBarDividerDisplay]} onResizeStop={[Function: onResizeStop]} size={{...}} defaultSize={{...}} as=\\"div\\" onResizeStart={[Function: onResizeStart]} style={{...}} grid={{...}} lockAspectRatio={false} lockAspectRatioExtraWidth={0} lockAspectRatioExtraHeight={0} scale={1} resizeRatio={1} snapGap={0}>
               <div style={{...}} className={[undefined]}>
-                <SideBar tabs={{...}} isExpanded={false} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
+                <SideBar tabs={{...}} isExpanded={true} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
                   <div className=\\"sidebar-container\\" />
                 </SideBar>
                 <div className={[undefined]} style={[undefined]} />
@@ -1562,7 +1562,7 @@ exports[`AssessmentWorkspace page with overdue assessment renders correctly 1`] 
           <div className=\\"workspace-parent\\">
             <Resizable enable={{...}} minWidth=\\"auto\\" maxWidth=\\"50%\\" onResize={[Function: toggleSideBarDividerDisplay]} onResizeStop={[Function: onResizeStop]} size={{...}} defaultSize={{...}} as=\\"div\\" onResizeStart={[Function: onResizeStart]} style={{...}} grid={{...}} lockAspectRatio={false} lockAspectRatioExtraWidth={0} lockAspectRatioExtraHeight={0} scale={1} resizeRatio={1} snapGap={0}>
               <div style={{...}} className={[undefined]}>
-                <SideBar tabs={{...}} isExpanded={false} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
+                <SideBar tabs={{...}} isExpanded={true} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
                   <div className=\\"sidebar-container\\" />
                 </SideBar>
                 <div className={[undefined]} style={[undefined]} />
@@ -2116,7 +2116,7 @@ exports[`AssessmentWorkspace page with programming question renders correctly 1`
           <div className=\\"workspace-parent\\">
             <Resizable enable={{...}} minWidth=\\"auto\\" maxWidth=\\"50%\\" onResize={[Function: toggleSideBarDividerDisplay]} onResizeStop={[Function: onResizeStop]} size={{...}} defaultSize={{...}} as=\\"div\\" onResizeStart={[Function: onResizeStart]} style={{...}} grid={{...}} lockAspectRatio={false} lockAspectRatioExtraWidth={0} lockAspectRatioExtraHeight={0} scale={1} resizeRatio={1} snapGap={0}>
               <div style={{...}} className={[undefined]}>
-                <SideBar tabs={{...}} isExpanded={false} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
+                <SideBar tabs={{...}} isExpanded={true} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
                   <div className=\\"sidebar-container\\" />
                 </SideBar>
                 <div className={[undefined]} style={[undefined]} />
@@ -2670,7 +2670,7 @@ exports[`AssessmentWorkspace renders Grading tab correctly if the question has b
           <div className=\\"workspace-parent\\">
             <Resizable enable={{...}} minWidth=\\"auto\\" maxWidth=\\"50%\\" onResize={[Function: toggleSideBarDividerDisplay]} onResizeStop={[Function: onResizeStop]} size={{...}} defaultSize={{...}} as=\\"div\\" onResizeStart={[Function: onResizeStart]} style={{...}} grid={{...}} lockAspectRatio={false} lockAspectRatioExtraWidth={0} lockAspectRatioExtraHeight={0} scale={1} resizeRatio={1} snapGap={0}>
               <div style={{...}} className={[undefined]}>
-                <SideBar tabs={{...}} isExpanded={false} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
+                <SideBar tabs={{...}} isExpanded={true} expandSideBar={[Function: expandSideBar]} collapseSideBar={[Function: collapseSideBar]}>
                   <div className=\\"sidebar-container\\" />
                 </SideBar>
                 <div className={[undefined]} style={[undefined]} />

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -42,7 +42,7 @@ const Workspace: React.FC<WorkspaceProps> = props => {
   const sideDividerDiv = React.useRef<HTMLDivElement | null>(null);
   const [contentContainerWidth] = useDimensions(contentContainerDiv);
   const [expandedSideBarWidth, setExpandedSideBarWidth] = React.useState<number>(200);
-  const [isSideBarExpanded, setIsSideBarExpanded] = React.useState<boolean>(false);
+  const [isSideBarExpanded, setIsSideBarExpanded] = React.useState<boolean>(true);
 
   const sideBarCollapsedWidth = 40;
 

--- a/src/commons/workspace/Workspace.tsx
+++ b/src/commons/workspace/Workspace.tsx
@@ -41,28 +41,13 @@ const Workspace: React.FC<WorkspaceProps> = props => {
   const maxDividerHeight = React.useRef<number | null>(null);
   const sideDividerDiv = React.useRef<HTMLDivElement | null>(null);
   const [contentContainerWidth] = useDimensions(contentContainerDiv);
-  const [lastExpandedSideBarWidth, setLastExpandedSideBarWidth] = React.useState<number>(200);
+  const [expandedSideBarWidth, setExpandedSideBarWidth] = React.useState<number>(200);
   const [isSideBarExpanded, setIsSideBarExpanded] = React.useState<boolean>(false);
 
   const sideBarCollapsedWidth = 40;
 
-  const expandSideBar = () => {
-    setIsSideBarExpanded(true);
-    const sideBar = sideBarResizable.current;
-    if (sideBar === null) {
-      throw Error('Reference to SideBar not found when expanding.');
-    }
-    sideBar.updateSize({ width: lastExpandedSideBarWidth, height: '100%' });
-  };
-
-  const collapseSideBar = () => {
-    setIsSideBarExpanded(false);
-    const sideBar = sideBarResizable.current;
-    if (sideBar === null) {
-      throw Error('Reference to SideBar not found when collapsing.');
-    }
-    sideBar.updateSize({ width: sideBarCollapsedWidth, height: '100%' });
-  };
+  const expandSideBar = () => setIsSideBarExpanded(true);
+  const collapseSideBar = () => setIsSideBarExpanded(false);
 
   FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -83,7 +68,7 @@ const Workspace: React.FC<WorkspaceProps> = props => {
     ) => {
       const sideBarWidth = elementRef.clientWidth;
       if (sideBarWidth !== sideBarCollapsedWidth) {
-        setLastExpandedSideBarWidth(sideBarWidth);
+        setExpandedSideBarWidth(sideBarWidth);
       }
     };
     const isSideBarRendered = props.sideBarProps.tabs.length !== 0;
@@ -95,9 +80,10 @@ const Workspace: React.FC<WorkspaceProps> = props => {
       onResize: toggleSideBarDividerDisplay,
       onResizeStop,
       ref: sideBarResizable,
-      // Force update of width when sidebar is not rendered or sidebar is collapsed.
-      size:
-        isSideBarRendered && isSideBarExpanded ? undefined : { width: minWidth, height: '100%' },
+      size: {
+        width: isSideBarRendered && isSideBarExpanded ? expandedSideBarWidth : minWidth,
+        height: '100%'
+      },
       defaultSize: { width: minWidth, height: '100%' }
     };
   };
@@ -139,7 +125,7 @@ const Workspace: React.FC<WorkspaceProps> = props => {
       if (sideBar === null) {
         throw Error('Reference to SideBar not found when resizing.');
       }
-      sideBar.updateSize({ width: 40, height: '100%' });
+      sideBar.updateSize({ width: sideBarCollapsedWidth, height: '100%' });
       setIsSideBarExpanded(false);
     } else {
       setIsSideBarExpanded(true);


### PR DESCRIPTION
### Description

As suggested by Prof @martin-henz, it would be sensible to expand the sidebar by default. This is so that when users enable the multiple files mode, they do not have to click two buttons (the multiple files mode button & the files sidebar tab).

In the process, I also fixed a latent bug in the sidebar width logic that surfaced due to this change. This made me realise that I could simplify the logic to make it both more readable and robust. Instead of setting the width of the sidebar whenever the `expandSideBar` and `collapseSideBar` functions are called, the responsibility of setting the width is now part of the sidebar's `Resizable` component.

Part of #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

The multiple files mode is not yet ready for production and is disabled programmatically. Enable multiple files mode for testing by changing the condition to `false`:
https://github.com/source-academy/frontend/blob/9bc11408b104e29679bfdc025992b241975ea6d7/src/pages/playground/Playground.tsx#L603-L615

In the playground, enable multiple files mode and verify that the sidebar is expanded by default.