### PR TITLE
Fix webpack configuration

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -78,7 +78,7 @@ const cracoConfig = (module.exports = {
       ];
 
       // Workaround to suppress warnings caused by ts-morph in js-slang
-      webpackConfig.module.noParse = /typescript\.js$/;
+      webpackConfig.module.noParse = /node_modules\/@ts-morph\/common\/dist\/typescript\.js$/;
 
       return webpackConfig;
     }


### PR DESCRIPTION
### Description

SA frontend is currently encountering `Uncaught ReferenceError: webpack_public_path is not defined`. This occurred because the `noParse` parameter was set to be too loose. Fix is to change the attribute to the exact path.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Frontend should load properly now.
