### PR TITLE
Standardise Acorn version to v8.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@sourceacademy/sling-client": "^0.1.0",
     "@szhsin/react-menu": "^3.2.0",
     "ace-builds": "^1.4.14",
-    "acorn": "^8.8.0",
+    "acorn": "^8.8.2",
     "ag-grid-community": "^28.0.2",
     "ag-grid-react": "^28.0.0",
     "array-move": "^4.0.0",

--- a/src/commons/repl/__tests__/__snapshots__/Repl.tsx.snap
+++ b/src/commons/repl/__tests__/__snapshots__/Repl.tsx.snap
@@ -17,7 +17,7 @@ exports[`Empty output renders an empty card 1`] = `
 exports[`Error output (no consoleLogs) renders correctly 1`] = `
 "<Blueprint4.Card elevation={0} interactive={false}>
   <Component className=\\"error-output\\">
-    Line &lt;unknown&gt;: Expected , got .
+    Expected , got .
   </Component>
 </Blueprint4.Card>"
 `;
@@ -32,7 +32,7 @@ exports[`Error output (with consoleLogs) renders correctly 1`] = `
   </Component>
   <br />
   <Component className=\\"error-output\\">
-    Line &lt;unknown&gt;: Expected , got .
+    Expected , got .
   </Component>
 </Blueprint4.Card>"
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3174,7 +3174,7 @@ acorn-walk@^8.0.0, acorn-walk@^8.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@*, acorn@^8.0.3, acorn@^8.1, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
+acorn@*, acorn@^8.0.3, acorn@^8.1, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0, acorn@^8.8.2:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==


### PR DESCRIPTION
### Description

It seems that when linking js-slang to the frontend, the mismatch in the version of Acorn results in the following error (courtesy of @zhaojj2209):
![image](https://user-images.githubusercontent.com/5585517/227775443-b31f5edc-8a74-4a21-a49c-7a8a612e610e.png)

More specifically, it is due to the following change: https://github.com/acornjs/acorn/pull/1140.

To resolve this issue, we need to ensure that both js-slang and the frontend use the same version of Acorn.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Verify that #2389 works when linking to js-slang with https://github.com/source-academy/js-slang/pull/1380 checked out.