### PR TITLE
Forbid using Folder mode with Source 1 & its variants

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -659,6 +659,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
     const chapterSelect = (
       <ControlBarChapterSelect
         handleChapterSelect={handleChapterSelect}
+        isFolderModeEnabled={isFolderModeEnabled}
         sourceChapter={props.assessment!.questions[questionId].library.chapter}
         sourceVariant={
           props.assessment!.questions[questionId].library.variant ?? Constants.defaultSourceVariant

--- a/src/commons/assessmentWorkspace/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
+++ b/src/commons/assessmentWorkspace/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
@@ -152,9 +152,9 @@ exports[`AssessmentWorkspace page with ContestVoting question renders correctly 
                     </Blueprint4.Button>
                   </ControlButton>
                 </ControlBarResetButton>
-                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
-                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
-                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
+                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} isFolderModeEnabled={false} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
+                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
+                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
                       <Blueprint4.Popover autoFocus={false} enforceFocus={false} isOpen={false} disabled={true} position=\\"bottom-left\\" className=\\"\\" onInteraction={[Function (anonymous)]} popoverClassName=\\"bp4-select-popover\\" onOpening={[Function (anonymous)]} onOpened={[Function (anonymous)]} onClosing={[Function (anonymous)]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} interactionKind=\\"click\\" minimal={false} modifiers={{...}} openOnTargetFocus={true} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
                         <Manager>
                           <span className=\\"bp4-popover-wrapper\\">
@@ -888,9 +888,9 @@ exports[`AssessmentWorkspace page with MCQ question renders correctly 1`] = `
                     </Tooltip2Provider>
                   </Blueprint4.Tooltip2>
                 </ControlBarRunButton>
-                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
-                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
-                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
+                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} isFolderModeEnabled={false} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
+                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
+                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
                       <Blueprint4.Popover autoFocus={false} enforceFocus={false} isOpen={false} disabled={true} position=\\"bottom-left\\" className=\\"\\" onInteraction={[Function (anonymous)]} popoverClassName=\\"bp4-select-popover\\" onOpening={[Function (anonymous)]} onOpened={[Function (anonymous)]} onClosing={[Function (anonymous)]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} interactionKind=\\"click\\" minimal={false} modifiers={{...}} openOnTargetFocus={true} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
                         <Manager>
                           <span className=\\"bp4-popover-wrapper\\">
@@ -1488,9 +1488,9 @@ exports[`AssessmentWorkspace page with overdue assessment renders correctly 1`] 
                     </Blueprint4.Button>
                   </ControlButton>
                 </ControlBarResetButton>
-                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
-                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
-                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
+                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} isFolderModeEnabled={false} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
+                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
+                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
                       <Blueprint4.Popover autoFocus={false} enforceFocus={false} isOpen={false} disabled={true} position=\\"bottom-left\\" className=\\"\\" onInteraction={[Function (anonymous)]} popoverClassName=\\"bp4-select-popover\\" onOpening={[Function (anonymous)]} onOpened={[Function (anonymous)]} onClosing={[Function (anonymous)]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} interactionKind=\\"click\\" minimal={false} modifiers={{...}} openOnTargetFocus={true} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
                         <Manager>
                           <span className=\\"bp4-popover-wrapper\\">
@@ -2044,9 +2044,9 @@ exports[`AssessmentWorkspace page with programming question renders correctly 1`
                     </Blueprint4.Button>
                   </ControlButton>
                 </ControlBarResetButton>
-                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
-                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
-                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
+                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} isFolderModeEnabled={false} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
+                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
+                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
                       <Blueprint4.Popover autoFocus={false} enforceFocus={false} isOpen={false} disabled={true} position=\\"bottom-left\\" className=\\"\\" onInteraction={[Function (anonymous)]} popoverClassName=\\"bp4-select-popover\\" onOpening={[Function (anonymous)]} onOpened={[Function (anonymous)]} onClosing={[Function (anonymous)]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} interactionKind=\\"click\\" minimal={false} modifiers={{...}} openOnTargetFocus={true} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
                         <Manager>
                           <span className=\\"bp4-popover-wrapper\\">
@@ -2600,9 +2600,9 @@ exports[`AssessmentWorkspace renders Grading tab correctly if the question has b
                     </Blueprint4.Button>
                   </ControlButton>
                 </ControlBarResetButton>
-                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
-                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
-                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function: chapterRenderer]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
+                <ControlBarChapterSelect handleChapterSelect={[Function: handleChapterSelect]} isFolderModeEnabled={false} sourceChapter={1} sourceVariant=\\"default\\" disabled={true}>
+                  <Blueprint4.Select items={{...}} onItemSelect={[Function: handleChapterSelect]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} filterable={false} disabled={true}>
+                    <Blueprint4.QueryList items={{...}} onItemSelect={[Function (anonymous)]} itemRenderer={[Function (anonymous)]} itemListRenderer={[Function: chapterListRenderer]} disabled={true} renderer={[Function (anonymous)]} resetOnQuery={true}>
                       <Blueprint4.Popover autoFocus={false} enforceFocus={false} isOpen={false} disabled={true} position=\\"bottom-left\\" className=\\"\\" onInteraction={[Function (anonymous)]} popoverClassName=\\"bp4-select-popover\\" onOpening={[Function (anonymous)]} onOpened={[Function (anonymous)]} onClosing={[Function (anonymous)]} boundary=\\"scrollParent\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} hoverCloseDelay={300} hoverOpenDelay={150} inheritDarkTheme={true} interactionKind=\\"click\\" minimal={false} modifiers={{...}} openOnTargetFocus={true} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" transitionDuration={300} usePortal={true} wrapperTagName=\\"span\\">
                         <Manager>
                           <span className=\\"bp4-popover-wrapper\\">

--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -53,7 +53,9 @@ const chapterRenderer: (isFolderModeEnabled: boolean) => ItemRenderer<SALanguage
   (isFolderModeEnabled: boolean) =>
   (lang, { handleClick }) => {
     const isDisabled = isFolderModeEnabled && lang.chapter === Chapter.SOURCE_1;
-    const tooltipContent = isDisabled ? 'Cannot use Source 1 while in Folder mode' : '';
+    const tooltipContent = isDisabled
+      ? 'Folder mode makes use of lists which are not available in Source 1. To switch to Source 1, disable Folder mode.'
+      : '';
     return (
       <Tooltip2 content={tooltipContent}>
         <MenuItem

--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -1,5 +1,6 @@
 import { Button, Classes, Menu, MenuItem } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { ItemListRenderer, ItemRenderer, Select } from '@blueprintjs/select';
 import { Chapter, Variant } from 'js-slang/dist/types';
 import React from 'react';
@@ -23,6 +24,7 @@ type DispatchProps = {
 };
 
 type StateProps = {
+  isFolderModeEnabled: boolean;
   sourceChapter: Chapter;
   sourceVariant: Variant;
   disabled?: boolean;
@@ -35,7 +37,7 @@ const chapterListRenderer: ItemListRenderer<SALanguage> = ({ itemsParentRef, ren
   const fullTSChoice = renderItem(fullTSLanguage, 0);
   const htmlChoice = renderItem(htmlLanguage, 0);
   return (
-    <Menu ulRef={itemsParentRef}>
+    <Menu ulRef={itemsParentRef} style={{ display: 'flex', flexDirection: 'column' }}>
       {defaultChoices}
       {Constants.playgroundOnly && fullJSChoice}
       {Constants.playgroundOnly && fullTSChoice}
@@ -47,13 +49,27 @@ const chapterListRenderer: ItemListRenderer<SALanguage> = ({ itemsParentRef, ren
   );
 };
 
-const chapterRenderer: ItemRenderer<SALanguage> = (lang, { handleClick }) => (
-  <MenuItem key={lang.displayName} onClick={handleClick} text={lang.displayName} />
-);
+const chapterRenderer: (isFolderModeEnabled: boolean) => ItemRenderer<SALanguage> =
+  (isFolderModeEnabled: boolean) =>
+  (lang, { handleClick }) => {
+    const isDisabled = isFolderModeEnabled && lang.chapter === Chapter.SOURCE_1;
+    const tooltipContent = isDisabled ? 'Cannot use Source 1 while in Folder mode' : '';
+    return (
+      <Tooltip2 content={tooltipContent}>
+        <MenuItem
+          key={lang.displayName}
+          onClick={handleClick}
+          text={lang.displayName}
+          disabled={isDisabled}
+        />
+      </Tooltip2>
+    );
+  };
 
 const ChapterSelectComponent = Select.ofType<SALanguage>();
 
 export const ControlBarChapterSelect: React.FC<ControlBarChapterSelectProps> = ({
+  isFolderModeEnabled,
   sourceChapter,
   sourceVariant,
   handleChapterSelect = () => {},
@@ -63,7 +79,7 @@ export const ControlBarChapterSelect: React.FC<ControlBarChapterSelectProps> = (
     <ChapterSelectComponent
       items={sourceLanguages}
       onItemSelect={handleChapterSelect}
-      itemRenderer={chapterRenderer}
+      itemRenderer={chapterRenderer(isFolderModeEnabled)}
       itemListRenderer={chapterListRenderer}
       filterable={false}
       disabled={disabled}

--- a/src/commons/sideContent/githubAssessments/SideContentMissionEditor.tsx
+++ b/src/commons/sideContent/githubAssessments/SideContentMissionEditor.tsx
@@ -8,6 +8,7 @@ import { MissionMetadata } from '../../githubAssessments/GitHubMissionTypes';
 import Constants from '../../utils/Constants';
 
 export type SideContentMissionEditorProps = {
+  isFolderModeEnabled: boolean;
   missionMetadata: MissionMetadata;
   setMissionMetadata: (missionMetadata: MissionMetadata) => void;
 };
@@ -21,6 +22,7 @@ const SideContentMissionEditor: React.FC<SideContentMissionEditorProps> = props 
         </div>
         <div className="SideContentMissionEditorOptionColumn">
           <ControlBarChapterSelect
+            isFolderModeEnabled={props.isFolderModeEnabled}
             sourceChapter={props.missionMetadata.sourceVersion}
             sourceVariant={Constants.defaultSourceVariant}
             key="chapter"

--- a/src/pages/academy/sourcereel/Sourcereel.tsx
+++ b/src/pages/academy/sourcereel/Sourcereel.tsx
@@ -222,6 +222,7 @@ const Sourcereel: React.FC<SourcereelProps> = props => {
   const chapterSelect = (
     <ControlBarChapterSelect
       handleChapterSelect={chapterSelectHandler}
+      isFolderModeEnabled={isFolderModeEnabled}
       sourceChapter={props.sourceChapter}
       sourceVariant={props.sourceVariant}
       key="chapter"

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -871,6 +871,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
         iconName: IconNames.BUILD,
         body: (
           <SideContentMissionEditor
+            isFolderModeEnabled={isFolderModeEnabled}
             missionMetadata={missionMetadata}
             setMissionMetadata={setMissionMetadataWrapper}
           />
@@ -929,6 +930,7 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
     const chapterSelect = (
       <ControlBarChapterSelect
         handleChapterSelect={() => {}}
+        isFolderModeEnabled={isFolderModeEnabled}
         sourceChapter={missionMetadata.sourceVersion}
         sourceVariant={Constants.defaultSourceVariant}
         disabled={true}

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -962,9 +962,10 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
           chapterSelect,
           props.playgroundSourceChapter === Chapter.FULL_JS ? null : shareButton,
           isSicpEditor ? null : sessionButtons,
+          // Local imports/exports require Source 2+ as Source 1 does not have lists.
+          props.playgroundSourceChapter === Chapter.SOURCE_1 ? null : toggleFolderModeButton,
           persistenceButtons,
-          githubButtons,
-          toggleFolderModeButton
+          githubButtons
         ]
       },
       selectedTabId: selectedTab,

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -468,6 +468,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
     () => (
       <ControlBarChapterSelect
         handleChapterSelect={chapterSelectHandler}
+        isFolderModeEnabled={isFolderModeEnabled}
         sourceChapter={props.playgroundSourceChapter}
         sourceVariant={props.playgroundSourceVariant}
         key="chapter"
@@ -476,6 +477,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
     ),
     [
       chapterSelectHandler,
+      isFolderModeEnabled,
       props.playgroundSourceChapter,
       props.playgroundSourceVariant,
       usingRemoteExecution

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -917,7 +917,8 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
         props.playgroundSourceChapter === Chapter.FULL_JS ? null : shareButton,
         chapterSelect,
         isSicpEditor ? null : sessionButtons,
-        toggleFolderModeButton,
+        // Local imports/exports require Source 2+ as Source 1 does not have lists.
+        props.playgroundSourceChapter === Chapter.SOURCE_1 ? null : toggleFolderModeButton,
         persistenceButtons,
         githubButtons,
         usingRemoteExecution || !isSourceLanguage(props.playgroundSourceChapter)

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -211,6 +211,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
   const chapterSelect = (
     <ControlBarChapterSelect
       handleChapterSelect={chapterSelectHandler}
+      isFolderModeEnabled={isFolderModeEnabled}
       sourceChapter={props.sourceChapter}
       sourceVariant={props.sourceVariant}
       key="chapter"


### PR DESCRIPTION
### Description

Because local imports/exports rely on the use of data structures, it cannot be used in Source 1. Lists are only introduced in Source 2+. As such, we do not want to allow Folder mode when using Source 1. As discussed with Prof @martin-henz, we will impose the following restrictions:
1. When the current sublanguage is Source 1 and its variants, the control bar button to toggle Folder mode is not shown.
1. When in Folder mode, Source 1 and its variants are disabled in the sublanguage selector.

![image](https://user-images.githubusercontent.com/5585517/228569575-48d4125c-80a6-4712-a179-36120f388d1c.png)

Part of #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

The Folder mode is not yet ready for production and is disabled programmatically. Enable Folder mode for testing by changing the condition to `false`:
https://github.com/source-academy/frontend/blob/b90a7a249be4969e6127e08eedc06900db2a78d5/src/pages/playground/Playground.tsx#L609-L622

Check that the behaviour is as described above.