### PR TITLE
Disable collaborative editing mode & Folder mode from being used together

### DIFF
--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -55,9 +55,13 @@ const chapterRenderer: (isFolderModeEnabled: boolean) => ItemRenderer<SALanguage
     const isDisabled = isFolderModeEnabled && lang.chapter === Chapter.SOURCE_1;
     const tooltipContent = isDisabled
       ? 'Folder mode makes use of lists which are not available in Source 1. To switch to Source 1, disable Folder mode.'
-      : '';
+      : undefined;
     return (
-      <Tooltip2 key={lang.displayName} content={tooltipContent}>
+      <Tooltip2
+        key={lang.displayName}
+        content={tooltipContent}
+        disabled={tooltipContent === undefined}
+      >
         <MenuItem onClick={handleClick} text={lang.displayName} disabled={isDisabled} />
       </Tooltip2>
     );

--- a/src/commons/controlBar/ControlBarSessionButton.tsx
+++ b/src/commons/controlBar/ControlBarSessionButton.tsx
@@ -1,6 +1,6 @@
 import { Classes, Colors, Menu } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { Popover2 } from '@blueprintjs/popover2';
+import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
 import * as CopyToClipboard from 'react-copy-to-clipboard';
 
@@ -15,6 +15,7 @@ type DispatchProps = {
 };
 
 type StateProps = {
+  isFolderModeEnabled: boolean;
   editorSessionId?: string;
   getEditorValue: () => string;
   sharedbConnected?: boolean;
@@ -124,28 +125,35 @@ export class ControlBarSessionButtons extends React.PureComponent<
       />
     );
 
+    const tooltipContent = this.props.isFolderModeEnabled
+      ? 'Currently unsupported in Folder mode'
+      : undefined;
+
     return (
-      <Popover2
-        content={
-          <Menu large={true}>
-            {inviteButton}
-            {this.props.editorSessionId === '' ? joinButton : leaveButton}
-          </Menu>
-        }
-      >
-        <ControlButton
-          label="Session"
-          icon={IconNames.SOCIAL_MEDIA}
-          options={{
-            iconColor:
-              this.props.editorSessionId === ''
-                ? undefined
-                : this.props.sharedbConnected
-                ? Colors.GREEN3
-                : Colors.RED3
-          }}
-        />
-      </Popover2>
+      <Tooltip2 content={tooltipContent} disabled={tooltipContent === undefined}>
+        <Popover2
+          content={
+            <Menu large={true}>
+              {inviteButton}
+              {this.props.editorSessionId === '' ? joinButton : leaveButton}
+            </Menu>
+          }
+        >
+          <ControlButton
+            label="Session"
+            icon={IconNames.SOCIAL_MEDIA}
+            options={{
+              iconColor:
+                this.props.editorSessionId === ''
+                  ? undefined
+                  : this.props.sharedbConnected
+                  ? Colors.GREEN3
+                  : Colors.RED3
+            }}
+            isDisabled={this.props.isFolderModeEnabled}
+          />
+        </Popover2>
+      </Tooltip2>
     );
   }
 

--- a/src/commons/controlBar/ControlBarSessionButton.tsx
+++ b/src/commons/controlBar/ControlBarSessionButton.tsx
@@ -138,6 +138,7 @@ export class ControlBarSessionButtons extends React.PureComponent<
               {this.props.editorSessionId === '' ? joinButton : leaveButton}
             </Menu>
           }
+          disabled={this.props.isFolderModeEnabled}
         >
           <ControlButton
             label="Session"

--- a/src/commons/controlBar/ControlBarToggleFolderModeButton.tsx
+++ b/src/commons/controlBar/ControlBarToggleFolderModeButton.tsx
@@ -7,14 +7,18 @@ import ControlButton from '../ControlButton';
 
 type ControlBarToggleFolderModeButtonProps = {
   isFolderModeEnabled: boolean;
+  isSessionActive: boolean;
   toggleFolderMode: () => void;
 };
 
 export const ControlBarToggleFolderModeButton: React.FC<ControlBarToggleFolderModeButtonProps> = ({
   isFolderModeEnabled,
+  isSessionActive,
   toggleFolderMode
 }) => {
-  const tooltipContent = `${isFolderModeEnabled ? 'Disable' : 'Enable'} Folder mode`;
+  const tooltipContent = isSessionActive
+    ? 'Currently unsupported while a collaborative session is active'
+    : `${isFolderModeEnabled ? 'Disable' : 'Enable'} Folder mode`;
   return (
     <Tooltip2 content={tooltipContent}>
       <ControlButton
@@ -24,6 +28,7 @@ export const ControlBarToggleFolderModeButton: React.FC<ControlBarToggleFolderMo
           iconColor: isFolderModeEnabled ? Colors.BLUE4 : undefined
         }}
         onClick={toggleFolderMode}
+        isDisabled={isSessionActive}
       />
     </Tooltip2>
   );

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -684,11 +684,12 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
     return (
       <ControlBarToggleFolderModeButton
         isFolderModeEnabled={isFolderModeEnabled}
+        isSessionActive={props.editorSessionId !== ''}
         toggleFolderMode={() => dispatch(toggleFolderMode(workspaceLocation))}
         key="folder"
       />
     );
-  }, [dispatch, isFolderModeEnabled, workspaceLocation]);
+  }, [dispatch, isFolderModeEnabled, props.editorSessionId, workspaceLocation]);
 
   const playgroundIntroductionTab: SideContentTab = React.useMemo(
     () => ({

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -632,6 +632,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
   );
 
   const getEditorValue = React.useCallback(
+    // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
     () => store.getState().workspaces[workspaceLocation].editorTabs[0].value,
     [store, workspaceLocation]
   );
@@ -639,15 +640,22 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
   const sessionButtons = React.useMemo(
     () => (
       <ControlBarSessionButtons
+        isFolderModeEnabled={isFolderModeEnabled}
         editorSessionId={props.editorSessionId}
-        // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
         getEditorValue={getEditorValue}
         handleSetEditorSessionId={id => dispatch(setEditorSessionId(workspaceLocation, id))}
         sharedbConnected={props.sharedbConnected}
         key="session"
       />
     ),
-    [dispatch, getEditorValue, props.editorSessionId, props.sharedbConnected, workspaceLocation]
+    [
+      dispatch,
+      getEditorValue,
+      isFolderModeEnabled,
+      props.editorSessionId,
+      props.sharedbConnected,
+      workspaceLocation
+    ]
   );
 
   const shareButton = React.useMemo(() => {


### PR DESCRIPTION
### Description

![image](https://user-images.githubusercontent.com/5585517/229129876-786dd68f-7fd1-4fd2-a3c8-3828edd0611a.png)
![image](https://user-images.githubusercontent.com/5585517/229130093-c3d4ebd8-4d60-4f05-b86f-df83d901bf0d.png)

Part of #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

The Folder mode is not yet ready for production and is disabled programmatically. Enable Folder mode for testing by changing the condition to `false`:
https://github.com/source-academy/frontend/blob/b90a7a249be4969e6127e08eedc06900db2a78d5/src/pages/playground/Playground.tsx#L609-L622

Check that collaborative editing mode & Folder mode cannot be enabled at the same time.