### PR TITLE
Handle cases where no editor tabs are open

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -642,7 +642,13 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
         <ControlBarResetButton onClick={onClickResetTemplate} key="reset_template" />
       ) : null;
 
-    const runButton = <ControlBarRunButton handleEditorEval={handleEval} key="run" />;
+    const runButton = (
+      <ControlBarRunButton
+        isEntrypointFileDefined={activeEditorTabIndex !== null}
+        handleEditorEval={handleEval}
+        key="run"
+      />
+    );
 
     const saveButton =
       props.canSave &&

--- a/src/commons/assessmentWorkspace/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
+++ b/src/commons/assessmentWorkspace/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
@@ -93,7 +93,7 @@ exports[`AssessmentWorkspace page with ContestVoting question renders correctly 
           <ControlBar editorButtons={{...}} flowButtons={{...}}>
             <div className=\\"ControlBar\\">
               <div className=\\"ControlBar_editor bp4-button-group\\">
-                <ControlBarRunButton handleEditorEval={[Function: handleEval]}>
+                <ControlBarRunButton isEntrypointFileDefined={true} handleEditorEval={[Function: handleEval]}>
                   <Blueprint4.Tooltip2 content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" compact={false} hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100}>
                     <Tooltip2Provider>
                       <Blueprint4.Popover2 modifiers={{...}} content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} disabled={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp4-tooltip2\\" portalContainer={[undefined]} boundary=\\"clippingParents\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} matchTargetWidth={false} openOnTargetFocus={true} positioningStrategy=\\"absolute\\" renderTarget={[undefined]} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" usePortal={true}>
@@ -101,7 +101,7 @@ exports[`AssessmentWorkspace page with ContestVoting question renders correctly 
                           <Reference>
                             <Blueprint4.ResizeSensor2 targetRef={[Function (anonymous)]} onResize={[Function (anonymous)]}>
                               <span aria-haspopup={[undefined]} className=\\"bp4-popover2-target\\" onBlur={[Function (anonymous)]} onContextMenu={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]}>
-                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} isDisabled={false} className=\\"\\" disabled={[undefined]} tabIndex={0}>
                                   <Blueprint4.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className={[undefined]} type={[undefined]} onClick={[Function: handleEval]} icon={{...}} rightIcon={false}>
                                     <button type={[undefined]} disabled={false} className=\\"bp4-button bp4-minimal\\" onClick={[Function: handleEval]} onBlur={[Function (anonymous)]} onFocus={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
                                       <Blueprint4.Icon icon={{...}}>
@@ -850,7 +850,7 @@ exports[`AssessmentWorkspace page with MCQ question renders correctly 1`] = `
           <ControlBar editorButtons={{...}} flowButtons={{...}}>
             <div className=\\"ControlBar\\">
               <div className=\\"ControlBar_editor bp4-button-group\\">
-                <ControlBarRunButton handleEditorEval={[Function: handleEval]}>
+                <ControlBarRunButton isEntrypointFileDefined={true} handleEditorEval={[Function: handleEval]}>
                   <Blueprint4.Tooltip2 content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" compact={false} hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100}>
                     <Tooltip2Provider>
                       <Blueprint4.Popover2 modifiers={{...}} content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} disabled={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp4-tooltip2\\" portalContainer={[undefined]} boundary=\\"clippingParents\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} matchTargetWidth={false} openOnTargetFocus={true} positioningStrategy=\\"absolute\\" renderTarget={[undefined]} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" usePortal={true}>
@@ -858,7 +858,7 @@ exports[`AssessmentWorkspace page with MCQ question renders correctly 1`] = `
                           <Reference>
                             <Blueprint4.ResizeSensor2 targetRef={[Function (anonymous)]} onResize={[Function (anonymous)]}>
                               <span aria-haspopup={[undefined]} className=\\"bp4-popover2-target\\" onBlur={[Function (anonymous)]} onContextMenu={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]}>
-                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} isDisabled={false} className=\\"\\" disabled={[undefined]} tabIndex={0}>
                                   <Blueprint4.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className={[undefined]} type={[undefined]} onClick={[Function: handleEval]} icon={{...}} rightIcon={false}>
                                     <button type={[undefined]} disabled={false} className=\\"bp4-button bp4-minimal\\" onClick={[Function: handleEval]} onBlur={[Function (anonymous)]} onFocus={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
                                       <Blueprint4.Icon icon={{...}}>
@@ -1429,7 +1429,7 @@ exports[`AssessmentWorkspace page with overdue assessment renders correctly 1`] 
           <ControlBar editorButtons={{...}} flowButtons={{...}}>
             <div className=\\"ControlBar\\">
               <div className=\\"ControlBar_editor bp4-button-group\\">
-                <ControlBarRunButton handleEditorEval={[Function: handleEval]}>
+                <ControlBarRunButton isEntrypointFileDefined={true} handleEditorEval={[Function: handleEval]}>
                   <Blueprint4.Tooltip2 content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" compact={false} hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100}>
                     <Tooltip2Provider>
                       <Blueprint4.Popover2 modifiers={{...}} content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} disabled={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp4-tooltip2\\" portalContainer={[undefined]} boundary=\\"clippingParents\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} matchTargetWidth={false} openOnTargetFocus={true} positioningStrategy=\\"absolute\\" renderTarget={[undefined]} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" usePortal={true}>
@@ -1437,7 +1437,7 @@ exports[`AssessmentWorkspace page with overdue assessment renders correctly 1`] 
                           <Reference>
                             <Blueprint4.ResizeSensor2 targetRef={[Function (anonymous)]} onResize={[Function (anonymous)]}>
                               <span aria-haspopup={[undefined]} className=\\"bp4-popover2-target\\" onBlur={[Function (anonymous)]} onContextMenu={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]}>
-                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} isDisabled={false} className=\\"\\" disabled={[undefined]} tabIndex={0}>
                                   <Blueprint4.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className={[undefined]} type={[undefined]} onClick={[Function: handleEval]} icon={{...}} rightIcon={false}>
                                     <button type={[undefined]} disabled={false} className=\\"bp4-button bp4-minimal\\" onClick={[Function: handleEval]} onBlur={[Function (anonymous)]} onFocus={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
                                       <Blueprint4.Icon icon={{...}}>
@@ -1964,7 +1964,7 @@ exports[`AssessmentWorkspace page with programming question renders correctly 1`
           <ControlBar editorButtons={{...}} flowButtons={{...}}>
             <div className=\\"ControlBar\\">
               <div className=\\"ControlBar_editor bp4-button-group\\">
-                <ControlBarRunButton handleEditorEval={[Function: handleEval]}>
+                <ControlBarRunButton isEntrypointFileDefined={true} handleEditorEval={[Function: handleEval]}>
                   <Blueprint4.Tooltip2 content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" compact={false} hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100}>
                     <Tooltip2Provider>
                       <Blueprint4.Popover2 modifiers={{...}} content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} disabled={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp4-tooltip2\\" portalContainer={[undefined]} boundary=\\"clippingParents\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} matchTargetWidth={false} openOnTargetFocus={true} positioningStrategy=\\"absolute\\" renderTarget={[undefined]} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" usePortal={true}>
@@ -1972,7 +1972,7 @@ exports[`AssessmentWorkspace page with programming question renders correctly 1`
                           <Reference>
                             <Blueprint4.ResizeSensor2 targetRef={[Function (anonymous)]} onResize={[Function (anonymous)]}>
                               <span aria-haspopup={[undefined]} className=\\"bp4-popover2-target\\" onBlur={[Function (anonymous)]} onContextMenu={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]}>
-                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} isDisabled={false} className=\\"\\" disabled={[undefined]} tabIndex={0}>
                                   <Blueprint4.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className={[undefined]} type={[undefined]} onClick={[Function: handleEval]} icon={{...}} rightIcon={false}>
                                     <button type={[undefined]} disabled={false} className=\\"bp4-button bp4-minimal\\" onClick={[Function: handleEval]} onBlur={[Function (anonymous)]} onFocus={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
                                       <Blueprint4.Icon icon={{...}}>
@@ -2520,7 +2520,7 @@ exports[`AssessmentWorkspace renders Grading tab correctly if the question has b
           <ControlBar editorButtons={{...}} flowButtons={{...}}>
             <div className=\\"ControlBar\\">
               <div className=\\"ControlBar_editor bp4-button-group\\">
-                <ControlBarRunButton handleEditorEval={[Function: handleEval]}>
+                <ControlBarRunButton isEntrypointFileDefined={true} handleEditorEval={[Function: handleEval]}>
                   <Blueprint4.Tooltip2 content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" compact={false} hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100}>
                     <Tooltip2Provider>
                       <Blueprint4.Popover2 modifiers={{...}} content=\\"...or press shift-enter in the editor\\" placement=\\"top\\" hoverCloseDelay={0} hoverOpenDelay={100} interactionKind=\\"hover-target\\" minimal={false} transitionDuration={100} autoFocus={false} canEscapeKeyClose={false} disabled={false} enforceFocus={false} lazy={true} popoverClassName=\\"bp4-tooltip2\\" portalContainer={[undefined]} boundary=\\"clippingParents\\" captureDismiss={false} defaultIsOpen={false} fill={false} hasBackdrop={false} inheritDarkTheme={true} matchTargetWidth={false} openOnTargetFocus={true} positioningStrategy=\\"absolute\\" renderTarget={[undefined]} shouldReturnFocusOnClose={false} targetTagName=\\"span\\" usePortal={true}>
@@ -2528,7 +2528,7 @@ exports[`AssessmentWorkspace renders Grading tab correctly if the question has b
                           <Reference>
                             <Blueprint4.ResizeSensor2 targetRef={[Function (anonymous)]} onResize={[Function (anonymous)]}>
                               <span aria-haspopup={[undefined]} className=\\"bp4-popover2-target\\" onBlur={[Function (anonymous)]} onContextMenu={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseEnter={[Function (anonymous)]} onMouseLeave={[Function (anonymous)]}>
-                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} className=\\"\\" disabled={[undefined]} tabIndex={0}>
+                                <ControlButton label=\\"Run\\" icon=\\"play\\" onClick={[Function: handleEval]} options={{...}} isDisabled={false} className=\\"\\" disabled={[undefined]} tabIndex={0}>
                                   <Blueprint4.Button disabled={false} fill={false} intent=\\"none\\" minimal={true} className={[undefined]} type={[undefined]} onClick={[Function: handleEval]} icon={{...}} rightIcon={false}>
                                     <button type={[undefined]} disabled={false} className=\\"bp4-button bp4-minimal\\" onClick={[Function: handleEval]} onBlur={[Function (anonymous)]} onFocus={[undefined]} onKeyDown={[Function (anonymous)]} onKeyUp={[Function (anonymous)]} tabIndex={[undefined]}>
                                       <Blueprint4.Icon icon={{...}}>

--- a/src/commons/controlBar/ControlBarAutorunButtons.tsx
+++ b/src/commons/controlBar/ControlBarAutorunButtons.tsx
@@ -18,6 +18,7 @@ type DispatchProps = {
 };
 
 type StateProps = {
+  isEntrypointFileDefined: boolean;
   isDebugging: boolean;
   isEditorAutorun?: boolean;
   isRunning: boolean;
@@ -31,6 +32,7 @@ export const ControlBarAutorunButtons: React.FC<ControlBarAutorunButtonProps> = 
   const showRunButton = !props.isDebugging && (
     <ControlBarRunButton
       handleEditorEval={props.handleEditorEval}
+      isEntrypointFileDefined={props.isEntrypointFileDefined}
       // Neon Green: #39FF14
       color={props.isRunning ? '#39FF14' : undefined}
       className={props.isRunning ? 'WaitingCursor' : undefined}

--- a/src/commons/controlBar/ControlBarRunButton.tsx
+++ b/src/commons/controlBar/ControlBarRunButton.tsx
@@ -13,18 +13,23 @@ type DispatchProps = {
 
 type StateProps = {
   key: string;
+  isEntrypointFileDefined: boolean;
   color?: string;
   className?: string;
 };
 
 export const ControlBarRunButton: React.FC<ControlButtonRunButtonProps> = props => {
+  const tooltipContent = props.isEntrypointFileDefined
+    ? '...or press shift-enter in the editor'
+    : 'Open a file to evaluate the program with the file as the entrypoint';
   return (
-    <Tooltip2 content="...or press shift-enter in the editor" placement={Position.TOP}>
+    <Tooltip2 content={tooltipContent} placement={Position.TOP}>
       <ControlButton
         label="Run"
         icon={IconNames.PLAY}
         onClick={props.handleEditorEval}
         options={{ iconColor: props.color, className: props.className }}
+        isDisabled={!props.isEntrypointFileDefined}
       />
     </Tooltip2>
   );

--- a/src/commons/editingWorkspace/EditingWorkspace.tsx
+++ b/src/commons/editingWorkspace/EditingWorkspace.tsx
@@ -572,7 +572,13 @@ const EditingWorkspace: React.FC<EditingWorkspaceProps> = props => {
       <ControlBarResetButton onClick={onClickResetTemplate} key="reset_template" />
     );
 
-    const runButton = <ControlBarRunButton handleEditorEval={props.handleEditorEval} key="run" />;
+    const runButton = (
+      <ControlBarRunButton
+        isEntrypointFileDefined={activeEditorTabIndex !== null}
+        handleEditorEval={props.handleEditorEval}
+        key="run"
+      />
+    );
 
     const saveButton = (
       <ControlButtonSaveButton

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -649,8 +649,7 @@ export function* evalEditor(
   ]);
 
   if (activeEditorTabIndex === null) {
-    // TODO: Implement this.
-    throw new Error('To be handled...');
+    throw new Error('Cannot evaluate program without an entrypoint file.');
   }
 
   const defaultFilePath = `${WORKSPACE_BASE_PATHS[workspaceLocation]}/program.js`;

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -104,6 +104,7 @@ export default function* WorkspaceSaga(): SagaIterator {
       const isFolderModeEnabled: boolean = yield select(
         (state: OverallState) => state.workspaces[workspaceLocation].isFolderModeEnabled
       );
+      yield put(actions.setFolderMode(workspaceLocation, !isFolderModeEnabled));
       const warningMessage = `Folder mode ${isFolderModeEnabled ? 'enabled' : 'disabled'}`;
       yield call(showWarningMessage, warningMessage, 750);
     }

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -30,6 +30,7 @@ import DataVisualizer from '../../features/dataVisualizer/dataVisualizer';
 import { DeviceSession } from '../../features/remoteExecution/RemoteExecutionTypes';
 import { WORKSPACE_BASE_PATHS } from '../../pages/fileSystem/createInBrowserFileSystem';
 import {
+  defaultEditorValue,
   isSourceLanguage,
   OverallState,
   styliseSublanguage
@@ -44,7 +45,7 @@ import {
 } from '../application/types/InterpreterTypes';
 import { Library, Testcase, TestcaseType, TestcaseTypes } from '../assessment/AssessmentTypes';
 import { Documentation } from '../documentation/Documentation';
-import { retrieveFilesInWorkspaceAsRecord } from '../fileSystem/utils';
+import { retrieveFilesInWorkspaceAsRecord, writeFileRecursively } from '../fileSystem/utils';
 import { SideContentType } from '../sideContent/SideContentTypes';
 import { actions } from '../utils/ActionsHelper';
 import DisplayBufferService from '../utils/DisplayBufferService';
@@ -77,6 +78,7 @@ import {
   PLAYGROUND_EXTERNAL_SELECT,
   PlaygroundWorkspaceState,
   PROMPT_AUTOCOMPLETE,
+  SET_FOLDER_MODE,
   SicpWorkspaceState,
   TOGGLE_EDITOR_AUTORUN,
   TOGGLE_FOLDER_MODE,
@@ -109,6 +111,56 @@ export default function* WorkspaceSaga(): SagaIterator {
       yield call(showWarningMessage, warningMessage, 750);
     }
   );
+
+  yield takeEvery(SET_FOLDER_MODE, function* (action: ReturnType<typeof actions.setFolderMode>) {
+    const workspaceLocation = action.payload.workspaceLocation;
+    const isFolderModeEnabled: boolean = yield select(
+      (state: OverallState) => state.workspaces[workspaceLocation].isFolderModeEnabled
+    );
+    // Do nothing if Folder mode is enabled.
+    if (isFolderModeEnabled) {
+      return;
+    }
+
+    const editorTabs: EditorTabState[] = yield select(
+      (state: OverallState) => state.workspaces[workspaceLocation].editorTabs
+    );
+    // If Folder mode is disabled and there are no open editor tabs, add an editor tab.
+    if (editorTabs.length === 0) {
+      const defaultFilePath = `${WORKSPACE_BASE_PATHS[workspaceLocation]}/program.js`;
+      const fileSystem: FSModule | null = yield select(
+        (state: OverallState) => state.fileSystem.inBrowserFileSystem
+      );
+      // If the file system is not initialised, add an editor tab with the default editor value.
+      if (fileSystem === null) {
+        yield put(actions.addEditorTab(workspaceLocation, defaultFilePath, defaultEditorValue));
+        return;
+      }
+      const editorValue: string = yield new Promise((resolve, reject) => {
+        fileSystem.exists(defaultFilePath, fileExists => {
+          if (!fileExists) {
+            // If the file does not exist, we need to also create it in the file system.
+            writeFileRecursively(fileSystem, defaultFilePath, defaultEditorValue)
+              .then(() => resolve(defaultEditorValue))
+              .catch(err => reject(err));
+            return;
+          }
+          fileSystem.readFile(defaultFilePath, 'utf-8', (err, fileContents) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            if (fileContents === undefined) {
+              reject(new Error('File exists but has no contents.'));
+              return;
+            }
+            resolve(fileContents);
+          });
+        });
+      });
+      yield put(actions.addEditorTab(workspaceLocation, defaultFilePath, editorValue));
+    }
+  });
 
   // Mirror editor updates to the associated file in the filesystem.
   yield takeEvery(

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -43,7 +43,8 @@ import {
   endClearContext,
   moveCursor,
   sendReplInputToOutput,
-  setEditorHighlightedLines
+  setEditorHighlightedLines,
+  setFolderMode
 } from '../../workspace/WorkspaceActions';
 import {
   BEGIN_CLEAR_CONTEXT,
@@ -93,7 +94,7 @@ beforeEach(() => {
 });
 
 describe('TOGGLE_FOLDER_MODE', () => {
-  test('calls showWarningMessage correctly when isFolderMode is false', () => {
+  test('enables Folder mode & calls showWarningMessage correctly when isFolderMode is false', () => {
     const workspaceLocation = 'assessment';
     const updatedWorkspaceFields: Partial<WorkspaceState> = {
       isFolderModeEnabled: false
@@ -102,6 +103,7 @@ describe('TOGGLE_FOLDER_MODE', () => {
 
     return expectSaga(workspaceSaga)
       .withState(updatedDefaultState)
+      .put(setFolderMode(workspaceLocation, true))
       .call(showWarningMessage, 'Folder mode disabled', 750)
       .dispatch({
         type: TOGGLE_FOLDER_MODE,
@@ -110,7 +112,7 @@ describe('TOGGLE_FOLDER_MODE', () => {
       .silentRun();
   });
 
-  test('calls showWarningMessage correctly when isFolderMode is true', () => {
+  test('disables Folder mode & calls showWarningMessage correctly when isFolderMode is true', () => {
     const workspaceLocation = 'grading';
     const updatedWorkspaceFields: Partial<WorkspaceState> = {
       isFolderModeEnabled: true
@@ -119,6 +121,7 @@ describe('TOGGLE_FOLDER_MODE', () => {
 
     return expectSaga(workspaceSaga)
       .withState(updatedDefaultState)
+      .put(setFolderMode(workspaceLocation, false))
       .call(showWarningMessage, 'Folder mode enabled', 750)
       .dispatch({
         type: TOGGLE_FOLDER_MODE,

--- a/src/commons/workspace/WorkspaceReducer.ts
+++ b/src/commons/workspace/WorkspaceReducer.ts
@@ -56,7 +56,6 @@ import {
   SET_FOLDER_MODE,
   SHIFT_EDITOR_TAB,
   TOGGLE_EDITOR_AUTORUN,
-  TOGGLE_FOLDER_MODE,
   TOGGLE_USING_SUBST,
   UPDATE_ACTIVE_EDITOR_TAB,
   UPDATE_ACTIVE_EDITOR_TAB_INDEX,
@@ -591,14 +590,6 @@ export const WorkspaceReducer: Reducer<WorkspaceManagerState> = (
           ...state.grading,
           currentSubmission: action.payload.submissionId,
           currentQuestion: action.payload.questionId
-        }
-      };
-    case TOGGLE_FOLDER_MODE:
-      return {
-        ...state,
-        [workspaceLocation]: {
-          ...state[workspaceLocation],
-          isFolderModeEnabled: !state[workspaceLocation].isFolderModeEnabled
         }
       };
     case SET_FOLDER_MODE:

--- a/src/commons/workspace/__tests__/WorkspaceReducer.ts
+++ b/src/commons/workspace/__tests__/WorkspaceReducer.ts
@@ -55,7 +55,6 @@ import {
   SET_FOLDER_MODE,
   SHIFT_EDITOR_TAB,
   TOGGLE_EDITOR_AUTORUN,
-  TOGGLE_FOLDER_MODE,
   TOGGLE_USING_SUBST,
   UPDATE_ACTIVE_EDITOR_TAB,
   UPDATE_ACTIVE_EDITOR_TAB_INDEX,
@@ -1289,33 +1288,6 @@ describe('UPDATE_CURRENT_SUBMISSION_ID', () => {
         currentSubmission: submissionId,
         currentQuestion: questionId
       }
-    });
-  });
-});
-
-describe('TOGGLE_FOLDER_MODE', () => {
-  test('toggles isFolderModeEnabled correctly', () => {
-    const actions = generateActions(TOGGLE_FOLDER_MODE);
-
-    actions.forEach(action => {
-      let result = WorkspaceReducer(defaultWorkspaceManager, action);
-      const location = action.payload.workspaceLocation;
-      expect(result).toEqual({
-        ...defaultWorkspaceManager,
-        [location]: {
-          ...defaultWorkspaceManager[location],
-          isFolderModeEnabled: true
-        }
-      });
-
-      result = WorkspaceReducer(result, action);
-      expect(result).toEqual({
-        ...defaultWorkspaceManager,
-        [location]: {
-          ...defaultWorkspaceManager[location],
-          isFolderModeEnabled: false
-        }
-      });
     });
   });
 });

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -416,7 +416,13 @@ class GradingWorkspace extends React.Component<GradingWorkspaceProps, State> {
       <ControlBarQuestionViewButton questionProgress={questionProgress} key="question_view" />
     );
 
-    const runButton = <ControlBarRunButton handleEditorEval={this.handleEval} key="run" />;
+    const runButton = (
+      <ControlBarRunButton
+        isEntrypointFileDefined={this.props.activeEditorTabIndex !== null}
+        handleEditorEval={this.handleEval}
+        key="run"
+      />
+    );
 
     return {
       editorButtons: [runButton],

--- a/src/pages/academy/sourcereel/Sourcereel.tsx
+++ b/src/pages/academy/sourcereel/Sourcereel.tsx
@@ -200,6 +200,7 @@ const Sourcereel: React.FC<SourcereelProps> = props => {
       handleEditorEval={editorEvalHandler}
       handleInterruptEval={() => dispatch(beginInterruptExecution(workspaceLocation))}
       handleToggleEditorAutorun={() => dispatch(toggleEditorAutorun(workspaceLocation))}
+      isEntrypointFileDefined={activeEditorTabIndex !== null}
       isDebugging={props.isDebugging}
       isEditorAutorun={props.isEditorAutorun}
       isRunning={props.isRunning}

--- a/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
+++ b/src/pages/githubAssessments/GitHubAssessmentWorkspace.tsx
@@ -915,7 +915,13 @@ const GitHubAssessmentWorkspace: React.FC<GitHubAssessmentWorkspaceProps> = prop
   };
 
   const controlBarProps: () => ControlBarProps = () => {
-    const runButton = <ControlBarRunButton handleEditorEval={handleEval} key="run" />;
+    const runButton = (
+      <ControlBarRunButton
+        isEntrypointFileDefined={activeEditorTabIndex !== null}
+        handleEditorEval={handleEval}
+        key="run"
+      />
+    );
 
     const saveButton = (
       <ControlButtonSaveButton

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -465,6 +465,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
   const autorunButtons = React.useMemo(() => {
     return (
       <ControlBarAutorunButtons
+        isEntrypointFileDefined={activeEditorTabIndex !== null}
         isDebugging={props.isDebugging}
         isEditorAutorun={props.isEditorAutorun}
         isRunning={props.isRunning}
@@ -482,6 +483,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
       />
     );
   }, [
+    activeEditorTabIndex,
     handleDebuggerPause,
     handleDebuggerReset,
     handleDebuggerResume,

--- a/src/pages/sourcecast/Sourcecast.tsx
+++ b/src/pages/sourcecast/Sourcecast.tsx
@@ -198,6 +198,7 @@ const Sourcecast: React.FC<SourcecastProps> = props => {
       handleEditorEval={props.handleEditorEval}
       handleInterruptEval={() => dispatch(beginInterruptExecution(workspaceLocation))}
       handleToggleEditorAutorun={() => dispatch(toggleEditorAutorun(workspaceLocation))}
+      isEntrypointFileDefined={activeEditorTabIndex !== null}
       isDebugging={props.isDebugging}
       isEditorAutorun={props.isEditorAutorun}
       isRunning={props.isRunning}


### PR DESCRIPTION
### Description

It is possible for users to close all editor tabs. After discussion with Prof @martin-henz, we want to add the following behaviours:
* The run button is now disabled when Folder mode is enabled with no open editor tabs. This is because Folder mode relies on the currently open editor tab to determine what the entrypoint of the program should be. Without an open editor tab, there is no program entrypoint and the program cannot be evaluated.
* When the user disables Folder mode without any editor tabs open, a default file (`/program.js`) will be open as an editor tab. If the default file does not exist in the file system, it is created with the default editor value.

Part of #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

The Folder mode is not yet ready for production and is disabled programmatically. Enable Folder mode for testing by changing the condition to `false`:
https://github.com/source-academy/frontend/blob/b90a7a249be4969e6127e08eedc06900db2a78d5/src/pages/playground/Playground.tsx#L609-L622

Check that the behaviours described above work.