### PR TITLE
Disable persistence methods in Folder mode

### DIFF
--- a/src/commons/controlBar/ControlBarGoogleDriveButtons.tsx
+++ b/src/commons/controlBar/ControlBarGoogleDriveButtons.tsx
@@ -8,6 +8,7 @@ import ControlButton from '../ControlButton';
 import { useResponsive } from '../utils/Hooks';
 
 export type ControlBarGoogleDriveButtonsProps = {
+  isFolderModeEnabled: boolean;
   loggedInAs?: string;
   currentFile?: PersistenceFile;
   isDirty?: boolean;
@@ -36,6 +37,7 @@ export const ControlBarGoogleDriveButtons: React.FC<ControlBarGoogleDriveButtons
       label={(props.currentFile && props.currentFile.name) || 'Google Drive'}
       icon={IconNames.CLOUD}
       options={{ intent: stateToIntent[state] }}
+      isDisabled={props.isFolderModeEnabled}
     />
   );
   const openButton = (
@@ -58,24 +60,30 @@ export const ControlBarGoogleDriveButtons: React.FC<ControlBarGoogleDriveButtons
       <ControlButton label="Log out" icon={IconNames.LOG_OUT} onClick={props.onClickLogOut} />
     </Tooltip2>
   );
+  const tooltipContent = props.isFolderModeEnabled
+    ? 'Currently unsupported in Folder mode'
+    : undefined;
 
   return (
-    <Popover2
-      autoFocus={false}
-      content={
-        <div>
-          <ButtonGroup large={!isMobileBreakpoint}>
-            {openButton}
-            {saveButton}
-            {saveAsButton}
-            {logoutButton}
-          </ButtonGroup>
-        </div>
-      }
-      onOpening={props.onPopoverOpening}
-      popoverClassName={Classes.POPOVER_DISMISS}
-    >
-      {mainButton}
-    </Popover2>
+    <Tooltip2 content={tooltipContent} disabled={tooltipContent === undefined}>
+      <Popover2
+        autoFocus={false}
+        content={
+          <div>
+            <ButtonGroup large={!isMobileBreakpoint}>
+              {openButton}
+              {saveButton}
+              {saveAsButton}
+              {logoutButton}
+            </ButtonGroup>
+          </div>
+        }
+        onOpening={props.onPopoverOpening}
+        popoverClassName={Classes.POPOVER_DISMISS}
+        disabled={props.isFolderModeEnabled}
+      >
+        {mainButton}
+      </Popover2>
+    </Tooltip2>
   );
 };

--- a/src/commons/controlBar/ControlBarToggleFolderModeButton.tsx
+++ b/src/commons/controlBar/ControlBarToggleFolderModeButton.tsx
@@ -8,16 +8,20 @@ import ControlButton from '../ControlButton';
 type ControlBarToggleFolderModeButtonProps = {
   isFolderModeEnabled: boolean;
   isSessionActive: boolean;
+  isPersistenceActive: boolean;
   toggleFolderMode: () => void;
 };
 
 export const ControlBarToggleFolderModeButton: React.FC<ControlBarToggleFolderModeButtonProps> = ({
   isFolderModeEnabled,
   isSessionActive,
+  isPersistenceActive,
   toggleFolderMode
 }) => {
   const tooltipContent = isSessionActive
     ? 'Currently unsupported while a collaborative session is active'
+    : isPersistenceActive
+    ? 'Currently unsupported while a persistence method is active'
     : `${isFolderModeEnabled ? 'Disable' : 'Enable'} Folder mode`;
   return (
     <Tooltip2 content={tooltipContent}>
@@ -28,7 +32,7 @@ export const ControlBarToggleFolderModeButton: React.FC<ControlBarToggleFolderMo
           iconColor: isFolderModeEnabled ? Colors.BLUE4 : undefined
         }}
         onClick={toggleFolderMode}
-        isDisabled={isSessionActive}
+        isDisabled={isSessionActive || isPersistenceActive}
       />
     </Tooltip2>
   );

--- a/src/commons/controlBar/github/ControlBarGitHubButtons.tsx
+++ b/src/commons/controlBar/github/ControlBarGitHubButtons.tsx
@@ -1,6 +1,6 @@
 import { ButtonGroup, Classes, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { Popover2 } from '@blueprintjs/popover2';
+import { Popover2, Tooltip2 } from '@blueprintjs/popover2';
 import { Octokit } from '@octokit/rest';
 import * as React from 'react';
 import { useResponsive } from 'src/commons/utils/Hooks';
@@ -9,6 +9,7 @@ import { GitHubSaveInfo } from '../../../features/github/GitHubTypes';
 import ControlButton from '../../ControlButton';
 
 export type ControlBarGitHubButtonsProps = {
+  isFolderModeEnabled: boolean;
   loggedInAs?: Octokit;
   githubSaveInfo: GitHubSaveInfo;
   isDirty: boolean;
@@ -47,6 +48,7 @@ export const ControlBarGitHubButtons: React.FC<ControlBarGitHubButtonsProps> = p
       label={mainButtonDisplayText}
       icon={IconNames.GIT_BRANCH}
       options={{ intent: mainButtonIntent }}
+      isDisabled={props.isFolderModeEnabled}
     />
   );
 
@@ -83,22 +85,29 @@ export const ControlBarGitHubButtons: React.FC<ControlBarGitHubButtonsProps> = p
     <ControlButton label="Log In" icon={IconNames.LOG_IN} onClick={props.onClickLogIn} />
   );
 
+  const tooltipContent = props.isFolderModeEnabled
+    ? 'Currently unsupported in Folder mode'
+    : undefined;
+
   return (
-    <Popover2
-      autoFocus={false}
-      content={
-        <div>
-          <ButtonGroup large={!isMobileBreakpoint}>
-            {openButton}
-            {saveButton}
-            {saveAsButton}
-            {loginButton}
-          </ButtonGroup>
-        </div>
-      }
-      popoverClassName={Classes.POPOVER_DISMISS}
-    >
-      {mainButton}
-    </Popover2>
+    <Tooltip2 content={tooltipContent} disabled={tooltipContent === undefined}>
+      <Popover2
+        autoFocus={false}
+        content={
+          <div>
+            <ButtonGroup large={!isMobileBreakpoint}>
+              {openButton}
+              {saveButton}
+              {saveAsButton}
+              {loginButton}
+            </ButtonGroup>
+          </div>
+        }
+        popoverClassName={Classes.POPOVER_DISMISS}
+        disabled={props.isFolderModeEnabled}
+      >
+        {mainButton}
+      </Popover2>
+    </Tooltip2>
   );
 };

--- a/src/commons/sagas/GitHubPersistenceSaga.ts
+++ b/src/commons/sagas/GitHubPersistenceSaga.ts
@@ -3,7 +3,7 @@ import {
   GetResponseTypeFromEndpointMethod
 } from '@octokit/types';
 import { SagaIterator } from 'redux-saga';
-import { call, put, takeLatest } from 'redux-saga/effects';
+import { call, put, select, takeLatest } from 'redux-saga/effects';
 
 import {
   GITHUB_OPEN_FILE,
@@ -13,6 +13,7 @@ import {
 import * as GitHubUtils from '../../features/github/GitHubUtils';
 import { getGitHubOctokitInstance } from '../../features/github/GitHubUtils';
 import { store } from '../../pages/createStore';
+import { OverallState } from '../application/ApplicationTypes';
 import { LOGIN_GITHUB, LOGOUT_GITHUB } from '../application/types/SessionTypes';
 import FileExplorerDialog, { FileExplorerDialogProps } from '../gitHubOverlay/FileExplorerDialog';
 import RepositoryDialog, { RepositoryDialogProps } from '../gitHubOverlay/RepositoryDialog';
@@ -20,6 +21,7 @@ import { actions } from '../utils/ActionsHelper';
 import Constants from '../utils/Constants';
 import { promisifyDialog } from '../utils/DialogHelper';
 import { showSuccessMessage, showWarningMessage } from '../utils/NotificationsHelper';
+import { EditorTabState } from '../workspace/WorkspaceTypes';
 
 export function* GitHubPersistenceSaga(): SagaIterator {
   yield takeLatest(LOGIN_GITHUB, githubLoginSaga);
@@ -121,8 +123,16 @@ function* githubSaveFile(): any {
   const githubEmail = authUser.data.email;
   const githubName = authUser.data.name;
   const commitMessage = 'Changes made from Source Academy';
-  // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-  const content = store.getState().workspaces.playground.editorTabs[0].value;
+  const activeEditorTabIndex: number | null = yield select(
+    (state: OverallState) => state.workspaces.playground.activeEditorTabIndex
+  );
+  if (activeEditorTabIndex === null) {
+    throw new Error('No active editor tab found.');
+  }
+  const editorTabs: EditorTabState[] = yield select(
+    (state: OverallState) => state.workspaces.playground.editorTabs
+  );
+  const content = editorTabs[activeEditorTabIndex].value;
 
   GitHubUtils.performOverwritingSave(
     octokit,
@@ -160,8 +170,16 @@ function* githubSaveFileAs(): any {
     }));
   const repoName = yield call(getRepoName);
 
-  // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-  const editorContent = store.getState().workspaces.playground.editorTabs[0].value;
+  const activeEditorTabIndex: number | null = yield select(
+    (state: OverallState) => state.workspaces.playground.activeEditorTabIndex
+  );
+  if (activeEditorTabIndex === null) {
+    throw new Error('No active editor tab found.');
+  }
+  const editorTabs: EditorTabState[] = yield select(
+    (state: OverallState) => state.workspaces.playground.editorTabs
+  );
+  const editorContent = editorTabs[activeEditorTabIndex].value;
 
   if (repoName !== '') {
     const pickerType = 'Save';

--- a/src/commons/sagas/PersistenceSaga.tsx
+++ b/src/commons/sagas/PersistenceSaga.tsx
@@ -78,8 +78,13 @@ export function* persistenceSaga(): SagaIterator {
         fields: 'appProperties'
       });
       const contents = yield call([gapi.client.drive.files, 'get'], { fileId: id, alt: 'media' });
-      // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-      yield put(actions.updateEditorValue('playground', 0, contents.body));
+      const activeEditorTabIndex: number | null = yield select(
+        (state: OverallState) => state.workspaces.playground.activeEditorTabIndex
+      );
+      if (activeEditorTabIndex === null) {
+        throw new Error('No active editor tab found.');
+      }
+      yield put(actions.updateEditorValue('playground', activeEditorTabIndex, contents.body));
       yield put(actions.playgroundUpdatePersistenceFile({ id, name, lastSaved: new Date() }));
       if (meta && meta.appProperties) {
         yield put(
@@ -114,13 +119,20 @@ export function* persistenceSaga(): SagaIterator {
     try {
       yield call(ensureInitialisedAndAuthorised);
 
-      const [code, chapter, variant, external] = yield select((state: OverallState) => [
-        // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-        state.workspaces.playground.editorTabs[0].value,
-        state.workspaces.playground.context.chapter,
-        state.workspaces.playground.context.variant,
-        state.workspaces.playground.externalLibrary
-      ]);
+      const [activeEditorTabIndex, editorTabs, chapter, variant, external] = yield select(
+        (state: OverallState) => [
+          state.workspaces.playground.activeEditorTabIndex,
+          state.workspaces.playground.editorTabs,
+          state.workspaces.playground.context.chapter,
+          state.workspaces.playground.context.variant,
+          state.workspaces.playground.externalLibrary
+        ]
+      );
+
+      if (activeEditorTabIndex === null) {
+        throw new Error('No active editor tab found.');
+      }
+      const code = editorTabs[activeEditorTabIndex].value;
 
       const pickedDir: PickFileResult = yield call(
         pickFile,
@@ -237,13 +249,20 @@ export function* persistenceSaga(): SagaIterator {
 
         yield call(ensureInitialisedAndAuthorised);
 
-        const [code, chapter, variant, external] = yield select((state: OverallState) => [
-          // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-          state.workspaces.playground.editorTabs[0].value,
-          state.workspaces.playground.context.chapter,
-          state.workspaces.playground.context.variant,
-          state.workspaces.playground.externalLibrary
-        ]);
+        const [activeEditorTabIndex, editorTabs, chapter, variant, external] = yield select(
+          (state: OverallState) => [
+            state.workspaces.playground.activeEditorTabIndex,
+            state.workspaces.playground.editorTabs,
+            state.workspaces.playground.context.chapter,
+            state.workspaces.playground.context.variant,
+            state.workspaces.playground.externalLibrary
+          ]
+        );
+
+        if (activeEditorTabIndex === null) {
+          throw new Error('No active editor tab found.');
+        }
+        const code = editorTabs[activeEditorTabIndex].value;
 
         const config: IPlaygroundConfig = {
           chapter,

--- a/src/commons/sagas/__tests__/PersistenceSaga.ts
+++ b/src/commons/sagas/__tests__/PersistenceSaga.ts
@@ -72,50 +72,60 @@ test('LOGOUT_GOOGLE causes logout', async () => {
 
 describe('PERSISTENCE_OPEN_PICKER', () => {
   test('opens a file on success path', () => {
-    return (
-      expectSaga(PersistenceSaga)
-        .dispatch(actions.persistenceOpenPicker())
-        .provide({
-          call(effect, next) {
-            switch (effect.fn.name) {
-              case 'pickFile':
-                return { id: FILE_ID, name: FILE_NAME, picked: true };
-              case 'showSimpleConfirmDialog':
-                return true;
-              case 'get':
-                expect(effect.args[0].fileId).toEqual(FILE_ID);
-                if (effect.args[0].alt === 'media') {
-                  return { body: FILE_DATA };
-                } else if (effect.args[0].fields.includes('appProperties')) {
-                  return {
-                    result: {
-                      appProperties: {
-                        chapter: SOURCE_CHAPTER,
-                        variant: SOURCE_VARIANT,
-                        external: SOURCE_LIBRARY
-                      }
-                    }
-                  };
-                }
-                break;
-              case 'ensureInitialisedAndAuthorised':
-              case 'ensureInitialised':
-              case 'showMessage':
-              case 'showSuccessMessage':
-                return;
+    return expectSaga(PersistenceSaga)
+      .withState({
+        workspaces: {
+          playground: {
+            activeEditorTabIndex: 0,
+            editorTabs: [{ value: FILE_DATA }],
+            externalLibrary: SOURCE_LIBRARY,
+            context: {
+              chapter: SOURCE_CHAPTER,
+              variant: SOURCE_VARIANT
             }
-            fail(`unexpected function called: ${effect.fn.name}`);
           }
-        })
-        .put.like({
-          action: actions.playgroundUpdatePersistenceFile({ id: FILE_ID, name: FILE_NAME })
-        })
-        // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-        .put(actions.updateEditorValue('playground', 0, FILE_DATA))
-        .put(actions.chapterSelect(SOURCE_CHAPTER, SOURCE_VARIANT, 'playground'))
-        .put(actions.externalLibrarySelect(SOURCE_LIBRARY, 'playground'))
-        .silentRun()
-    );
+        }
+      })
+      .dispatch(actions.persistenceOpenPicker())
+      .provide({
+        call(effect, next) {
+          switch (effect.fn.name) {
+            case 'pickFile':
+              return { id: FILE_ID, name: FILE_NAME, picked: true };
+            case 'showSimpleConfirmDialog':
+              return true;
+            case 'get':
+              expect(effect.args[0].fileId).toEqual(FILE_ID);
+              if (effect.args[0].alt === 'media') {
+                return { body: FILE_DATA };
+              } else if (effect.args[0].fields.includes('appProperties')) {
+                return {
+                  result: {
+                    appProperties: {
+                      chapter: SOURCE_CHAPTER,
+                      variant: SOURCE_VARIANT,
+                      external: SOURCE_LIBRARY
+                    }
+                  }
+                };
+              }
+              break;
+            case 'ensureInitialisedAndAuthorised':
+            case 'ensureInitialised':
+            case 'showMessage':
+            case 'showSuccessMessage':
+              return;
+          }
+          fail(`unexpected function called: ${effect.fn.name}`);
+        }
+      })
+      .put.like({
+        action: actions.playgroundUpdatePersistenceFile({ id: FILE_ID, name: FILE_NAME })
+      })
+      .put(actions.updateEditorValue('playground', 0, FILE_DATA))
+      .put(actions.chapterSelect(SOURCE_CHAPTER, SOURCE_VARIANT, 'playground'))
+      .put(actions.externalLibrarySelect(SOURCE_LIBRARY, 'playground'))
+      .silentRun();
   });
 
   test('does not open if picker cancelled', () => {
@@ -171,6 +181,7 @@ test('PERSISTENCE_SAVE_FILE saves', () => {
     .withState({
       workspaces: {
         playground: {
+          activeEditorTabIndex: 0,
           editorTabs: [{ value: FILE_DATA }],
           externalLibrary: SOURCE_LIBRARY,
           context: {
@@ -222,6 +233,7 @@ describe('PERSISTENCE_SAVE_FILE_AS', () => {
       .withState({
         workspaces: {
           playground: {
+            activeEditorTabIndex: 0,
             editorTabs: [{ value: FILE_DATA }],
             externalLibrary: SOURCE_LIBRARY,
             context: {
@@ -279,6 +291,7 @@ describe('PERSISTENCE_SAVE_FILE_AS', () => {
       .withState({
         workspaces: {
           playground: {
+            activeEditorTabIndex: 0,
             editorTabs: [{ value: FILE_DATA }],
             externalLibrary: SOURCE_LIBRARY,
             context: {
@@ -336,6 +349,7 @@ describe('PERSISTENCE_SAVE_FILE_AS', () => {
       .withState({
         workspaces: {
           playground: {
+            activeEditorTabIndex: 0,
             editorTabs: [{ value: FILE_DATA }],
             externalLibrary: SOURCE_LIBRARY,
             context: {
@@ -395,6 +409,7 @@ describe('PERSISTENCE_SAVE_FILE_AS', () => {
       .withState({
         workspaces: {
           playground: {
+            activeEditorTabIndex: 0,
             editorTabs: [{ value: FILE_DATA }],
             externalLibrary: SOURCE_LIBRARY,
             context: {
@@ -453,6 +468,7 @@ describe('PERSISTENCE_SAVE_FILE_AS', () => {
       .withState({
         workspaces: {
           playground: {
+            activeEditorTabIndex: 0,
             editorTabs: [{ value: FILE_DATA }],
             externalLibrary: SOURCE_LIBRARY,
             context: {

--- a/src/features/github/GitHubUtils.tsx
+++ b/src/features/github/GitHubUtils.tsx
@@ -192,8 +192,11 @@ export async function openFileInEditor(
 
   if (content) {
     const newEditorValue = Buffer.from(content, 'base64').toString();
-    // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
-    store.dispatch(actions.updateEditorValue('playground', 0, newEditorValue));
+    const activeEditorTabIndex = store.getState().workspaces.playground.activeEditorTabIndex;
+    if (activeEditorTabIndex === null) {
+      throw new Error('No active editor tab found.');
+    }
+    store.dispatch(actions.updateEditorValue('playground', activeEditorTabIndex, newEditorValue));
     store.dispatch(actions.playgroundUpdateGitHubSaveInfo(repoName, filePath, new Date()));
     showSuccessMessage('Successfully loaded file!', 1000);
   }

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -595,6 +595,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
     return (
       <ControlBarGitHubButtons
         key="github"
+        isFolderModeEnabled={isFolderModeEnabled}
         loggedInAs={githubOctokitObject.octokit}
         githubSaveInfo={githubSaveInfo}
         isDirty={githubPersistenceIsDirty}
@@ -605,7 +606,13 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
         onClickLogOut={() => dispatch(logoutGitHub())}
       />
     );
-  }, [dispatch, githubOctokitObject, githubPersistenceIsDirty, githubSaveInfo]);
+  }, [
+    dispatch,
+    githubOctokitObject.octokit,
+    githubPersistenceIsDirty,
+    githubSaveInfo,
+    isFolderModeEnabled
+  ]);
 
   const executionTime = React.useMemo(
     () => (

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -695,11 +695,19 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
       <ControlBarToggleFolderModeButton
         isFolderModeEnabled={isFolderModeEnabled}
         isSessionActive={props.editorSessionId !== ''}
+        isPersistenceActive={persistenceFile !== undefined || githubSaveInfo.repoName !== ''}
         toggleFolderMode={() => dispatch(toggleFolderMode(workspaceLocation))}
         key="folder"
       />
     );
-  }, [dispatch, isFolderModeEnabled, props.editorSessionId, workspaceLocation]);
+  }, [
+    dispatch,
+    githubSaveInfo.repoName,
+    isFolderModeEnabled,
+    persistenceFile,
+    props.editorSessionId,
+    workspaceLocation
+  ]);
 
   const playgroundIntroductionTab: SideContentTab = React.useMemo(
     () => ({

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -571,6 +571,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
   const persistenceButtons = React.useMemo(() => {
     return (
       <ControlBarGoogleDriveButtons
+        isFolderModeEnabled={isFolderModeEnabled}
         currentFile={persistenceFile}
         loggedInAs={persistenceUser}
         isDirty={persistenceIsDirty}
@@ -584,7 +585,7 @@ const Playground: React.FC<PlaygroundProps> = ({ workspaceLocation = 'playground
         onPopoverOpening={() => dispatch(persistenceInitialise())}
       />
     );
-  }, [dispatch, persistenceUser, persistenceFile, persistenceIsDirty]);
+  }, [isFolderModeEnabled, persistenceFile, persistenceUser, persistenceIsDirty, dispatch]);
 
   const githubOctokitObject = useTypedSelector(store => store.session.githubOctokitObject);
   const githubSaveInfo = props.githubSaveInfo;


### PR DESCRIPTION
### Description

The persistence methods will have to be reworked to account for Folder mode in the future. For now, we disallow saving to GitHub & Google Drive when in Folder mode.

Also updated the code relating to persistence so that it can work with any active editor tab index (and not just 0).

Related to #2176.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

The Folder mode is not yet ready for production and is disabled programmatically. Enable Folder mode for testing by changing the condition to `false`:
https://github.com/source-academy/frontend/blob/b90a7a249be4969e6127e08eedc06900db2a78d5/src/pages/playground/Playground.tsx#L609-L622

Check that the persistence methods cannot be used in Folder mode.