### PR TITLE
Fix Folder mode toggle notification being reversed

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -107,7 +107,7 @@ export default function* WorkspaceSaga(): SagaIterator {
         (state: OverallState) => state.workspaces[workspaceLocation].isFolderModeEnabled
       );
       yield put(actions.setFolderMode(workspaceLocation, !isFolderModeEnabled));
-      const warningMessage = `Folder mode ${isFolderModeEnabled ? 'enabled' : 'disabled'}`;
+      const warningMessage = `Folder mode ${!isFolderModeEnabled ? 'enabled' : 'disabled'}`;
       yield call(showWarningMessage, warningMessage, 750);
     }
   );

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -96,10 +96,10 @@ beforeEach(() => {
 describe('TOGGLE_FOLDER_MODE', () => {
   test('enables Folder mode & calls showWarningMessage correctly when isFolderMode is false', () => {
     const workspaceLocation = 'assessment';
-    const updatedWorkspaceFields: Partial<WorkspaceState> = {
+    const currentWorkspaceFields: Partial<WorkspaceState> = {
       isFolderModeEnabled: false
     };
-    const updatedDefaultState = generateDefaultState(workspaceLocation, updatedWorkspaceFields);
+    const updatedDefaultState = generateDefaultState(workspaceLocation, currentWorkspaceFields);
 
     return expectSaga(workspaceSaga)
       .withState(updatedDefaultState)
@@ -114,10 +114,10 @@ describe('TOGGLE_FOLDER_MODE', () => {
 
   test('disables Folder mode & calls showWarningMessage correctly when isFolderMode is true', () => {
     const workspaceLocation = 'grading';
-    const updatedWorkspaceFields: Partial<WorkspaceState> = {
+    const currentWorkspaceFields: Partial<WorkspaceState> = {
       isFolderModeEnabled: true
     };
-    const updatedDefaultState = generateDefaultState(workspaceLocation, updatedWorkspaceFields);
+    const updatedDefaultState = generateDefaultState(workspaceLocation, currentWorkspaceFields);
 
     return expectSaga(workspaceSaga)
       .withState(updatedDefaultState)

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -104,7 +104,7 @@ describe('TOGGLE_FOLDER_MODE', () => {
     return expectSaga(workspaceSaga)
       .withState(updatedDefaultState)
       .put(setFolderMode(workspaceLocation, true))
-      .call(showWarningMessage, 'Folder mode disabled', 750)
+      .call(showWarningMessage, 'Folder mode enabled', 750)
       .dispatch({
         type: TOGGLE_FOLDER_MODE,
         payload: { workspaceLocation }
@@ -122,7 +122,7 @@ describe('TOGGLE_FOLDER_MODE', () => {
     return expectSaga(workspaceSaga)
       .withState(updatedDefaultState)
       .put(setFolderMode(workspaceLocation, false))
-      .call(showWarningMessage, 'Folder mode enabled', 750)
+      .call(showWarningMessage, 'Folder mode disabled', 750)
       .dispatch({
         type: TOGGLE_FOLDER_MODE,
         payload: { workspaceLocation }


### PR DESCRIPTION
### Description

The `TOGGLE_FOLDER_MODE` action was made to rely on the `SET_FOLDER_MODE` action in #2399. However, this change resulted in the Folder mode toggle notification being reversed due to the change in the control flow of how the `TOGGLE_FOLDER_MODE` action is dispatched to the Redux store. Specifically, the `TOGGLE_FOLDER_MODE` saga used to run after the Folder mode state was toggled. Now, it runs before the state is toggled as it is responsible for dispatching the `SET_FOLDER_MODE` action.

Fixes #2409.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Check that enabling/disabling Folder mode results in the correct notification.