### PR TITLE
Give focus to existing editor tab when opening already opened file

### DIFF
--- a/src/commons/workspace/WorkspaceReducer.ts
+++ b/src/commons/workspace/WorkspaceReducer.ts
@@ -737,12 +737,20 @@ export const WorkspaceReducer: Reducer<WorkspaceManagerState> = (
     }
     case ADD_EDITOR_TAB: {
       const { filePath, editorValue } = action.payload;
-      const fileIsAlreadyOpen =
-        state[workspaceLocation].editorTabs.find(
-          (editorTab: EditorTabState) => editorTab.filePath === filePath
-        ) !== undefined;
+
+      const editorTabs = state[workspaceLocation].editorTabs;
+      const openedEditorTabIndex = editorTabs.findIndex(
+        (editorTab: EditorTabState) => editorTab.filePath === filePath
+      );
+      const fileIsAlreadyOpen = openedEditorTabIndex !== -1;
       if (fileIsAlreadyOpen) {
-        return state;
+        return {
+          ...state,
+          [workspaceLocation]: {
+            ...state[workspaceLocation],
+            activeEditorTabIndex: openedEditorTabIndex
+          }
+        };
       }
 
       const newEditorTab: EditorTabState = {

--- a/src/commons/workspace/__tests__/WorkspaceReducer.ts
+++ b/src/commons/workspace/__tests__/WorkspaceReducer.ts
@@ -1780,6 +1780,7 @@ describe('ADD_EDITOR_TAB', () => {
     breakpoints: []
   };
   const firstEditorTab: EditorTabState = {
+    filePath: '/goodbyeworld.js',
     value: 'Goodbye World!',
     highlightedLines: [],
     breakpoints: []
@@ -1823,8 +1824,8 @@ describe('ADD_EDITOR_TAB', () => {
     });
   });
 
-  test('does nothing if the file is already open as an editor tab', () => {
-    const filePath = '/helloworld.js';
+  test('sets the active editor tab index if the file is already open as an editor tab', () => {
+    const filePath = '/goodbyeworld.js';
     const editorValue = 'The quick brown fox jumped over the lazy pomeranian.';
     const defaultWorkspaceState: WorkspaceManagerState = generateDefaultWorkspace({
       activeEditorTabIndex: 0,
@@ -1835,9 +1836,18 @@ describe('ADD_EDITOR_TAB', () => {
 
     actions.forEach(action => {
       const result = WorkspaceReducer(defaultWorkspaceState, action);
+      const location = action.payload.workspaceLocation;
       // Note: we stringify because context contains functions which cause
       // the two to compare unequal; stringifying strips functions
-      expect(JSON.stringify(result)).toEqual(JSON.stringify(defaultWorkspaceState));
+      expect(JSON.stringify(result)).toEqual(
+        JSON.stringify({
+          ...defaultWorkspaceState,
+          [location]: {
+            ...defaultWorkspaceState[location],
+            activeEditorTabIndex: 1
+          }
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
### Description

Currently, trying to open a file that already has an existing editor tab open results in nothing happening, which can be confusing to the user. By making this change, the file that the user is interacting with will always end up at the active editor tab regardless of whether it was already open or not.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Try to open a file that is already opened as an editor tab, but is not the active editor tab. Focus should be given to the editor tab corresponding to the file being opened.