### PR TITLE
Load application even when IndexedDB is unavailable

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,8 @@ console.log(`Using module backend: ${Constants.moduleBackendUrl}`);
 
 // Initialise the browser file system before rendering to avoid race conditions on the file system.
 createInBrowserFileSystem(store)
-  .then(() => {
+  .catch(err => console.error(err))
+  .finally(() => {
     render(
       <Provider store={store}>
         <Router history={history}>
@@ -47,8 +48,7 @@ createInBrowserFileSystem(store)
       </Provider>,
       rootContainer
     );
-  })
-  .catch(err => console.error(err));
+  });
 
 registerServiceWorker({
   onUpdate: () => {


### PR DESCRIPTION
### Description

This is an issue in browsers where IndexedDB is unavailable while in private browsing mode (i.e., Firefox). The Chromium browsers are fine because they make use of an emulation of IndexedDB that only exists in memory.

Regression introduced in #2396. Related to #2238.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Open the Source Academy in Firefox's private browsing mode and check that the application loads.