### PR TITLE
Fix Source HTML chapter display

### DIFF
--- a/src/commons/sideContent/SideContentHtmlDisplay.tsx
+++ b/src/commons/sideContent/SideContentHtmlDisplay.tsx
@@ -29,7 +29,7 @@ const SideContentHtmlDisplay: React.FC<SideContentHtmlDisplayProps> = props => {
       className="sa-html-display"
       title="HTML Display"
       sandbox="allow-scripts"
-      srcDoc={content}
+      srcDoc={JSON.parse(content)}
       src="about:blank"
     />
   );

--- a/src/commons/sideContent/__tests__/SideContentHtmlDisplay.tsx
+++ b/src/commons/sideContent/__tests__/SideContentHtmlDisplay.tsx
@@ -1,11 +1,12 @@
 import { fireEvent } from '@testing-library/react';
 import { mount } from 'enzyme';
+import { stringify } from 'js-slang/dist/utils/stringify';
 
 import SideContentHtmlDisplay from '../SideContentHtmlDisplay';
 
 test('HTML Display renders correctly', () => {
   const mockProps = {
-    content: '<p>Hello World!</p>',
+    content: stringify('<p>Hello World!</p>'),
     handleAddHtmlConsoleError: (errorMsg: string) => {}
   };
   const htmlDisplay = mount(<SideContentHtmlDisplay {...mockProps} />);
@@ -16,7 +17,7 @@ describe('HTML Display postMessage Listener', () => {
   const mockHandleAddHtmlConsoleError = jest.fn((errorMsg: string) => {});
 
   const mockProps = {
-    content: '<p>Hello World!</p>',
+    content: stringify('<p>Hello World!</p>'),
     handleAddHtmlConsoleError: mockHandleAddHtmlConsoleError
   };
 

--- a/src/commons/sideContent/__tests__/__snapshots__/SideContentHtmlDisplay.tsx.snap
+++ b/src/commons/sideContent/__tests__/__snapshots__/SideContentHtmlDisplay.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HTML Display renders correctly 1`] = `
-"<SideContentHtmlDisplay content=\\"<p>Hello World!</p>\\" handleAddHtmlConsoleError={[Function: handleAddHtmlConsoleError]}>
+"<SideContentHtmlDisplay content=\\"\\"<p>Hello World!</p>\\"\\" handleAddHtmlConsoleError={[Function: handleAddHtmlConsoleError]}>
   <iframe className=\\"sa-html-display\\" title=\\"HTML Display\\" sandbox=\\"allow-scripts\\" srcDoc=\\"<p>Hello World!</p>\\" src=\\"about:blank\\" />
 </SideContentHtmlDisplay>"
 `;


### PR DESCRIPTION
### Description

Regression introduced in #2262. Now that values are all stringified, HTML code passed to the iframe component is now broken.
<img width="510" alt="Screenshot 2023-04-11 at 01 49 05" src="https://user-images.githubusercontent.com/54243224/230960700-13cab488-17a2-4745-b40c-35d6ab4e2b53.png">

Fix is to unescape the string by calling `JSON.parse`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Go on HTML chapter and test that HTML code displays correctly.
