### PR TITLE
Changed mention of "Source" to "JavaScript" for switcher button

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -258,7 +258,7 @@ export const defaultAchievement: AchievementState = {
 
 export const defaultPlayground: PlaygroundState = {
   githubSaveInfo: { repoName: '', filePath: '' },
-  lang: 'Source'
+  lang: 'JavaScript'
 };
 
 export const defaultEditorValue = '// Type your program in here!';

--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -111,7 +111,7 @@ export const ControlBarChapterSelect: React.FC<ControlBarChapterSelectProps> = (
 
   let chapterListRenderer: ItemListRenderer<SALanguage> = chapterListRendererA;
 
-  if (selectedLang === 'Source') {
+  if (selectedLang === 'JavaScript') {
     chapterListRenderer = chapterListRendererA;
   } else if (selectedLang === 'Scheme') {
     chapterListRenderer = chapterListRendererB;

--- a/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
+++ b/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
@@ -23,7 +23,7 @@ const NavigationBarLangSelectButton = () => {
       isOpen={isOpen}
       content={
         <Menu>
-          <MenuItem onClick={() => selectLang('Source')} text="Source" />
+          <MenuItem onClick={() => selectLang('JavaScript')} text="JavaScript" />
           <MenuItem onClick={() => selectLang('Scheme')} text="Scheme" />
           <MenuItem onClick={() => selectLang('Python')} text="Python" />
         </Menu>

--- a/src/commons/navigationBar/subcomponents/__tests__/NavigationBarLangSelectButton.tsx
+++ b/src/commons/navigationBar/subcomponents/__tests__/NavigationBarLangSelectButton.tsx
@@ -45,7 +45,7 @@ describe('NavigationBarLangSelectButton', () => {
     expect(store.getState().playground.lang).toEqual('Python');
   });
 
-  it('should call selectLang with "Source" when "Source" menu item is clicked', () => {
+  it('should call selectLang with "JavaScript" when "JavaScript" menu item is clicked', () => {
     const wrapper = mount(
       <Provider store={store}>
         <NavigationBarLangSelectButton />
@@ -54,9 +54,9 @@ describe('NavigationBarLangSelectButton', () => {
     console.log(wrapper.debug());
     wrapper.find('button').simulate('click');
     wrapper
-      .findWhere(node => node.type() === 'li' && node.text() === 'Source')
+      .findWhere(node => node.type() === 'li' && node.text() === 'JavaScript')
       .find('a[role="menuitem"]')
       .simulate('click');
-    expect(store.getState().playground.lang).toEqual('Source');
+    expect(store.getState().playground.lang).toEqual('JavaScript');
   });
 });

--- a/src/pages/__tests__/createStore.test.ts
+++ b/src/pages/__tests__/createStore.test.ts
@@ -39,7 +39,7 @@ const mockChangedStoredState: SavedState = {
   playgroundSourceChapter: Constants.defaultSourceChapter,
   playgroundSourceVariant: Variant.DEFAULT,
   playgroundExternalLibrary: 'NONE' as ExternalLibraryName,
-  playgroundLang: 'Source'
+  playgroundLang: 'JavaScript'
 };
 
 const mockChangedState: OverallState = {


### PR DESCRIPTION
### Description

Resolves issue https://github.com/source-academy/frontend/issues/2448

Renames "Source" to "JavaScript", for the language switching system. Not done for the languages themselves yet.

### Type of change

- Changed "Source" to "JavaScript"

### How to test

- `yarn test` 

### Checklist

- [ ] I have tested this code
