### PR TITLE
Disable Python S2-4 until they're ready

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -151,9 +151,9 @@ export const schemeLanguages: SALanguage[] = [
 
 export const pyLanguages: SALanguage[] = [
   { chapter: Chapter.PYTHON_1, variant: Variant.DEFAULT, displayName: 'Python \xa71' },
-  { chapter: Chapter.PYTHON_2, variant: Variant.DEFAULT, displayName: 'Python \xa72' },
-  { chapter: Chapter.PYTHON_3, variant: Variant.DEFAULT, displayName: 'Python \xa73' },
-  { chapter: Chapter.PYTHON_4, variant: Variant.DEFAULT, displayName: 'Python \xa74' }
+  //{ chapter: Chapter.PYTHON_2, variant: Variant.DEFAULT, displayName: 'Python \xa72' },
+  //{ chapter: Chapter.PYTHON_3, variant: Variant.DEFAULT, displayName: 'Python \xa73' },
+  //{ chapter: Chapter.PYTHON_4, variant: Variant.DEFAULT, displayName: 'Python \xa74' }
   //{ chapter: Chapter.FULL_PYTHON, variant: Variant.DEFAULT, displayName: 'Full Python' }
 ];
 
@@ -172,9 +172,9 @@ export const styliseSublanguage = (chapter: Chapter, variant: Variant = Variant.
     case Chapter.FULL_SCHEME:
       return schemeLanguages.find(lang => lang.chapter === chapter)!.displayName;
     case Chapter.PYTHON_1:
-    case Chapter.PYTHON_2:
-    case Chapter.PYTHON_3:
-    case Chapter.PYTHON_4:
+    // case Chapter.PYTHON_2:
+    // case Chapter.PYTHON_3:
+    // case Chapter.PYTHON_4:
       return pyLanguages.find(lang => lang.chapter === chapter)!.displayName;
     default:
       return `Source \xa7${chapter}${

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -150,7 +150,7 @@ export const schemeLanguages: SALanguage[] = [
 ];
 
 export const pyLanguages: SALanguage[] = [
-  { chapter: Chapter.PYTHON_1, variant: Variant.DEFAULT, displayName: 'Python \xa71' },
+  { chapter: Chapter.PYTHON_1, variant: Variant.DEFAULT, displayName: 'Python \xa71' }
   //{ chapter: Chapter.PYTHON_2, variant: Variant.DEFAULT, displayName: 'Python \xa72' },
   //{ chapter: Chapter.PYTHON_3, variant: Variant.DEFAULT, displayName: 'Python \xa73' },
   //{ chapter: Chapter.PYTHON_4, variant: Variant.DEFAULT, displayName: 'Python \xa74' }
@@ -172,9 +172,9 @@ export const styliseSublanguage = (chapter: Chapter, variant: Variant = Variant.
     case Chapter.FULL_SCHEME:
       return schemeLanguages.find(lang => lang.chapter === chapter)!.displayName;
     case Chapter.PYTHON_1:
-    // case Chapter.PYTHON_2:
-    // case Chapter.PYTHON_3:
-    // case Chapter.PYTHON_4:
+      // case Chapter.PYTHON_2:
+      // case Chapter.PYTHON_3:
+      // case Chapter.PYTHON_4:
       return pyLanguages.find(lang => lang.chapter === chapter)!.displayName;
     default:
       return `Source \xa7${chapter}${


### PR DESCRIPTION
### Description

Disables the Python chapter 2 to 4 options in the frontend until they're ready. Fixes #2450.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Rebuild and see the SA playground.

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
