### PR TITLE
Fix incorrect syntax highlighting for non-Source languages

### DIFF
--- a/src/commons/utils/AceHelper.ts
+++ b/src/commons/utils/AceHelper.ts
@@ -32,8 +32,25 @@ export const selectMode = (chapter: Chapter, variant: Variant, library: string) 
 };
 
 export const getModeString = (chapter: Chapter, variant: Variant, library: string) => {
-  if (chapter === Chapter.HTML) {
-    return 'html';
+  // TODO: Create our own highlighting rules for the different sublanguages
+  switch (chapter) {
+    case Chapter.HTML:
+      return 'html';
+    case Chapter.FULL_TS:
+      return 'typescript';
+    case Chapter.PYTHON_1:
+    case Chapter.PYTHON_2:
+    case Chapter.PYTHON_3:
+    case Chapter.PYTHON_4:
+    case Chapter.FULL_PYTHON:
+      return 'python';
+    case Chapter.SCHEME_1:
+    case Chapter.SCHEME_2:
+    case Chapter.SCHEME_3:
+    case Chapter.SCHEME_4:
+    case Chapter.FULL_SCHEME:
+      return 'scheme';
+    default:
+      return `source${chapter}${variant}${library}`;
   }
-  return `source${chapter}${variant}${library}`;
 };


### PR DESCRIPTION
Enables the correct syntax highlighting rules for non-Source languages.

Note that this is a hotfix. Ideally, the highlighting rules should be defined in js-slang together with the language itself, just like how it is currently implemented for Source languages.

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
