### PR TITLE
Fixed the inconsistency in the environment visualiser with breakpoint…

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -993,6 +993,20 @@ export function* evalCode(
             .usingSubst
       )
     : false;
+  const stepLimit: number = yield select(
+    (state: OverallState) => state.workspaces[workspaceLocation].stepLimit
+  );
+  const substActiveAndCorrectChapter = context.chapter <= 2 && substIsActive;
+  if (substActiveAndCorrectChapter) {
+    context.executionMethod = 'interpreter';
+    // icon to blink
+    const icon = document.getElementById(SideContentType.substVisualizer + '-icon');
+    if (icon) {
+      icon.classList.add('side-content-tab-alert');
+    }
+  }
+
+  // For the environment visualiser slider
   const envIsActive: boolean = correctWorkspace
     ? yield select(
         (state: OverallState) =>
@@ -1014,25 +1028,12 @@ export function* evalCode(
             .envSteps
       )
     : -1;
-  const stepLimit: number = yield select(
-    (state: OverallState) => state.workspaces[workspaceLocation].stepLimit
-  );
-  const substActiveAndCorrectChapter = context.chapter <= 2 && substIsActive;
-  if (substActiveAndCorrectChapter) {
-    context.executionMethod = 'interpreter';
-    // icon to blink
-    const icon = document.getElementById(SideContentType.substVisualizer + '-icon');
-    if (icon) {
-      icon.classList.add('side-content-tab-alert');
-    }
-  }
   const envActiveAndCorrectChapter = context.chapter >= 3 && envIsActive;
   if (envActiveAndCorrectChapter) {
     context.executionMethod = 'ec-evaluator';
-    context.runtime.envSteps = needUpdateEnv ? -1 : envSteps;
-  } else {
-    context.runtime.envSteps = -1;
   }
+  // When envSteps is -1, the entire code is run from the start.
+  context.runtime.envSteps = needUpdateEnv ? -1 : envSteps;
 
   const entrypointCode = files[entrypointFilePath];
 
@@ -1197,12 +1198,12 @@ export function* evalCode(
     );
   }
 
-  if (envActiveAndCorrectChapter) {
-    if (needUpdateEnv) {
-      yield put(actions.updateEnvStepsTotal(context.runtime.envStepsTotal, workspaceLocation));
-      yield put(actions.toggleUpdateEnv(false, workspaceLocation));
-      yield put(actions.updateBreakpointSteps(context.runtime.breakpointSteps, workspaceLocation));
-    }
+  // The first time the code is executed using the explicit control evaluator,
+  // the total number of steps and the breakpoints are updated in the Environment Visualiser slider.
+  if (context.executionMethod === 'ec-evaluator' && needUpdateEnv) {
+    yield put(actions.updateEnvStepsTotal(context.runtime.envStepsTotal, workspaceLocation));
+    yield put(actions.toggleUpdateEnv(false, workspaceLocation));
+    yield put(actions.updateBreakpointSteps(context.runtime.breakpointSteps, workspaceLocation));
   }
 }
 


### PR DESCRIPTION

### Description

This PR fixes https://github.com/source-academy/frontend/issues/2458.

Fixing this issue required that the number of steps in the environment visualizer slider was always explicitly obtained from the redux state. Previously, it was only obtained when the environment visualizer side content tab was open, which is not the case when breakpoints are used.

There was a similar issue in the _total_ number of steps for the slider not being updated when using breakpoints. Previously, this was only updated when the environment visualizer side content tab was open, but it has now been changed to update whenever code is executed using the explicit control evaluator (this effectively includes both cases).

Documentation has also been added.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [x] I have updated the documentation
