### PR TITLE
Errors from the previous context are reset when evaluating the REPL

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -293,6 +293,8 @@ export default function* WorkspaceSaga(): SagaIterator {
     yield put(actions.clearReplInput(workspaceLocation));
     yield put(actions.sendReplInputToOutput(code, workspaceLocation));
     context = yield select((state: OverallState) => state.workspaces[workspaceLocation].context);
+    // Reset old context.errors
+    context.errors = [];
     const codeFilePath = '/code.js';
     const codeFiles = {
       [codeFilePath]: code


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR fixes https://github.com/source-academy/js-slang/issues/1383.

The reason for this bug was that context.errors was not being cleared every time the REPL was evaluated resulting in the same error propagating repeatedly even for valid programs. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
