### PR TITLE
Use separate EditSession for each editor tab

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -342,6 +342,8 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
   if (editor !== undefined) {
     if (filePath !== props.filePath) {
       editor.setSession(props.session);
+      // Give focus to the editor tab after switching.
+      editor.focus();
       setFilePath(props.filePath);
     }
   }

--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -342,8 +342,11 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
   if (editor !== undefined) {
     if (filePath !== props.filePath) {
       editor.setSession(props.session);
-      // Give focus to the editor tab after switching.
-      editor.focus();
+      // Give focus to the editor tab only after switching from another tab.
+      // This is necessary to prevent 'unstable_flushDiscreteUpdates' warnings.
+      if (filePath !== undefined) {
+        editor.focus();
+      }
       setFilePath(props.filePath);
     }
   }

--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -341,6 +341,12 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
   // Set edit session history when switching to another editor tab.
   if (editor !== undefined) {
     if (filePath !== props.filePath) {
+      // Unfortunately, the current editor sets the mode globally.
+      // The side effects make it very hard to ensure that the correct
+      // mode is set for every EditSession. As such, we add this one
+      // line to always propagate the mode whenever we set a new session.
+      // See AceHelper#selectMode for more information.
+      props.session.setMode(editor.getSession().getMode());
       editor.setSession(props.session);
       // Give focus to the editor tab only after switching from another tab.
       // This is necessary to prevent 'unstable_flushDiscreteUpdates' warnings.


### PR DESCRIPTION
### Description

Store a separate `EditSession` object for each editor tab. This allows each editor tab to maintain its own cursor position, highlighting, edit history, scroll position, etc.

![vmconnect_TUniDmDC4m](https://github.com/source-academy/frontend/assets/5585517/32cbfc26-f4f6-4fe0-bdb1-9b6122336e9f)

Resolves #2401.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Enable Folder mode, then check that each editor tab has a separate history of operations.