### PR TITLE
Allow overriding request host in request helper

### DIFF
--- a/src/commons/utils/RequestHelper.tsx
+++ b/src/commons/utils/RequestHelper.tsx
@@ -47,12 +47,14 @@ let refreshingTokensPromise: Promise<Tokens | null> | undefined;
 export const request = async (
   path: string,
   method: RequestMethod,
-  opts: RequestOptions
+  opts: RequestOptions,
+  rawUrl?: string
 ): Promise<Response | null> => {
   const fetchOptions = generateApiCallHeadersAndFetchOptions(method, opts);
 
   try {
-    const resp = await fetch(`${Constants.backendUrl}/v2/${path}`, fetchOptions);
+    const url = rawUrl ? rawUrl : `${Constants.backendUrl}/v2/${path}`;
+    const resp = await fetch(url, fetchOptions);
     if (resp.ok) {
       return resp;
     }


### PR DESCRIPTION
Done to support multiple backends.

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In order to pipe API requests to the stories backend (and potentially more backends in the future) through the request helper, we will need a way to override the URL.

The alternative would be a major refactor which I don't think is worth the effort at the moment.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
