### PR TITLE
Fix stories code execution

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -324,8 +324,7 @@ export default function* WorkspaceSaga(): SagaIterator {
     const codeFiles = {
       [codeFilePath]: code
     };
-    // TODO: Check what happens to the env here
-    yield call(evalCode, codeFiles, codeFilePath, context, execTime, 'stories', EVAL_STORY);
+    yield call(evalCode, codeFiles, codeFilePath, context, execTime, 'stories', EVAL_STORY, env);
   });
 
   yield takeEvery(DEBUG_RESUME, function* (action: ReturnType<typeof actions.debuggerResume>) {
@@ -654,12 +653,13 @@ function* clearContext(workspaceLocation: WorkspaceLocation, entrypointCode: str
 
 export function* dumpDisplayBuffer(
   workspaceLocation: WorkspaceLocation,
-  isStoriesBlock: boolean = false
+  isStoriesBlock: boolean = false,
+  storyEnv?: string
 ): Generator<StrictEffect, void, any> {
   if (!isStoriesBlock) {
     yield put(actions.handleConsoleLog(workspaceLocation, ...DisplayBufferService.dump()));
   } else {
-    yield put(actions.handleStoriesConsoleLog(workspaceLocation, ...DisplayBufferService.dump()));
+    yield put(actions.handleStoriesConsoleLog(storyEnv!, ...DisplayBufferService.dump()));
   }
 }
 
@@ -1036,11 +1036,12 @@ export function* evalCode(
   context: Context,
   execTime: number,
   workspaceLocation: WorkspaceLocation,
-  actionType: string
+  actionType: string,
+  storyEnv?: string
 ): SagaIterator {
   context.runtime.debuggerOn =
     (actionType === EVAL_EDITOR || actionType === DEBUG_RESUME) && context.chapter > 2;
-  const isStoriesBlock = actionType === EVAL_STORY;
+  const isStoriesBlock = actionType === EVAL_STORY || workspaceLocation === 'stories';
 
   // Logic for execution of substitution model visualizer
   const correctWorkspace = workspaceLocation === 'playground' || workspaceLocation === 'sicp';
@@ -1051,10 +1052,11 @@ export function* evalCode(
             .usingSubst
       )
     : isStoriesBlock
-    ? yield select((state: OverallState) => state.stories.envs[workspaceLocation].usingSubst)
+    ? // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
+      yield select((state: OverallState) => state.stories.envs[storyEnv!].usingSubst)
     : false;
   const stepLimit: number = isStoriesBlock
-    ? yield select((state: OverallState) => state.stories.envs[workspaceLocation].stepLimit)
+    ? yield select((state: OverallState) => state.stories.envs[storyEnv!].stepLimit)
     : yield select((state: OverallState) => state.workspaces[workspaceLocation].stepLimit);
   const substActiveAndCorrectChapter = context.chapter <= 2 && substIsActive;
   if (substActiveAndCorrectChapter) {
@@ -1213,11 +1215,12 @@ export function* evalCode(
     result.status !== 'suspended-non-det' &&
     result.status !== 'suspended-ec-eval'
   ) {
-    yield* dumpDisplayBuffer(workspaceLocation, isStoriesBlock);
+    yield* dumpDisplayBuffer(workspaceLocation, isStoriesBlock, storyEnv);
     if (!isStoriesBlock) {
       yield put(actions.evalInterpreterError(context.errors, workspaceLocation));
     } else {
-      yield put(actions.evalStoryError(context.errors, workspaceLocation));
+      // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
+      yield put(actions.evalStoryError(context.errors, storyEnv!));
     }
     // we need to parse again, but preserve the errors in context
     const oldErrors = context.errors;
@@ -1248,14 +1251,15 @@ export function* evalCode(
     lastNonDetResult = result;
   }
 
-  yield* dumpDisplayBuffer(workspaceLocation, isStoriesBlock);
+  yield* dumpDisplayBuffer(workspaceLocation, isStoriesBlock, storyEnv);
 
   // Do not write interpreter output to REPL, if executing chunks (e.g. prepend/postpend blocks)
   if (actionType !== EVAL_SILENT) {
     if (!isStoriesBlock) {
       yield put(actions.evalInterpreterSuccess(result.value, workspaceLocation));
     } else {
-      yield put(actions.evalStorySuccess(result.value, workspaceLocation));
+      // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
+      yield put(actions.evalStorySuccess(result.value, storyEnv!));
     }
   }
 
@@ -1270,7 +1274,8 @@ export function* evalCode(
   }
   if (isStoriesBlock) {
     yield put(
-      notifyStoriesEvaluated(result, lastDebuggerResult, entrypointCode, context, workspaceLocation)
+      // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
+      notifyStoriesEvaluated(result, lastDebuggerResult, entrypointCode, context, storyEnv!)
     );
   }
 

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -103,6 +103,7 @@ export default function* WorkspaceSaga(): SagaIterator {
           actions.handleConsoleLog(action.payload.workspaceLocation, action.payload.errorMsg)
         );
       } else {
+        // FIXME: Use story env
         yield put(
           actions.handleStoriesConsoleLog(action.payload.workspaceLocation, action.payload.errorMsg)
         );

--- a/src/commons/sideContent/GenericSideContent.tsx
+++ b/src/commons/sideContent/GenericSideContent.tsx
@@ -1,6 +1,7 @@
 import { TabId } from '@blueprintjs/core';
 import React from 'react';
 
+import { OverallState } from '../application/ApplicationTypes';
 import { useTypedSelector } from '../utils/Hooks';
 import { DebuggerContext, WorkspaceLocation } from '../workspace/WorkspaceTypes';
 import { getDynamicTabs } from './SideContentHelper';
@@ -47,7 +48,7 @@ type StateProps = {
     afterDynamicTabs: SideContentTab[];
   };
   workspaceLocation?: WorkspaceLocation;
-  isStories?: boolean;
+  getDebuggerContext?: (state: OverallState) => DebuggerContext | undefined;
 };
 
 const GenericSideContent = (props: GenericSideContentProps) => {
@@ -57,10 +58,8 @@ const GenericSideContent = (props: GenericSideContentProps) => {
   );
 
   // Fetch debuggerContext from store
-  const debuggerContext = useTypedSelector(state =>
-    props.isStories
-      ? props.workspaceLocation && state.stories.envs[props.workspaceLocation].debuggerContext
-      : props.workspaceLocation && state.workspaces[props.workspaceLocation].debuggerContext
+  const debuggerContext = useTypedSelector(
+    state => props.workspaceLocation && state.workspaces[props.workspaceLocation].debuggerContext
   );
 
   React.useEffect(() => {

--- a/src/commons/sideContent/GenericSideContent.tsx
+++ b/src/commons/sideContent/GenericSideContent.tsx
@@ -59,7 +59,9 @@ const GenericSideContent = (props: GenericSideContentProps) => {
 
   // Fetch debuggerContext from store
   const debuggerContext = useTypedSelector(
-    state => props.workspaceLocation && state.workspaces[props.workspaceLocation].debuggerContext
+    props.getDebuggerContext ??
+      (state =>
+        props.workspaceLocation && state.workspaces[props.workspaceLocation].debuggerContext)
   );
 
   React.useEffect(() => {

--- a/src/features/stories/StoriesActions.ts
+++ b/src/features/stories/StoriesActions.ts
@@ -35,7 +35,7 @@ export const evalStoryError = (errors: SourceError[], env: string) =>
 export const evalStorySuccess = (value: Value, env: string) =>
   action(EVAL_STORY_SUCCESS, { type: 'result', value, env });
 
-export const handleStoriesConsoleLog = (env: String, ...logString: string[]) =>
+export const handleStoriesConsoleLog = (env: string, ...logString: string[]) =>
   action(HANDLE_STORIES_CONSOLE_LOG, { logString, env });
 
 export const notifyStoriesEvaluated = (

--- a/src/features/stories/StoriesReducer.ts
+++ b/src/features/stories/StoriesReducer.ts
@@ -29,7 +29,7 @@ export const StoriesReducer: Reducer<StoriesState> = (
   state = defaultStories,
   action: SourceActionType
 ) => {
-  const env: string = (action as any).payload ? (action as any).payload.env : DEFAULT_ENV;
+  const env: string = (action as any).payload?.env ?? DEFAULT_ENV;
   let newOutput: InterpreterOutput[];
   let lastOutput: InterpreterOutput;
   switch (action.type) {

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -197,7 +197,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
     },
     workspaceLocation: 'stories',
     storyEnv: env,
-    isStories: true
+    getDebuggerContext: state => state.stories.envs[env].debuggerContext
   };
 
   const execEvaluate = () => {

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -44,7 +44,7 @@ function parseCommands(key: string, commandsString: string): string | undefined 
 const SourceBlock: React.FC<SourceBlockProps> = props => {
   const dispatch = useDispatch();
   const [code, setCode] = useState<string>(props.children);
-  const [outputIndex, setOutputIndex] = useState<number>(Infinity);
+  const [outputIndex, setOutputIndex] = useState(Infinity);
   const [sideContentHidden, setSideContentHidden] = useState<boolean>(true);
   const [selectedTab, setSelectedTab] = useState(SideContentType.introduction);
 
@@ -216,11 +216,16 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
   // to handle environment reset
   useEffect(() => {
     if (output.length === 0) {
+      console.log('setting to infinity');
       setOutputIndex(Infinity);
     }
+    setOutputIndex(output.length);
   }, [output]);
 
   selectMode(chapter, variant, ExternalLibraryName.NONE);
+
+  console.log(outputIndex);
+  console.log(output);
 
   return (
     <div className={Classes.DARK}>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Supersedes #2559. Decouples stories workspace logic in WorkspaceSaga from the workspace location, thus fixing the regressions introduced by the initial decoupling of stories state from workspace location in #2424.

Also introduced code quality improvements.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
