### PR TITLE
Restore some stories tabs

### DIFF
--- a/src/features/stories/StoriesReducer.ts
+++ b/src/features/stories/StoriesReducer.ts
@@ -106,9 +106,10 @@ export const StoriesReducer: Reducer<StoriesState> = (
         }
       };
     case EVAL_STORY_SUCCESS:
+      const execType = state.envs[env].context.executionMethod;
       const newOutputEntry: Partial<ResultOutput> = {
         type: action.payload.type as 'result' | undefined,
-        value: stringify(action.payload.value)
+        value: execType === 'interpreter' ? action.payload.value : stringify(action.payload.value)
       };
       lastOutput = state.envs[env].output.slice(-1)[0];
       if (lastOutput !== undefined && lastOutput.type === 'running') {

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -153,7 +153,10 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
     //   tabs.push(envVisualizerTab);
     // }
 
-    if (chapter <= 2 && (variant === Variant.DEFAULT || variant === Variant.NATIVE)) {
+    if (
+      chapter <= Chapter.SOURCE_2 &&
+      (variant === Variant.DEFAULT || variant === Variant.NATIVE)
+    ) {
       // Enable Subst Visualizer only for default Source 1 & 2
       tabs.push(makeSubstVisualizerTabFrom(output));
     }

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -4,18 +4,23 @@ import { Chapter, Variant } from 'js-slang/dist/types';
 import React, { useEffect, useRef, useState } from 'react';
 import AceEditor from 'react-ace';
 import { useDispatch } from 'react-redux';
-import { styliseSublanguage } from 'src/commons/application/ApplicationTypes';
+import { ResultOutput, styliseSublanguage } from 'src/commons/application/ApplicationTypes';
 import { ControlBarRunButton } from 'src/commons/controlBar/ControlBarRunButton';
 import ControlButton from 'src/commons/ControlButton';
 import { SideContentTab, SideContentType } from 'src/commons/sideContent/SideContentTypes';
 import Constants from 'src/commons/utils/Constants';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
+import { addHtmlConsoleError } from 'src/commons/workspace/WorkspaceActions';
 import {
   clearStoryEnv,
   evalStory,
   toggleStoriesUsingSubst
 } from 'src/features/stories/StoriesActions';
-import { dataVisualizerTab, makeSubstVisualizerTabFrom } from 'src/pages/playground/PlaygroundTabs';
+import {
+  dataVisualizerTab,
+  makeHtmlDisplayTabFrom,
+  makeSubstVisualizerTabFrom
+} from 'src/pages/playground/PlaygroundTabs';
 
 import { ExternalLibraryName } from '../../../commons/application/types/ExternalTypes';
 import { Output } from '../../../commons/repl/Repl';
@@ -122,25 +127,17 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
 
     // TODO: Restore logic post refactor
 
-    // // For HTML Chapter, HTML Display tab is added only after code is run
-    // if (chapter === Chapter.HTML) {
-    //   if (output.length > outputIndex && output[outputIndex].type === 'result') {
-    //     tabs.push({
-    //       label: 'HTML Display',
-    //       iconName: IconNames.MODAL,
-    //       body: (
-    //         <SideContentHtmlDisplay
-    //           content={(output[outputIndex] as ResultOutput).value}
-    //           handleAddHtmlConsoleError={errorMsg =>
-    //             dispatch(addHtmlConsoleError(errorMsg, 'stories', true))
-    //           }
-    //         />
-    //       ),
-    //       id: SideContentType.htmlDisplay
-    //     });
-    //   }
-    //   return tabs;
-    // }
+    // For HTML Chapter, HTML Display tab is added only after code is run
+    if (chapter === Chapter.HTML) {
+      if (output.length > outputIndex && output[outputIndex].type === 'result') {
+        tabs.push(
+          makeHtmlDisplayTabFrom(output[outputIndex] as ResultOutput, errorMsg =>
+            dispatch(addHtmlConsoleError(errorMsg, 'stories', env))
+          )
+        );
+      }
+      return tabs;
+    }
 
     // // (TEMP) Remove tabs for fullJS until support is integrated
     // if (chapter === Chapter.FULL_JS) {

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -15,6 +15,7 @@ import {
   evalStory,
   toggleStoriesUsingSubst
 } from 'src/features/stories/StoriesActions';
+import { dataVisualizerTab } from 'src/pages/playground/PlaygroundTabs';
 
 import { ExternalLibraryName } from '../../../commons/application/types/ExternalTypes';
 import { Output } from '../../../commons/repl/Repl';
@@ -107,14 +108,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
       ? styliseSublanguage(chapter, variant)
       : env + ' | ' + styliseSublanguage(chapter, variant);
 
-  // TODO: Add data visualiser and env visualiser tabs
-
-  // const dataVisualizerTab: SideContentTab = {
-  //   label: 'Data Visualizer',
-  //   iconName: IconNames.EYE_OPEN,
-  //   body: <SideContentDataVisualizer />,
-  //   id: SideContentType.dataVisualizer
-  // };
+  // TODO: Add env visualiser tabs and shift to language config
 
   // const envVisualizerTab: SideContentTab = {
   //   label: 'Env Visualizer',
@@ -168,10 +162,10 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
     //   return [...tabs, dataVisualizerTab];
     // }
 
-    // if (chapter >= 2) {
-    //   // Enable Data Visualizer for Source Chapter 2 and above
-    //   tabs.push(dataVisualizerTab);
-    // }
+    if (chapter >= Chapter.SOURCE_2) {
+      // Enable Data Visualizer for Source Chapter 2 and above
+      tabs.push(dataVisualizerTab);
+    }
     // if (chapter >= 3 && variant !== Variant.CONCURRENT && variant !== Variant.NON_DET) {
     //   // Enable Env Visualizer for Source Chapter 3 and above
     //   tabs.push(envVisualizerTab);

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -1,6 +1,6 @@
 import { Card, Classes } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import { Chapter } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 import React, { useEffect, useRef, useState } from 'react';
 import AceEditor from 'react-ace';
 import { useDispatch } from 'react-redux';
@@ -15,7 +15,7 @@ import {
   evalStory,
   toggleStoriesUsingSubst
 } from 'src/features/stories/StoriesActions';
-import { dataVisualizerTab } from 'src/pages/playground/PlaygroundTabs';
+import { dataVisualizerTab, makeSubstVisualizerTabFrom } from 'src/pages/playground/PlaygroundTabs';
 
 import { ExternalLibraryName } from '../../../commons/application/types/ExternalTypes';
 import { Output } from '../../../commons/repl/Repl';
@@ -117,21 +117,6 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
   //   id: SideContentType.envVisualizer
   // };
 
-  // const processStepperOutput = (output: InterpreterOutput[]) => {
-  //   const editorOutput = output[0];
-  //   if (
-  //     editorOutput &&
-  //     editorOutput.type === 'result' &&
-  //     editorOutput.value instanceof Array &&
-  //     editorOutput.value[0] === Object(editorOutput.value[0]) &&
-  //     isStepperOutput(editorOutput.value[0])
-  //   ) {
-  //     return editorOutput.value;
-  //   } else {
-  //     return [];
-  //   }
-  // };
-
   const tabs = React.useMemo(() => {
     const tabs: SideContentTab[] = [];
 
@@ -171,15 +156,10 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
     //   tabs.push(envVisualizerTab);
     // }
 
-    // if (chapter <= 2 && (variant === Variant.DEFAULT || variant === Variant.NATIVE)) {
-    //   // Enable Subst Visualizer only for default Source 1 & 2
-    //   tabs.push({
-    //     label: 'Stepper',
-    //     iconName: IconNames.FLOW_REVIEW,
-    //     body: <SideContentSubstVisualizer content={processStepperOutput(output)} />,
-    //     id: SideContentType.substVisualizer
-    //   });
-    // }
+    if (chapter <= 2 && (variant === Variant.DEFAULT || variant === Variant.NATIVE)) {
+      // Enable Subst Visualizer only for default Source 1 & 2
+      tabs.push(makeSubstVisualizerTabFrom(output));
+    }
 
     return tabs;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -95,11 +95,11 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
       }
 
       if (chapter <= Chapter.SOURCE_2 && newTabId === SideContentType.substVisualizer) {
-        toggleStoriesUsingSubst(true, env);
+        dispatch(toggleStoriesUsingSubst(true, env));
       }
 
       if (prevTabId === SideContentType.substVisualizer) {
-        toggleStoriesUsingSubst(false, env);
+        dispatch(toggleStoriesUsingSubst(false, env));
       }
 
       setSelectedTab(newTabId);


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

* Restore data visualiser, HTML display, and stepper tabs
* Fix incorrect stories reducer (it was missing the hotfix from #2305)

There are still some bugs remaining, but nothing too major:

* The stepper runs the code chunk as if it were a fresh program, i.e. without any prepends. Thus we need to ensure that everything is defined in the same code block.
  * e.g. we can't have function definitions in Block 1, and their function calls in Block 2, and run the stepper from Block 2.
* _(only affects authors, not viewers) Updating chapters/variants is not being propagated correctly into the component lifecycle. If you change a code block's environment from Source 4 to Source 2 (or something that does not support the stepper to something that does), you will need to save the file and refresh the page in the browser for the stepper to work.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
