### PR TITLE
Set up stories auth-based conditional rendering

### DIFF
--- a/src/pages/stories/Stories.tsx
+++ b/src/pages/stories/Stories.tsx
@@ -27,6 +27,8 @@ const Stories: React.FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
+  const isLoggedIn = useTypedSelector(state => !!state.stories.userId);
+
   const handleNewStory = useCallback(() => navigate('/stories/new'), [navigate]);
   const handleDeleteStory = useCallback(
     async (id: number) => {
@@ -109,9 +111,11 @@ const Stories: React.FC = () => {
           <Flex justifyContent="justify-between">
             <Flex justifyContent="justify-start" spaceX="space-x-6">
               <Title>All Stories</Title>
-              <BpButton onClick={handleNewStory} icon={IconNames.PLUS}>
-                Add Story
-              </BpButton>
+              {isLoggedIn && (
+                <BpButton onClick={handleNewStory} icon={IconNames.PLUS}>
+                  Add Story
+                </BpButton>
+              )}
             </Flex>
             <TextInput
               maxWidth="max-w-xl"

--- a/src/pages/stories/Stories.tsx
+++ b/src/pages/stories/Stories.tsx
@@ -139,9 +139,9 @@ const Stories: React.FC = () => {
               )}
             storyActions={story => {
               const hasWritePermissions =
+                storiesUserId === story.authorId ||
                 storiesRole === StoriesRole.Moderator ||
-                storiesRole === StoriesRole.Admin ||
-                storiesUserId === story.authorId;
+                storiesRole === StoriesRole.Admin;
               return (
                 <StoryActions
                   storyId={story.id}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Uses the current stories user, as well as their role, to determine the appropriate permissions and UI elements to show. Note that this is on top of the backend, which also implements its own separate access control to ensure that permissions are always respected.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

* Public deployment should not have "New Story" button
* Only authors/admins/moderators can edit/delete/pin stories

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
