### PR TITLE
Fix bugs involving stepper in stories

### DIFF
--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -34,7 +34,8 @@ export enum SideContentType {
   substVisualizer = 'subst_visualiser',
   testcases = 'testcases',
   toneMatrix = 'tone_matrix',
-  htmlDisplay = 'html_display'
+  htmlDisplay = 'html_display',
+  storiesRun = 'stories_run'
 }
 
 /**

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -90,13 +90,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
       event: React.MouseEvent<HTMLElement>
     ) => {
       // TODO: Migrate relevant updated logic from Playground component
-      if (chapter <= Chapter.SOURCE_2 && newTabId === SideContentType.substVisualizer) {
-        dispatch(toggleStoriesUsingSubst(true, env));
-      }
-
-      if (prevTabId === SideContentType.substVisualizer) {
-        dispatch(toggleStoriesUsingSubst(false, env));
-      }
+      dispatch(toggleStoriesUsingSubst(newTabId === SideContentType.substVisualizer, env));
 
       setSelectedTab(newTabId);
     },

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -118,8 +118,26 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
   //   id: SideContentType.envVisualizer
   // };
 
+  const outputTab: SideContentTab = {
+    label: 'Normal Output',
+    iconName: IconNames.PLAY,
+    body:
+      output.length > outputIndex ? (
+        <div className="Repl" style={{ margin: 0 }}>
+          <div className="repl-output-parent">
+            <p className={Classes.RUNNING_TEXT}>Output:</p>
+            <Output output={output[outputIndex]} usingSubst={usingSubst || false} />
+          </div>
+        </div>
+      ) : (
+        <p className={Classes.RUNNING_TEXT}>Click "Run" in the top left to run some code!</p>
+      ),
+    // FIXME: Abuse of mobileRunTab id
+    id: SideContentType.mobileEditorRun
+  };
+
   const tabs = React.useMemo(() => {
-    const tabs: SideContentTab[] = [];
+    const tabs: SideContentTab[] = [outputTab];
 
     // TODO: Restore logic post refactor
 
@@ -234,14 +252,6 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
                   }}
                 />
               </Card>
-              <div className="Repl" style={{ margin: 0 }}>
-                {output.length > outputIndex ? (
-                  <div className="repl-output-parent">
-                    <p style={{ marginBlock: 6 }}>Output:</p>
-                    <Output output={output[outputIndex]} usingSubst={usingSubst || false} />
-                  </div>
-                ) : null}
-              </div>
               <div>
                 <StoriesSideContent {...sideContentProps} />
               </div>

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -90,6 +90,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
       event: React.MouseEvent<HTMLElement>
     ) => {
       // TODO: Migrate relevant updated logic from Playground component
+      // TODO: Use language config for source chapter.
       dispatch(toggleStoriesUsingSubst(newTabId === SideContentType.substVisualizer, env));
 
       setSelectedTab(newTabId);

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -81,8 +81,6 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
 
   const output = useTypedSelector(store => store.stories.envs[env]?.output || []);
 
-  const usingSubst = useTypedSelector(store => store.stories.envs[env]?.usingSubst || false);
-
   const onChangeTabs = React.useCallback(
     (
       newTabId: SideContentType,
@@ -113,6 +111,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
   //   id: SideContentType.envVisualizer
   // };
 
+  const usingSubst = selectedTab === SideContentType.substVisualizer;
   const outputTab: SideContentTab = {
     label: 'Normal Output',
     iconName: IconNames.PLAY,
@@ -121,7 +120,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
         <div className="Repl" style={{ margin: 0 }}>
           <div className="repl-output-parent">
             <p className={Classes.RUNNING_TEXT}>Output:</p>
-            <Output output={output[outputIndex]} usingSubst={usingSubst || false} />
+            <Output output={output[outputIndex]} usingSubst={usingSubst} />
           </div>
         </div>
       ) : (

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -191,6 +191,13 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
   };
 
   const execEvaluate = () => {
+    // We call onChangeTabs with the current tab when the run
+    // button is clicked. This is a hotfix for incorrect execution
+    // method because of the fact that execution logic is handled
+    // by the environment setting, but the currently showing tab
+    // is handled by the component setting.
+    onChangeTabs(selectedTab, selectedTab, {} as any);
+
     dispatch(evalStory(env, code));
     setOutputIndex(output.length);
   };

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -90,10 +90,6 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
       event: React.MouseEvent<HTMLElement>
     ) => {
       // TODO: Migrate relevant updated logic from Playground component
-      if (newTabId === prevTabId) {
-        return;
-      }
-
       if (chapter <= Chapter.SOURCE_2 && newTabId === SideContentType.substVisualizer) {
         dispatch(toggleStoriesUsingSubst(true, env));
       }

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -55,7 +55,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
   const dispatch = useDispatch();
   const [code, setCode] = useState<string>(props.content);
   const [outputIndex, setOutputIndex] = useState(Infinity);
-  const [selectedTab, setSelectedTab] = useState(SideContentType.introduction);
+  const [selectedTab, setSelectedTab] = useState(SideContentType.mobileEditorRun);
 
   const envList = useTypedSelector(store => Object.keys(store.stories.envs));
 

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -158,7 +158,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
       (variant === Variant.DEFAULT || variant === Variant.NATIVE)
     ) {
       // Enable Subst Visualizer only for default Source 1 & 2
-      tabs.push(makeSubstVisualizerTabFrom(output));
+      tabs.push(makeSubstVisualizerTabFrom(output.slice(outputIndex)));
     }
 
     return tabs;

--- a/src/features/stories/storiesComponents/SourceBlock.tsx
+++ b/src/features/stories/storiesComponents/SourceBlock.tsx
@@ -55,7 +55,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
   const dispatch = useDispatch();
   const [code, setCode] = useState<string>(props.content);
   const [outputIndex, setOutputIndex] = useState(Infinity);
-  const [selectedTab, setSelectedTab] = useState(SideContentType.mobileEditorRun);
+  const [selectedTab, setSelectedTab] = useState(SideContentType.storiesRun);
 
   const envList = useTypedSelector(store => Object.keys(store.stories.envs));
 
@@ -126,8 +126,7 @@ const SourceBlock: React.FC<SourceBlockProps> = props => {
       ) : (
         <p className={Classes.RUNNING_TEXT}>Click "Run" in the top left to run some code!</p>
       ),
-    // FIXME: Abuse of mobileRunTab id
-    id: SideContentType.mobileEditorRun
+    id: SideContentType.storiesRun
   };
 
   const tabs = React.useMemo(() => {

--- a/src/features/stories/storiesComponents/StoriesSideContent.tsx
+++ b/src/features/stories/storiesComponents/StoriesSideContent.tsx
@@ -1,8 +1,6 @@
 import { Card, Icon, Tab, TabProps, Tabs } from '@blueprintjs/core';
-import { IconNames } from '@blueprintjs/icons';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
-import ControlButton from 'src/commons/ControlButton';
 
 import GenericSideContent, {
   generateIconId,
@@ -28,11 +26,7 @@ const generateClassName = (id: string | undefined) =>
     ? 'side-content-tooltip side-content-tab-alert'
     : 'side-content-tooltip';
 
-const renderTab = (
-  tab: SideContentTab,
-  isHidden: boolean,
-  workspaceLocation?: WorkspaceLocation
-) => {
+const renderTab = (tab: SideContentTab, workspaceLocation?: WorkspaceLocation) => {
   const iconSize = 20;
   const tabId = tab.id === undefined || tab.id === SideContentType.module ? tab.label : tab.id;
   const tabTitle = (
@@ -64,17 +58,15 @@ const renderTab = (
     : tab.body;
   const tabPanel: JSX.Element = <div className="side-content-text">{tabBody}</div>;
 
-  return <Tab key={tabId} {...tabProps} panel={isHidden ? undefined : tabPanel} />;
+  return <Tab key={tabId} {...tabProps} panel={tabPanel} />;
 };
 
 // TODO: Reduce code duplication with the main SideContent component
 const StoriesSideContent: React.FC<StoriesSideContentProps> = ({
   selectedTabId,
   renderActiveTabPanelOnly,
-  // isHidden,
   ...otherProps
 }) => {
-  const [isHidden, setIsHidden] = React.useState(true);
   return (
     <GenericSideContent
       {...otherProps}
@@ -84,21 +76,11 @@ const StoriesSideContent: React.FC<StoriesSideContentProps> = ({
             <div className="side-content-tabs">
               <Tabs
                 id="side-content-tabs"
-                onChange={(newTabId: SideContentType, prevTabId: SideContentType, e) => {
-                  setIsHidden(false);
-                  changeTabsCallback(newTabId, prevTabId, e);
-                }}
+                onChange={changeTabsCallback}
                 renderActiveTabPanelOnly={renderActiveTabPanelOnly}
                 selectedTabId={selectedTabId}
               >
-                {dynamicTabs.map(tab => renderTab(tab, isHidden, otherProps.workspaceLocation))}
-                {dynamicTabs.length ? (
-                  <ControlButton
-                    label={isHidden ? 'Show' : 'Hide'}
-                    onClick={() => setIsHidden(!isHidden)}
-                    icon={isHidden ? IconNames.EYE_OPEN : IconNames.EYE_OFF}
-                  />
-                ) : undefined}
+                {dynamicTabs.map(tab => renderTab(tab, otherProps.workspaceLocation))}
               </Tabs>
             </div>
           </Card>

--- a/src/features/stories/storiesComponents/StoriesSideContent.tsx
+++ b/src/features/stories/storiesComponents/StoriesSideContent.tsx
@@ -1,4 +1,4 @@
-import { Icon, Tab, TabProps, Tabs } from '@blueprintjs/core';
+import { Card, Icon, Tab, TabProps, Tabs } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Tooltip2 } from '@blueprintjs/popover2';
 import * as React from 'react';
@@ -79,27 +79,29 @@ const StoriesSideContent: React.FC<StoriesSideContentProps> = ({
     <GenericSideContent
       {...otherProps}
       renderFunction={(dynamicTabs, changeTabsCallback) => (
-        <div className="side-content">
-          <div className="side-content-tabs">
-            <Tabs
-              id="side-content-tabs"
-              onChange={(newTabId: SideContentType, prevTabId: SideContentType, e) => {
-                setIsHidden(false);
-                changeTabsCallback(newTabId, prevTabId, e);
-              }}
-              renderActiveTabPanelOnly={renderActiveTabPanelOnly}
-              selectedTabId={selectedTabId}
-            >
-              {dynamicTabs.map(tab => renderTab(tab, isHidden, otherProps.workspaceLocation))}
-              {dynamicTabs.length ? (
-                <ControlButton
-                  label={isHidden ? 'Show' : 'Hide'}
-                  onClick={() => setIsHidden(!isHidden)}
-                  icon={isHidden ? IconNames.EYE_OPEN : IconNames.EYE_OFF}
-                />
-              ) : undefined}
-            </Tabs>
-          </div>
+        <div className="stories-side-content">
+          <Card>
+            <div className="side-content-tabs">
+              <Tabs
+                id="side-content-tabs"
+                onChange={(newTabId: SideContentType, prevTabId: SideContentType, e) => {
+                  setIsHidden(false);
+                  changeTabsCallback(newTabId, prevTabId, e);
+                }}
+                renderActiveTabPanelOnly={renderActiveTabPanelOnly}
+                selectedTabId={selectedTabId}
+              >
+                {dynamicTabs.map(tab => renderTab(tab, isHidden, otherProps.workspaceLocation))}
+                {dynamicTabs.length ? (
+                  <ControlButton
+                    label={isHidden ? 'Show' : 'Hide'}
+                    onClick={() => setIsHidden(!isHidden)}
+                    icon={isHidden ? IconNames.EYE_OPEN : IconNames.EYE_OFF}
+                  />
+                ) : undefined}
+              </Tabs>
+            </div>
+          </Card>
         </div>
       )}
     />

--- a/src/styles/_stories.scss
+++ b/src/styles/_stories.scss
@@ -8,6 +8,33 @@
     border-radius: 6px;
     overflow: hidden;
   }
+
+  .stories-side-content {
+    height: 100%;
+    overflow-y: auto;
+
+    .#{$ns}-card {
+      margin-top: 10px;
+
+      .#{$ns}-tabs {
+        width: 100%;
+
+        .#{$ns}-tab-list {
+          align-self: flex-start;
+
+          > *:not(:last-child) {
+            margin-right: 10px;
+          }
+        }
+
+        > .side-content-tab {
+          .side-content-text {
+            margin-bottom: 0;
+          }
+        }
+      }
+    }
+  }
 }
 
 .newUserblog {

--- a/src/styles/_workspace.scss
+++ b/src/styles/_workspace.scss
@@ -368,6 +368,10 @@ $code-color-error: #ff4444;
     }
   }
 
+  .#{$ns}-tab-indicator-wrapper {
+    margin-top: 8px;
+  }
+
   .side-content-tabs {
     flex: 1 1 auto;
     height: 100%;


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The main cause was the fact that execution logic was handled by the environment's state (context), but the rendering logic builds on assumptions that there is only one instance of a component accessing the same environment at the same time, which is not true for stories), e.g. multiple tabs can be showing at the same time (stepper in one `SourceBlock`, and another tab in another), and they or may not require the same execution logic.

There was also insufficient separation of concerns with regards to the fact that the rendering logic should ideally be based on the component state (e.g. which tabs are showing) as opposed to the environment context.

This PR addresses a couple of the issues. For the full reasons behind some of the changes (as well as the full list of changes), please refer to the detailed commit history.

Notable changes:

* Improved UI/UX
* Moved normal output to its own tab
* Separated rendering logic from environment state
* Removed show/hide tab functionality (was not needed with the new, more intuitive UI)

This PR fixes some bugs and runtime errors associated with the cause above, when running stories.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
