### PR TITLE
Persist stories data in local storage

### DIFF
--- a/src/features/stories/StoriesReducer.ts
+++ b/src/features/stories/StoriesReducer.ts
@@ -1,5 +1,6 @@
 import { stringify } from 'js-slang/dist/utils/stringify';
 import { Reducer } from 'redux';
+import { LOG_OUT } from 'src/commons/application/types/CommonsTypes';
 
 import {
   createDefaultStoriesEnv,
@@ -224,6 +225,8 @@ export const StoriesReducer: Reducer<StoriesState> = (
         groupName: action.payload.name,
         role: action.payload.role
       };
+    case LOG_OUT:
+      return defaultStories;
     default:
       return state;
   }

--- a/src/features/stories/StoriesTypes.ts
+++ b/src/features/stories/StoriesTypes.ts
@@ -60,7 +60,7 @@ export type StoriesEnvState = {
   readonly debuggerContext: DebuggerContext;
 };
 
-type StoriesAuthState = {
+export type StoriesAuthState = {
   readonly userId?: number;
   readonly userName?: string;
   readonly groupId?: number;

--- a/src/pages/__tests__/createStore.test.ts
+++ b/src/pages/__tests__/createStore.test.ts
@@ -4,6 +4,7 @@ import { compressToUTF16 } from 'lz-string';
 import {
   defaultLanguageConfig,
   defaultState,
+  defaultStories,
   OverallState
 } from '../../commons/application/ApplicationTypes';
 import { ExternalLibraryName } from '../../commons/application/types/ExternalTypes';
@@ -43,7 +44,8 @@ const mockChangedStoredState: SavedState = {
   playgroundSourceChapter: Constants.defaultSourceChapter,
   playgroundSourceVariant: Variant.DEFAULT,
   playgroundExternalLibrary: 'NONE' as ExternalLibraryName,
-  playgroundLanguage: defaultLanguageConfig
+  playgroundLanguage: defaultLanguageConfig,
+  stories: defaultStories
 };
 
 const mockChangedState: OverallState = {

--- a/src/pages/__tests__/localStorage.test.ts
+++ b/src/pages/__tests__/localStorage.test.ts
@@ -33,7 +33,12 @@ const mockShortDefaultState: SavedState = {
   playgroundSourceChapter: defaultState.workspaces.playground.context.chapter,
   playgroundSourceVariant: defaultState.workspaces.playground.context.variant,
   playgroundLanguage: defaultState.playground.languageConfig,
-  playgroundExternalLibrary: defaultState.workspaces.playground.externalLibrary
+  playgroundExternalLibrary: defaultState.workspaces.playground.externalLibrary,
+  stories: {
+    userId: defaultState.stories.userId,
+    groupId: defaultState.stories.groupId,
+    role: defaultState.stories.role
+  }
 };
 
 describe('loadStoredState() function', () => {

--- a/src/pages/createStore.ts
+++ b/src/pages/createStore.ts
@@ -81,6 +81,10 @@ function loadStore(loadedStore: SavedState | undefined) {
             : defaultState.workspaces.playground.context.variant
         }
       }
+    },
+    stories: {
+      ...defaultState.stories,
+      ...loadedStore.stories
     }
   };
 }

--- a/src/pages/localStorage.ts
+++ b/src/pages/localStorage.ts
@@ -1,5 +1,6 @@
 import { Chapter, Variant } from 'js-slang/dist/types';
 import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
+import { StoriesAuthState } from 'src/features/stories/StoriesTypes';
 
 import { OverallState, SALanguage } from '../commons/application/ApplicationTypes';
 import { ExternalLibraryName } from '../commons/application/types/ExternalTypes';
@@ -28,6 +29,7 @@ export type SavedState = {
   playgroundSourceVariant: Variant;
   playgroundLanguage: SALanguage;
   playgroundExternalLibrary: ExternalLibraryName;
+  stories: Partial<StoriesAuthState>;
 };
 
 export const loadStoredState = (): SavedState | undefined => {
@@ -82,7 +84,12 @@ export const saveState = (state: OverallState) => {
       playgroundSourceChapter: state.workspaces.playground.context.chapter,
       playgroundSourceVariant: state.workspaces.playground.context.variant,
       playgroundLanguage: state.playground.languageConfig,
-      playgroundExternalLibrary: state.workspaces.playground.externalLibrary
+      playgroundExternalLibrary: state.workspaces.playground.externalLibrary,
+      stories: {
+        userId: state.stories.userId,
+        groupId: state.stories.groupId,
+        role: state.stories.role
+      }
     };
     const serialized = compressToUTF16(JSON.stringify(stateToBeSaved));
     localStorage.setItem('storedState', serialized);

--- a/src/pages/stories/Stories.tsx
+++ b/src/pages/stories/Stories.tsx
@@ -149,10 +149,9 @@ const Stories: React.FC = () => {
                   story.isPinned || story.authorName.toLowerCase().includes(query.toLowerCase())
               )}
             storyActions={story => {
+              const isAuthor = storiesUserId === story.authorId;
               const hasWritePermissions =
-                storiesUserId === story.authorId ||
-                storiesRole === StoriesRole.Moderator ||
-                storiesRole === StoriesRole.Admin;
+                storiesRole === StoriesRole.Moderator || storiesRole === StoriesRole.Admin;
               return (
                 <StoryActions
                   storyId={story.id}
@@ -161,8 +160,8 @@ const Stories: React.FC = () => {
                   handleMovePinUp={handleMovePinUp}
                   handleMovePinDown={handleMovePinDown}
                   canView // everyone has view permissions, even anonymous users
-                  canEdit={hasWritePermissions}
-                  canDelete={hasWritePermissions}
+                  canEdit={isAuthor || hasWritePermissions}
+                  canDelete={isAuthor || hasWritePermissions}
                   canPin={hasWritePermissions}
                   isPinned={story.isPinned}
                 />


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allows for direct links to paths related to stories to work (based on the previous user auth state, as that is now stored in the local storage).

Also handles the deletion of this persisted data on logout.

Also fixed a minor permissions bug regarding the pin button being visible when the user has no permissions to change a story's pin setting.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
