### PR TITLE
Center SICP navigation search bar

### DIFF
--- a/src/commons/navigationBar/subcomponents/SicpNavigationBar.tsx
+++ b/src/commons/navigationBar/subcomponents/SicpNavigationBar.tsx
@@ -278,11 +278,7 @@ const SicpNavigationBar: React.FC = () => {
   };
 
   const userSearch = (
-    <div
-      className="userSearch"
-      style={{ position: 'absolute', top: '10%', left: '15%', width: '20%', height: '600%' }}
-      key="userSearch"
-    >
+    <div className="userSearch" style={{ position: 'relative' }} key="userSearch">
       <div className="userSearch-inner">
         <div style={{ display: 'inline-flex' }}>
           <InputGroup
@@ -300,7 +296,14 @@ const SicpNavigationBar: React.FC = () => {
       {searchAutocompleteResults.length !== 0 && (
         <div
           className="userSearchDropdown"
-          style={{ backgroundColor: 'white', outline: 'dashed', height: '100%', overflow: 'auto' }}
+          style={{
+            position: 'absolute',
+            backgroundColor: 'white',
+            outline: 'dashed',
+            width: '100%',
+            height: '600%',
+            overflow: 'auto'
+          }}
         >
           {searchAutocompleteResults.map((result, index) => (
             <div
@@ -327,11 +330,7 @@ const SicpNavigationBar: React.FC = () => {
   );
 
   const indexSearch = (
-    <div
-      className="indexSearch"
-      style={{ position: 'absolute', top: '10%', left: '36%', width: '20%', height: '600%' }}
-      key="indexSearch"
-    >
+    <div className="indexSearch" style={{ position: 'relative' }} key="indexSearch">
       <div className="indexSearch-inner">
         <div style={{ display: 'inline-flex' }}>
           <InputGroup
@@ -349,7 +348,14 @@ const SicpNavigationBar: React.FC = () => {
       {indexAutocompleteResults.length !== 0 && (
         <div
           className="userSearchDropdown"
-          style={{ backgroundColor: 'white', outline: 'dashed', height: '100%', overflow: 'auto' }}
+          style={{
+            position: 'absolute',
+            backgroundColor: 'white',
+            outline: 'dashed',
+            width: '100%',
+            height: '600%',
+            overflow: 'auto'
+          }}
         >
           {indexAutocompleteResults.map(result => (
             <div
@@ -372,6 +378,16 @@ const SicpNavigationBar: React.FC = () => {
           ))}
         </div>
       )}
+    </div>
+  );
+
+  const searchWrapper = (
+    <div
+      className="searchWrapper"
+      style={{ display: 'flex', width: '100%', justifyContent: 'center' }}
+      key="searchWrapper"
+    >
+      {[userSearch, indexSearch]}
     </div>
   );
 
@@ -415,8 +431,9 @@ const SicpNavigationBar: React.FC = () => {
   return (
     <>
       <Navbar className="SicpNavigationBar secondary-navbar">
-        <NavbarGroup align={Alignment.LEFT}>{[tocButton, userSearch, indexSearch]}</NavbarGroup>
+        <NavbarGroup align={Alignment.LEFT}>{tocButton}</NavbarGroup>
         <NavbarGroup align={Alignment.RIGHT}>{[prevButton, nextButton]}</NavbarGroup>
+        <NavbarGroup align={Alignment.CENTER}>{searchWrapper}</NavbarGroup>
       </Navbar>
       <Drawer {...drawerProps} className="sicp-toc-drawer">
         <SicpToc handleCloseToc={handleCloseToc} />

--- a/src/commons/navigationBar/subcomponents/__tests__/__snapshots__/SicpNavigationBar.tsx.snap
+++ b/src/commons/navigationBar/subcomponents/__tests__/__snapshots__/SicpNavigationBar.tsx.snap
@@ -11,76 +11,6 @@ exports[`Navbar renders correctly 1`] = `
       <TableOfContentsButton
         handleOpenToc={[Function]}
       />
-      <div
-        className="userSearch"
-        style={
-          Object {
-            "height": "600%",
-            "left": "15%",
-            "position": "absolute",
-            "top": "10%",
-            "width": "20%",
-          }
-        }
-      >
-        <div
-          className="userSearch-inner"
-        >
-          <div
-            style={
-              Object {
-                "display": "inline-flex",
-              }
-            }
-          >
-            <Blueprint4.InputGroup
-              onChange={[Function]}
-              placeholder="Search"
-              value=""
-            />
-            <ControlButton
-              icon="search"
-              label="Text"
-              onClick={[Function]}
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="indexSearch"
-        style={
-          Object {
-            "height": "600%",
-            "left": "36%",
-            "position": "absolute",
-            "top": "10%",
-            "width": "20%",
-          }
-        }
-      >
-        <div
-          className="indexSearch-inner"
-        >
-          <div
-            style={
-              Object {
-                "display": "inline-flex",
-              }
-            }
-          >
-            <Blueprint4.InputGroup
-              onChange={[Function]}
-              placeholder="Search"
-              value=""
-            />
-            <ControlButton
-              icon="search"
-              label="Index"
-              onClick={[Function]}
-            />
-          </div>
-        </div>
-      </div>
     </Blueprint4.NavbarGroup>
     <Blueprint4.NavbarGroup
       align="right"
@@ -96,6 +26,83 @@ exports[`Navbar renders correctly 1`] = `
             }
           }
         />
+      </div>
+    </Blueprint4.NavbarGroup>
+    <Blueprint4.NavbarGroup
+      align="center"
+    >
+      <div
+        className="searchWrapper"
+        style={
+          Object {
+            "display": "flex",
+            "justifyContent": "center",
+            "width": "100%",
+          }
+        }
+      >
+        <div
+          className="userSearch"
+          style={
+            Object {
+              "position": "relative",
+            }
+          }
+        >
+          <div
+            className="userSearch-inner"
+          >
+            <div
+              style={
+                Object {
+                  "display": "inline-flex",
+                }
+              }
+            >
+              <Blueprint4.InputGroup
+                onChange={[Function]}
+                placeholder="Search"
+                value=""
+              />
+              <ControlButton
+                icon="search"
+                label="Text"
+                onClick={[Function]}
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="indexSearch"
+          style={
+            Object {
+              "position": "relative",
+            }
+          }
+        >
+          <div
+            className="indexSearch-inner"
+          >
+            <div
+              style={
+                Object {
+                  "display": "inline-flex",
+                }
+              }
+            >
+              <Blueprint4.InputGroup
+                onChange={[Function]}
+                placeholder="Search"
+                value=""
+              />
+              <ControlButton
+                icon="search"
+                label="Index"
+                onClick={[Function]}
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </Blueprint4.NavbarGroup>
   </Blueprint4.Navbar>


### PR DESCRIPTION
### Description

This PR aims to resolve source-academy/sicp#906, to center the search bars on the SICP JS page regardless of screen width. 

Changes involved include adding a new inline component to wrap both search bars (`userSearch`, `indexSearch`), as well as modifying some inaccurate styling (regarding the use of `position: absolute` with respect to the search bar components themselves, they should instead be applied to the respective searchDropdowns). There is also a new NavbarGroup component included to contain the centered search bar(s).

<details>
<summary>Demonstration of changes: (click to expand)</summary>

New search bar:
<img width="1268" alt="NewPlacement" src="https://github.com/source-academy/frontend/assets/26355099/fc522c8b-3fa0-4d11-89d1-63ad43932802">

Original/Current behaviour | Updated/New behaviour
:-------------------------:|:-------------------------:  
![Current Behaviour](https://github.com/source-academy/frontend/assets/26355099/c67fa30b-6406-4bc3-b382-691159f7c6d0) | ![New Behaviour](https://github.com/source-academy/frontend/assets/26355099/a8a59388-7a74-42c6-bf1a-177c7b89f3d6)
</details>

The changes have been tested locally with the following browsers:
- Chrome v116
- Firefox v118

However, mobile-sized screens will still run into width problem (same behaviour as without this PR) as a caveat. A possible proposal would be to re-align the navigation bar items vertically on mobile screens, or alternatively, to reduce the content size of elements within.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Code was tested locally in a development environment with different browsers, and all tests/formatting checks have been successfully ran and passed.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
