### PR TITLE
Fix assessment workspace runtime error

### DIFF
--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -363,11 +363,11 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
     handleEditorUpdateBreakpoints(0, []);
     handleUpdateCurrentAssessmentId(assessmentId, questionId);
     handleResetWorkspace({
-      autogradingResults: options.autogradingResults,
+      autogradingResults: options.autogradingResults ?? [],
       // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
       editorTabs: [{ value: options.editorValue ?? '', highlightedLines: [], breakpoints: [] }],
-      programPrependValue: options.programPrependValue,
-      programPostpendValue: options.programPostpendValue,
+      programPrependValue: options.programPrependValue ?? '',
+      programPostpendValue: options.programPostpendValue ?? '',
       editorTestcases: options.editorTestcases ?? []
     });
     handleChangeExecTime(

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -67,6 +67,7 @@ import { SideContentTab, SideContentType } from '../sideContent/SideContentTypes
 import Constants from '../utils/Constants';
 import { useResponsive, useTypedSelector } from '../utils/Hooks';
 import { assessmentTypeLink } from '../utils/ParamParseHelper';
+import { assertType } from '../utils/TypeHelper';
 import Workspace, { WorkspaceProps } from '../workspace/Workspace';
 import {
   beginClearContext,
@@ -362,7 +363,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
     // TODO: Hardcoded to make use of the first editor tab. Refactoring is needed for this workspace to enable Folder mode.
     handleEditorUpdateBreakpoints(0, []);
     handleUpdateCurrentAssessmentId(assessmentId, questionId);
-    handleResetWorkspace({
+    const resetWorkspaceOptions = assertType<WorkspaceState>()({
       autogradingResults: options.autogradingResults ?? [],
       // TODO: Hardcoded to make use of the first editor tab. Rewrite after editor tabs are added.
       editorTabs: [{ value: options.editorValue ?? '', highlightedLines: [], breakpoints: [] }],
@@ -370,6 +371,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
       programPostpendValue: options.programPostpendValue ?? '',
       editorTestcases: options.editorTestcases ?? []
     });
+    handleResetWorkspace(resetWorkspaceOptions);
     handleChangeExecTime(
       question.library.execTimeMs ?? defaultWorkspaceManager.assessment.execTime
     );

--- a/src/commons/utils/TypeHelper.ts
+++ b/src/commons/utils/TypeHelper.ts
@@ -64,6 +64,13 @@ export const assertType =
     } & {
       // Keys of S should be optional to allow extension
       [key in keyof S]?: S[key];
+    } & {
+      // But if the key is defined in T, despite being a partial
+      // type, the value of T[key] must not be undefined
+      // unless undefined is allowed in S. Similar behavior to
+      // `--exactOptionalPropertyTypes` flag in tsconfig.json,
+      // but this allows us to only enforce it when we want to.
+      [key in keyof T]: key extends keyof S ? S[key] : never;
     } = any
   >(
     obj: T


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There was a regression in #2517 when I refactored the naked variables into a single config object – I missed out on setting fallback values (as they were no longer initialised).

This resulted in a runtime error when opening assessments where autograding is enabled and contains a multiple-choice question.

In the process of restoring the old behavior, I also noticed that the type guard function can produce incorrect results when checking the type of non-optional values. Thus, this PR also fixes the `assertType` function so that undefined values, unless the underlying type being checked against also allows for them, will result in a compile-time error.

This should prevent reoccurrence in the future.

Supersedes #2625.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [x] I have updated the documentation
