### PR TITLE
Fix 403 error popup on page load

### DIFF
--- a/src/pages/academy/Academy.tsx
+++ b/src/pages/academy/Academy.tsx
@@ -9,7 +9,6 @@ import Constants from 'src/commons/utils/Constants';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 
 import {
-  fetchGradingOverviews,
   fetchNotifications,
   updateLatestViewedCourse
 } from '../../commons/application/actions/SessionActions';
@@ -33,7 +32,6 @@ const Academy: React.FC<{}> = () => {
   const dispatch = useDispatch();
   React.useEffect(() => {
     dispatch(fetchNotifications());
-    dispatch(fetchGradingOverviews(false));
   }, [dispatch]);
 
   const agreedToResearch = useTypedSelector(state => state.session.agreedToResearch);

--- a/src/pages/academy/grading/Grading.tsx
+++ b/src/pages/academy/grading/Grading.tsx
@@ -1,6 +1,8 @@
 import { NonIdealState, Spinner, SpinnerSize } from '@blueprintjs/core';
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
 import { Navigate, useParams } from 'react-router';
+import { fetchGradingOverviews } from 'src/commons/application/actions/SessionActions';
 import { useTypedSelector } from 'src/commons/utils/Hooks';
 import { numberRegExp } from 'src/features/academy/AcademyTypes';
 
@@ -15,6 +17,11 @@ const Grading: React.FC = () => {
     submissionId: string;
     questionId: string;
   }>();
+
+  const dispatch = useDispatch();
+  React.useEffect(() => {
+    dispatch(fetchGradingOverviews(false));
+  }, [dispatch]);
 
   // If submissionId or questionId is defined but not numeric, redirect back to the Grading overviews page
   if (


### PR DESCRIPTION
### Description

The PR fixes a bug which shows a 403 error popup every single time a page in the academy tab has been loaded (see image below).

<details>
<summary>Error popup</summary>
<img width="738" alt="Error" src="https://github.com/source-academy/frontend/assets/26355099/a44a00a9-4c25-4f98-aa96-537ac199855e">
</details>

This bug had likely been introduced in the commit 05cad2b218bbf5cd694615d868c79b487593321e, where `src/pages/academy/Academy.ts` has a new dispatch effect added upon component loading. Grading overview data should be fetched in grading pages instead of main academy pages.

However, this fix has only been experimentally-tested locally, and further verification is required to ensure no regression towards the grading page(s).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

After running, ensure the frontend does not make an request to `<API>/v2/courses/<course_id>/admin/grading?group=false` (in browser console), and that the grading page(s) works normally.

### Checklist

- [ ] I have tested this code
- [ ] I have updated the documentation
