### PR TITLE
Fix grading submissions filter text not showing filter value

### DIFF
--- a/src/pages/academy/grading/subcomponents/GradingSubmissionsTable.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingSubmissionsTable.tsx
@@ -170,6 +170,7 @@ const GradingSubmissionTable: React.FC<GradingSubmissionTableProps> = ({ group, 
           maxWidth="max-w-sm"
           icon={() => <BpIcon icon={IconNames.SEARCH} style={{ marginLeft: '0.75rem' }} />}
           placeholder="Search for any value here..."
+          value={globalFilter ?? ''}
           onChange={e => setGlobalFilter(e.target.value)}
         />
       </Flex>


### PR DESCRIPTION
### Description

After applying a global filter for submission and then navigating to a sub-route of `/grading` (e.g. grading a submission), navigating back to `/grading` retains filter value in the filter state but the input text field stays empty. This fix populates the  text input correctly upon returning to the submission table. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

To reproduce the bug:
1. Apply a global submission filter using the text input
2. Grade any submission
3. Go back to `/grading` using the navbar
4. The submission are still filtered by the previous global filter (and any additional column filters) but the text input is empty

After the fix the text input in step 4 should show the previously applied filter.

### Checklist

<!-- Please delete options that are not relevant. -->

- [X] I have tested this code
