### PR TITLE
Add refresh button to force refresh service worker

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import 'src/styles/index.scss';
 
+import { Button } from '@blueprintjs/core';
 import * as Sentry from '@sentry/browser';
 import { setModulesStaticURL } from 'js-slang/dist/modules/moduleLoader';
 import { createRoot } from 'react-dom/client';
@@ -47,9 +48,21 @@ createInBrowserFileSystem(store)
   });
 
 registerServiceWorker({
-  onUpdate: () => {
+  onUpdate: registration => {
     showWarningMessage(
-      'A new version of Source Academy is available. Please refresh the browser.',
+      <div>
+        <span>A new version of Source Academy is available.&nbsp;</span>
+        <Button
+          onClick={() => {
+            if (registration && registration.waiting) {
+              registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+            }
+            window.location.reload();
+          }}
+        >
+          Refresh now
+        </Button>
+      </div>,
       0
     );
   }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adding a 'force refresh' button in the 'new version of SA' prompt to facilitate the upcoming deployments to prod.
- Users can click this button to force refresh instead of `Ctrl-Shift-r`
- Lessens confusion faced by students and staff whenever a new frontend version is available, as a normal browser reload does not work

<img width="910" alt="image" src="https://github.com/source-academy/frontend/assets/53928333/12d77656-4a26-4a03-a575-3d91e6e36dbc">

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Build the app locally and serve it (e.g. `yarn build; serve -s build -l 8000`
2. Load the webpage on your browser
3. Open `Developer's Console > Application > Service Worker > Status` and ensure the SW is activated and running
4. Make some changes in the codebase (any JSX element's text will do)
5. Rebuild the app and serve it
6. Refresh the webpage that is currently opened --> the prompt should pop up (at the same time, the SW status in developers console should show 'Installing', then 'waiting to activate')
7. Click on the 'Refresh now' button. The SW status should update in the developer's console. The new SW should now be running

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
