### PR TITLE
feat: add `xpBonus` to submissions table

### DIFF
--- a/src/pages/academy/grading/subcomponents/GradingSubmissionsTable.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingSubmissionsTable.tsx
@@ -76,14 +76,16 @@ const columns = [
       </Filterable>
     )
   }),
-  columnHelper.accessor(({ currentXp, maxXp }) => ({ currentXp, maxXp }), {
-    header: 'XP',
+  columnHelper.accessor(({ currentXp, xpBonus, maxXp }) => ({ currentXp, xpBonus, maxXp }), {
+    header: 'Raw XP (+Bonus)',
     enableColumnFilter: false,
     cell: info => {
-      const { currentXp, maxXp } = info.getValue();
+      const { currentXp, xpBonus, maxXp } = info.getValue();
       return (
         <Flex justifyContent="justify-start" spaceX="space-x-2">
-          <Text>{currentXp}</Text>
+          <Text>
+            {currentXp} (+{xpBonus})
+          </Text>
           <Text>/</Text>
           <Text>{maxXp}</Text>
         </Flex>


### PR DESCRIPTION
## Description

The current submissions table no longer shows the bonus XP a student obtained. This PR adds that functionality and displays it in the following format:

`<Raw XP> (+<Bonus XP>) / <Max XP>`


