### PR TITLE
Disable stories routes under public deployment

### DIFF
--- a/src/routes/routerConfig.tsx
+++ b/src/routes/routerConfig.tsx
@@ -91,22 +91,6 @@ const commonChildrenRoutes: RouteObject[] = [
     path: 'githubassessments/*',
     lazy: GitHubClassroom,
     loader: conditionalLoader(!Constants.enableGitHubAssessments, '/')
-  },
-  {
-    path: 'stories/new',
-    lazy: EditStory
-  },
-  {
-    path: 'stories/view/:id',
-    lazy: ViewStory
-  },
-  {
-    path: 'stories/edit/:id',
-    lazy: EditStory
-  },
-  {
-    path: 'stories',
-    lazy: Stories
   }
 ];
 
@@ -203,6 +187,22 @@ export const getFullAcademyRouterConfig = ({
         {
           path: 'mission-control/:assessmentId?/:questionId?',
           lazy: MissionControl
+        },
+        {
+          path: 'stories/new',
+          lazy: EditStory
+        },
+        {
+          path: 'stories/view/:id',
+          lazy: ViewStory
+        },
+        {
+          path: 'stories/edit/:id',
+          lazy: EditStory
+        },
+        {
+          path: 'stories',
+          lazy: Stories
         },
         ...commonChildrenRoutes,
         {


### PR DESCRIPTION
### Description

This PR attempts to resolve #2633 to disable the routes in the public deployment as stories are not yet available. The fix moves all stories-related routes to under `fullAcademy` router, instead of being under common routes where they would still be accessible in the public deployment.

Alternatively, adding a environment variable can also be considered instead, to toggle whether stories routes will be enabled (similar to how `githubAssessments` work right now). If this is the right way going forward, let me know and I will refactor the code accordingly.

Also as a side note, the stories component might also need to updated to have its own router instead, as right now they are statically defined in the main `routerConfig` file. This will also ease the implementation of #2632 where more fine-grained permissions control can be done within its own router. However, this is outside the scope of this PR and should be in its own standalone update. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Check if the routes are accessible when `REACT_APP_USE_BACKEND` is true and when is false (fullAcademy mode enabled and disabled).

The code has been tested locally, and confirmed that stories routes will no longer be present.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
