### PR TITLE
Fix breakpoints state going out of sync

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -411,10 +411,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
     // hopelessly incomplete
     editor.on(
       'gutterclick' as any,
-      makeHandleGutterClick(
-        (...args) => handleEditorUpdateBreakpointsRef.current(...args),
-        props.editorTabIndex
-      ) as any
+      makeHandleGutterClick(handleEditorUpdateBreakpointsRef.current, props.editorTabIndex)
     );
 
     // Change all info annotations to error annotations
@@ -485,8 +482,16 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
       if (!reactAceRef.current) {
         return;
       }
-      handleEditorValueChange(props.editorTabIndex, newCode);
+
       shiftBreakpointsWithCode(reactAceRef.current.editor, delta);
+
+      // Write editor state for the active editor tab to the store.
+      handleEditorValueChange(props.editorTabIndex, newCode);
+      handleEditorUpdateBreakpointsRef.current(
+        props.editorTabIndex,
+        reactAceRef.current.editor.session.getBreakpoints()
+      );
+
       if (handleUpdateHasUnsavedChanges) {
         handleUpdateHasUnsavedChanges(true);
       }


### PR DESCRIPTION
### Description

In #2269 & #2346, the behaviour of breakpoints was updated to be consistent with most code editors & IDEs available. However, due to the way the `Editor` component and the workspaces are implemented, the `Editor` maintains its own source of truth that is separate from the Redux store. The bug in #2646 occurs when the breakpoints state in the Redux store and the `Editor` component become unsynchronised.

To fix this issue, we write the current `Editor` breakpoints state to the Redux store whenever the `Editor` value updates. Ideally, the `Editor` should rely on the Redux store as the single source of truth, but this would require major refactoring and I'm not confident of not breaking other things along the way due to the lack of comprehensive tests + the rather hacky implementation of the `Editor`.

Fixes #2646.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Replicate

### Checklist

- [x] I have (manually) tested this code
- [ ] I have updated the documentation

Ideally, I would write regression tests here, but testing this particular logic requires some test framework that can simulate user input such as Cypress (and setting up such a test framework is beyond the scope of this PR).