### PR TITLE
Fix unable to remove highlighting from code

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -348,6 +348,22 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
       // See AceHelper#selectMode for more information.
       props.session.setMode(editor.getSession().getMode());
       editor.setSession(props.session);
+      /* eslint-disable */
+
+      // Add changeCursor event listener onto the current session.
+      // In ReactAce, this event listener is only bound on component
+      // mounting/creation, and hence changing sessions will need rebinding.
+      // See react-ace/src/ace.tsx#263,#460 for more details. We also need to
+      // ensure that event listener is only bound once to prevent memory leaks.
+      // We also need to check non-documented property _eventRegistry to
+      // see if the changeCursor listener event has been added yet.
+
+      // @ts-ignore
+      if (editor.getSession().selection._eventRegistry.changeCursor.length < 2) {
+        editor.getSession().selection.on('changeCursor', reactAceRef.current!.onCursorChange);
+      }
+
+      /* eslint-enable */
       // Give focus to the editor tab only after switching from another tab.
       // This is necessary to prevent 'unstable_flushDiscreteUpdates' warnings.
       if (filePath !== undefined) {


### PR DESCRIPTION
### Description

This PR attempts to fix #2645 where the highlighting is stuck after the implementation to use multiple editor sessions, due to the `onCursorChange` event not firing properly. After much code testing and extensive troubleshooting, the issue has been narrowed down to a likely upstream library problem.

As seen from the source code in ReactAce ([`ace.tsx` on line 263](https://github.com/securingsincity/react-ace/blob/5e2290f716fa965ba70889cc94b4221ac93334ac/src/ace.tsx#L263)), the event registration for `changeCursor` (which is linked to `onChangeCursor`) is only performed once during the `componentDidMount` lifecycle stage. This means that, only the default session initially created together with the editor will have the events bound, and any other sessions (created by us) will not be registered with the events. Our implementation of sessions completely ignore the default built-in session, and is replaced with our own default session (see [`Editor.tsx`#570](https://github.com/source-academy/frontend/blob/7cea1313d591eed07f9265243a431db7a285d2e0/src/commons/editor/Editor.tsx#L350)). This causes the problem even when not in folder mode.

I have already opened an issue over at the upstream library (securingsincity/react-ace#1839), and will monitor the progress on the issue (although there seems to be little activity there as of writing). In the meantime, a hacky-ish workaround will be proposed to resolve this issue for now.

Therefore, the current proposed fix will try to bind the `onCursorChange` handler back onto the session every time the session changes (see [`Editor.tsx`#350](https://github.com/source-academy/frontend/blob/7cea1313d591eed07f9265243a431db7a285d2e0/src/commons/editor/Editor.tsx#L350)). However, a event listener check (that relies on some internal non-documented property) is also required, to ensure that the event is only registered once (for a total of 2 event listeners, one from the default ace editor and the handler from react-ace), preventing any memory/listener leakages.

The changes have been tested locally on the latest codebase, with the latest Chrome browser. Folder mode switching also appears to be working fine (which required the use of multiple `EditorSession` in the first place).

https://github.com/source-academy/frontend/assets/26355099/413d230a-6871-4524-b14d-efcf4d5fc2c7

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Checking whether moving the cursor after highlighting a code block with `Ctrl + Shift + H` (or `Cmd + Shift + H` on macOS) will un-highlight the block of code.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
