### PR TITLE
Polyfill `path/posix` library when building

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -46,6 +46,7 @@ const cracoConfig = (module.exports = {
         'http': require.resolve('stream-http'),
         'https': require.resolve('https-browserify'),
         'os': require.resolve('os-browserify/browser'),
+        'path/posix': require.resolve('path-browserify'),
         'stream': require.resolve('stream-browserify'),
         'timers': require.resolve('timers-browserify'),
         'url': require.resolve('url/')

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "husky": "^8.0.2",
     "npm-run-all": "^4.1.5",
     "os-browserify": "^0.3.0",
+    "path-browserify": "^1.0.1",
     "prettier": "^2.8.8",
     "process": "^0.11.10",
     "react-error-overlay": "^6.0.11",


### PR DESCRIPTION
### Description

Node.js APIs are only available in Node.js environments (and not browser environments). In order to make use of Node.js APIs in the browser, Webpack includes polyfills of these APIs (libraries that contain the same or similar API but are implemented in pure JavaScript so that they can be run in the browser).

Webpack appears to polyfill the `path` module by default, but not the `path/posix` module. This PR adds the `path-browserify` library as a polyfill for `path/posix`. Note that the lock file does not change because Webpack already depends on `path-browserify`.

Fixes the build issue seen in #2655.

Relevant js-slang PR: https://github.com/source-academy/js-slang/pull/1470

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

1. Bump js-slang to v1.0.34.
1. Run `yarn run build` and verify that there are no errors.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
