### PR TITLE
Fix group switching for admins

### DIFF
--- a/src/pages/academy/grading/Grading.tsx
+++ b/src/pages/academy/grading/Grading.tsx
@@ -34,10 +34,6 @@ const Grading: React.FC = () => {
 
   const isAdmin = role === Role.Admin;
   const [showAllGroups, setShowAllGroups] = useState(isAdmin || group === null);
-  const handleShowAllGroups = (value: boolean) => {
-    // Admins will always see all groups regardless
-    setShowAllGroups(isAdmin || value);
-  };
   const groupOptions = [
     { value: false, label: 'my groups' },
     { value: true, label: 'all groups' }
@@ -122,7 +118,7 @@ const Grading: React.FC = () => {
                   <SimpleDropdown
                     options={groupOptions}
                     defaultValue={showAllGroups}
-                    onClick={handleShowAllGroups}
+                    onClick={setShowAllGroups}
                     popoverProps={{ position: Position.BOTTOM }}
                     buttonProps={{ minimal: true, rightIcon: 'caret-down' }}
                   />


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This was missed in #2644. Admins should now be able to filter by their own group ("all groups" remains default for them):

![image](https://github.com/source-academy/frontend/assets/34370238/bb339e66-4998-49af-8e0f-8a7628d72d0e)

_(Previously, toggling to "my groups" does nothing – this is a bug)_

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
