### PR TITLE
Deprecate set-output in Github Action workflows

### DIFF
--- a/.github/workflows/build-development.yml
+++ b/.github/workflows/build-development.yml
@@ -19,9 +19,9 @@ jobs:
         curl -sL https://sentry.io/get-cli/ | INSTALL_DIR=. bash
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - id: get-time
-      run: echo "::set-output name=time::$(date -Iseconds)"
+      run: echo "time=$(date -Iseconds)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v2
       id: yarn-cache
       with:


### PR DESCRIPTION
### Description

As of 11 October 2022, [Github has announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) that the `::set-output` and `::save-state` workflow commands have been deprecated and should be migrated to the new format as soon as possible. Even though the removal of the commands has been put on hold, we should still move away from the old commands to prevent possible breakages in the future.

Fixes #2478.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Ensure that GH Actions continue to work as expected without errors.

### Checklist

- [ ] I have tested this code
- [ ] I have updated the documentation
