### PR TITLE
Provide Module Side Content with more packages

### DIFF
--- a/src/commons/editor/tabs/utils.ts
+++ b/src/commons/editor/tabs/utils.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import { posix as pathlib } from 'path';
 
 /**
  * Returns the shortest file paths that is uniquely identifiable among
@@ -32,7 +32,7 @@ export const getShortestUniqueFilePaths = (originalFilePaths: string[]): string[
       ...segments,
       // It is necessary to remove empty segments to deal with the very first '/' in
       // file paths.
-      [filePath]: filePath.split(path.sep).filter(segment => segment !== '')
+      [filePath]: filePath.split(pathlib.sep).filter(segment => segment !== '')
     }),
     {}
   );

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -1099,6 +1099,8 @@ export function* evalCode(
     context.executionMethod = 'ec-evaluator';
   }
 
+  const isFolderModeEnabled: boolean = yield select((state: OverallState) => state.workspaces[workspaceLocation].isFolderModeEnabled)
+
   const entrypointCode = files[entrypointFilePath];
 
   function call_variant(variant: Variant) {
@@ -1168,13 +1170,15 @@ export function* evalCode(
         ? call(resume, lastDebuggerResult)
         : isNonDet || isLazy || isWasm
         ? call_variant(context.variant)
-        : call(runFilesInContext, files, entrypointFilePath, context, {
+        : call(runFilesInContext, isFolderModeEnabled ? files : {
+          [entrypointFilePath]: files[entrypointFilePath]
+        }, entrypointFilePath, context, {
             scheduler: 'preemptive',
             originalMaxExecTime: execTime,
             stepLimit: stepLimit,
             throwInfiniteLoops: true,
             useSubst: substActiveAndCorrectChapter,
-            envSteps: envSteps
+            envSteps: envSteps,
           }),
 
     /**

--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -1099,7 +1099,9 @@ export function* evalCode(
     context.executionMethod = 'ec-evaluator';
   }
 
-  const isFolderModeEnabled: boolean = yield select((state: OverallState) => state.workspaces[workspaceLocation].isFolderModeEnabled)
+  const isFolderModeEnabled: boolean = yield select(
+    (state: OverallState) => state.workspaces[workspaceLocation].isFolderModeEnabled
+  );
 
   const entrypointCode = files[entrypointFilePath];
 
@@ -1170,16 +1172,24 @@ export function* evalCode(
         ? call(resume, lastDebuggerResult)
         : isNonDet || isLazy || isWasm
         ? call_variant(context.variant)
-        : call(runFilesInContext, isFolderModeEnabled ? files : {
-          [entrypointFilePath]: files[entrypointFilePath]
-        }, entrypointFilePath, context, {
-            scheduler: 'preemptive',
-            originalMaxExecTime: execTime,
-            stepLimit: stepLimit,
-            throwInfiniteLoops: true,
-            useSubst: substActiveAndCorrectChapter,
-            envSteps: envSteps,
-          }),
+        : call(
+            runFilesInContext,
+            isFolderModeEnabled
+              ? files
+              : {
+                  [entrypointFilePath]: files[entrypointFilePath]
+                },
+            entrypointFilePath,
+            context,
+            {
+              scheduler: 'preemptive',
+              originalMaxExecTime: execTime,
+              stepLimit: stepLimit,
+              throwInfiniteLoops: true,
+              useSubst: substActiveAndCorrectChapter,
+              envSteps: envSteps
+            }
+          ),
 
     /**
      * A BEGIN_INTERRUPT_EXECUTION signals the beginning of an interruption,

--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -1,5 +1,11 @@
+import * as bp3core from '@blueprintjs/core';
+import * as bp3icons from '@blueprintjs/icons';
+import * as bp3popover from '@blueprintjs/popover2';
+import * as jsslang from 'js-slang';
+import * as jsslangDist from 'js-slang/dist';
 import React from 'react';
 import JSXRuntime from 'react/jsx-runtime';
+import * as ace from 'react-ace';
 import ReactDOM from 'react-dom';
 
 import type { DebuggerContext } from '../workspace/WorkspaceTypes';
@@ -10,18 +16,25 @@ import { ModuleSideContent, SideContentTab, SideContentType } from './SideConten
 //   string[]
 // >();
 
-const requireProvider = (x: string) => {
+const getRequireProvider = (context: jsslang.Context) => (x: string) => {
   const exports = {
     react: React,
+    'react/jsx-runtime': JSXRuntime,
+    'react-ace': ace,
     'react-dom': ReactDOM,
-    'react/jsx-runtime': JSXRuntime
+    '@blueprintjs/core': bp3core,
+    '@blueprintjs/icons': bp3icons,
+    '@blueprintjs/popover2': bp3popover,
+    'js-slang': jsslang,
+    'js-slang/dist': jsslangDist,
+    'js-slang/context': context,
   };
 
   if (!(x in exports)) throw new Error(`Dynamic require of ${x} is not supported`);
   return exports[x];
 };
 
-type RawTab = (provider: typeof requireProvider) => ModuleSideContent;
+type RawTab = (provider: ReturnType<typeof getRequireProvider>) => ModuleSideContent;
 
 /**
  * Returns an array of SideContentTabs to be spawned
@@ -34,7 +47,7 @@ export const getDynamicTabs = (debuggerContext: DebuggerContext): SideContentTab
 
   return Object.values(moduleContexts)
     .flatMap(({ tabs }) => tabs ?? [])
-    .map((rawTab: RawTab) => rawTab(requireProvider))
+    .map((rawTab: RawTab) => rawTab(getRequireProvider(debuggerContext.context)))
     .filter(({ toSpawn }) => !toSpawn || toSpawn(debuggerContext))
     .map(tab => ({
       ...tab,

--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -26,7 +26,7 @@ const requireProvider = (x: string) => {
     '@blueprintjs/icons': bp3icons,
     '@blueprintjs/popover2': bp3popover,
     'js-slang': jsslang,
-    'js-slang/dist': jsslangDist,
+    'js-slang/dist': jsslangDist
   };
 
   if (!(x in exports)) throw new Error(`Dynamic require of ${x} is not supported`);

--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -16,7 +16,7 @@ import { ModuleSideContent, SideContentTab, SideContentType } from './SideConten
 //   string[]
 // >();
 
-const getRequireProvider = (context: jsslang.Context) => (x: string) => {
+const requireProvider = (x: string) => {
   const exports = {
     react: React,
     'react/jsx-runtime': JSXRuntime,
@@ -27,14 +27,13 @@ const getRequireProvider = (context: jsslang.Context) => (x: string) => {
     '@blueprintjs/popover2': bp3popover,
     'js-slang': jsslang,
     'js-slang/dist': jsslangDist,
-    'js-slang/context': context,
   };
 
   if (!(x in exports)) throw new Error(`Dynamic require of ${x} is not supported`);
   return exports[x];
 };
 
-type RawTab = (provider: ReturnType<typeof getRequireProvider>) => ModuleSideContent;
+type RawTab = (provider: ReturnType<typeof requireProvider>) => ModuleSideContent;
 
 /**
  * Returns an array of SideContentTabs to be spawned
@@ -47,7 +46,7 @@ export const getDynamicTabs = (debuggerContext: DebuggerContext): SideContentTab
 
   return Object.values(moduleContexts)
     .flatMap(({ tabs }) => tabs ?? [])
-    .map((rawTab: RawTab) => rawTab(getRequireProvider(debuggerContext.context)))
+    .map((rawTab: RawTab) => rawTab(requireProvider))
     .filter(({ toSpawn }) => !toSpawn || toSpawn(debuggerContext))
     .map(tab => ({
       ...tab,


### PR DESCRIPTION
Source modules use several packages that are already available on the frontend. This means that these packages should not have to be bundled with Source modules. These packages are:
- `react` and `react/jsx-runtime` (both are necessary to maintain compatibility with both the old and new types of JSX transform)
- `react-dom`
- `react-ace`
- `@blueprintjs/core`,  `@blueprintjs/icons`,  `@blueprintjs/popover2`
- `js-slang`
If there are any other packages that fall under this category, I will modify this PR to further include them.

This PR makes these other packages available to the Source modules.

This PR also fixes an issue where even with folder mode disabled, files that had been previously created could still be imported