### PR TITLE
Tighten constraint of workspace actions

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.ts
+++ b/src/commons/sagas/WorkspaceSaga.ts
@@ -1302,7 +1302,9 @@ export function* evalCode(
   // the total number of steps and the breakpoints are updated in the Environment Visualiser slider.
   if (context.executionMethod === 'ec-evaluator' && needUpdateEnv) {
     yield put(actions.updateEnvStepsTotal(context.runtime.envStepsTotal, workspaceLocation));
-    yield put(actions.toggleUpdateEnv(false, workspaceLocation));
+    // `needUpdateEnv` implies `correctWorkspace`, which satisfies the type constraint.
+    // But TS can't infer that yet, so we need a typecast here.
+    yield put(actions.toggleUpdateEnv(false, workspaceLocation as any));
     yield put(actions.updateBreakpointSteps(context.runtime.breakpointSteps, workspaceLocation));
   }
   // Stop the home icon from flashing for an error if it is doing so since the evaluation is successful

--- a/src/commons/workspace/WorkspaceActions.ts
+++ b/src/commons/workspace/WorkspaceActions.ts
@@ -385,7 +385,7 @@ export const notifyProgramEvaluated = (
     workspaceLocation
   });
 
-export const toggleUsingSubst = (usingSubst: boolean, workspaceLocation: 'playground' | 'sicp') =>
+export const toggleUsingSubst = (usingSubst: boolean, workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'> | WorkspaceLocation) =>
   action(TOGGLE_USING_SUBST, { usingSubst, workspaceLocation });
 
 export const addHtmlConsoleError = (
@@ -394,10 +394,10 @@ export const addHtmlConsoleError = (
   storyEnv?: string
 ) => action(ADD_HTML_CONSOLE_ERROR, { errorMsg, workspaceLocation, storyEnv });
 
-export const toggleUsingEnv = (usingEnv: boolean, workspaceLocation: 'playground' | 'sicp') =>
+export const toggleUsingEnv = (usingEnv: boolean, workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'>) =>
   action(TOGGLE_USING_ENV, { usingEnv, workspaceLocation });
 
-export const toggleUpdateEnv = (updateEnv: boolean, workspaceLocation: 'playground' | 'sicp') =>
+export const toggleUpdateEnv = (updateEnv: boolean, workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'>) =>
   action(TOGGLE_UPDATE_ENV, { updateEnv, workspaceLocation });
 
 export const updateEnvSteps = (steps: number, workspaceLocation: WorkspaceLocation) =>

--- a/src/commons/workspace/WorkspaceActions.ts
+++ b/src/commons/workspace/WorkspaceActions.ts
@@ -385,8 +385,11 @@ export const notifyProgramEvaluated = (
     workspaceLocation
   });
 
-export const toggleUsingSubst = (usingSubst: boolean, workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'> | WorkspaceLocation) =>
-  action(TOGGLE_USING_SUBST, { usingSubst, workspaceLocation });
+// Only playground and sicp supports subst visualizer
+export const toggleUsingSubst = (
+  usingSubst: boolean,
+  workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'> | WorkspaceLocation
+) => action(TOGGLE_USING_SUBST, { usingSubst, workspaceLocation });
 
 export const addHtmlConsoleError = (
   errorMsg: string,
@@ -394,11 +397,17 @@ export const addHtmlConsoleError = (
   storyEnv?: string
 ) => action(ADD_HTML_CONSOLE_ERROR, { errorMsg, workspaceLocation, storyEnv });
 
-export const toggleUsingEnv = (usingEnv: boolean, workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'>) =>
-  action(TOGGLE_USING_ENV, { usingEnv, workspaceLocation });
+// Only playground and sicp supports CSE Machine
+export const toggleUsingEnv = (
+  usingEnv: boolean,
+  workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'>
+) => action(TOGGLE_USING_ENV, { usingEnv, workspaceLocation });
 
-export const toggleUpdateEnv = (updateEnv: boolean, workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'>) =>
-  action(TOGGLE_UPDATE_ENV, { updateEnv, workspaceLocation });
+// Only playground and sicp supports CSE Machine
+export const toggleUpdateEnv = (
+  updateEnv: boolean,
+  workspaceLocation: Extract<WorkspaceLocation, 'playground' | 'sicp'>
+) => action(TOGGLE_UPDATE_ENV, { updateEnv, workspaceLocation });
 
 export const updateEnvSteps = (steps: number, workspaceLocation: WorkspaceLocation) =>
   action(UPDATE_ENVSTEPS, { steps, workspaceLocation });

--- a/src/commons/workspace/WorkspaceActions.ts
+++ b/src/commons/workspace/WorkspaceActions.ts
@@ -385,7 +385,7 @@ export const notifyProgramEvaluated = (
     workspaceLocation
   });
 
-export const toggleUsingSubst = (usingSubst: boolean, workspaceLocation: WorkspaceLocation) =>
+export const toggleUsingSubst = (usingSubst: boolean, workspaceLocation: 'playground' | 'sicp') =>
   action(TOGGLE_USING_SUBST, { usingSubst, workspaceLocation });
 
 export const addHtmlConsoleError = (
@@ -394,10 +394,10 @@ export const addHtmlConsoleError = (
   storyEnv?: string
 ) => action(ADD_HTML_CONSOLE_ERROR, { errorMsg, workspaceLocation, storyEnv });
 
-export const toggleUsingEnv = (usingEnv: boolean, workspaceLocation: WorkspaceLocation) =>
+export const toggleUsingEnv = (usingEnv: boolean, workspaceLocation: 'playground' | 'sicp') =>
   action(TOGGLE_USING_ENV, { usingEnv, workspaceLocation });
 
-export const toggleUpdateEnv = (updateEnv: boolean, workspaceLocation: WorkspaceLocation) =>
+export const toggleUpdateEnv = (updateEnv: boolean, workspaceLocation: 'playground' | 'sicp') =>
   action(TOGGLE_UPDATE_ENV, { updateEnv, workspaceLocation });
 
 export const updateEnvSteps = (steps: number, workspaceLocation: WorkspaceLocation) =>

--- a/src/commons/workspace/WorkspaceReducer.ts
+++ b/src/commons/workspace/WorkspaceReducer.ts
@@ -571,42 +571,36 @@ export const WorkspaceReducer: Reducer<WorkspaceManagerState> = (
           isEditorAutorun: !state[workspaceLocation].isEditorAutorun
         }
       };
-    case TOGGLE_USING_SUBST:
-      if (workspaceLocation === 'playground' || workspaceLocation === 'sicp') {
-        return {
-          ...state,
-          [workspaceLocation]: {
-            ...state[workspaceLocation],
-            usingSubst: action.payload.usingSubst
-          }
-        };
-      } else {
-        return state;
-      }
-    case TOGGLE_USING_ENV:
-      if (workspaceLocation === 'playground' || workspaceLocation === 'sicp') {
-        return {
-          ...state,
-          [workspaceLocation]: {
-            ...state[workspaceLocation],
-            usingEnv: action.payload.usingEnv
-          }
-        };
-      } else {
-        return state;
-      }
-    case TOGGLE_UPDATE_ENV:
-      if (workspaceLocation === 'playground' || workspaceLocation === 'sicp') {
-        return {
-          ...state,
-          [workspaceLocation]: {
-            ...state[workspaceLocation],
-            updateEnv: action.payload.updateEnv
-          }
-        };
-      } else {
-        return state;
-      }
+    case TOGGLE_USING_SUBST: {
+      const { workspaceLocation } = action.payload;
+      return {
+        ...state,
+        [workspaceLocation]: {
+          ...state[workspaceLocation],
+          usingSubst: action.payload.usingSubst
+        }
+      };
+    }
+    case TOGGLE_USING_ENV: {
+      const { workspaceLocation } = action.payload;
+      return {
+        ...state,
+        [workspaceLocation]: {
+          ...state[workspaceLocation],
+          usingEnv: action.payload.usingEnv
+        }
+      };
+    }
+    case TOGGLE_UPDATE_ENV: {
+      const { workspaceLocation } = action.payload;
+      return {
+        ...state,
+        [workspaceLocation]: {
+          ...state[workspaceLocation],
+          updateEnv: action.payload.updateEnv
+        }
+      };
+    }
     case UPDATE_SUBMISSIONS_TABLE_FILTERS:
       return {
         ...state,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Moves the workspace location check from being from runtime to compile time to make some workspace actions more predictable when called from different workspaces.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements


### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
