### PR TITLE
Fix password-protected assessments

### DIFF
--- a/src/commons/achievement/AchievementView.tsx
+++ b/src/commons/achievement/AchievementView.tsx
@@ -45,7 +45,7 @@ const AchievementView: React.FC<AchievementViewProps> = ({ focusUuid, userState 
       dispatch({ type: FETCH_ASSESSMENT_ADMIN, payload: { assessmentId, courseRegId } });
     } else {
       // If user is student, fetch assessment details from assessment route instead, as seen below
-      dispatch({ type: FETCH_ASSESSMENT, payload: assessmentId });
+      dispatch({ type: FETCH_ASSESSMENT, payload: { assessmentId } });
     }
   }, [dispatch, assessmentId, courseRegId, isAdminView]);
 

--- a/src/commons/application/actions/SessionActions.ts
+++ b/src/commons/application/actions/SessionActions.ts
@@ -91,7 +91,8 @@ export const fetchUserAndCourse = () => action(FETCH_USER_AND_COURSE);
 
 export const fetchCourseConfig = () => action(FETCH_COURSE_CONFIG);
 
-export const fetchAssessment = (assessmentId: number) => action(FETCH_ASSESSMENT, assessmentId);
+export const fetchAssessment = (assessmentId: number, assessmentPassword?: string) =>
+  action(FETCH_ASSESSMENT, { assessmentId, assessmentPassword });
 
 export const fetchAssessmentAdmin = (assessmentId: number, courseRegId: number) =>
   action(FETCH_ASSESSMENT_ADMIN, { assessmentId, courseRegId });

--- a/src/commons/application/actions/__tests__/SessionActions.ts
+++ b/src/commons/application/actions/__tests__/SessionActions.ts
@@ -126,7 +126,7 @@ test('fetchAssessment generates correct action object', () => {
   const action = fetchAssessment(id);
   expect(action).toEqual({
     type: FETCH_ASSESSMENT,
-    payload: id
+    payload: { assessmentId: id }
   });
 });
 

--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -275,22 +275,13 @@ const Assessment: React.FC<AssessmentProps> = props => {
     if (!overview) {
       return <AssessmentNotFound />;
     }
-    let assessmentPassword: string | null = null;
-    // Only need to prompt for password the first time
-    if (overview.private && overview.status === AssessmentStatuses.not_attempted) {
-      // Attempt to load password-protected assessment
-      assessmentPassword = window.prompt('Please enter password.', '');
-      if (!assessmentPassword) {
-        // Cancelled action, redirect back to the Assessment overviews page
-        return <Navigate to={`/courses/${courseId}/${props.assessmentConfiguration.type}`} />;
-      }
-    }
 
+    const notAttempted = overview.status === AssessmentStatuses.not_attempted;
     const assessmentWorkspaceProps: AssessmentWorkspaceProps = {
       assessmentId,
-      assessmentPassword,
       questionId,
-      notAttempted: overview.status === AssessmentStatuses.not_attempted,
+      notAttempted,
+      needsPassword: !!overview.private && notAttempted,
       canSave:
         !isStudent ||
         (overview.status !== AssessmentStatuses.submitted && !beforeNow(overview.closeAt)),

--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -275,8 +275,20 @@ const Assessment: React.FC<AssessmentProps> = props => {
     if (!overview) {
       return <AssessmentNotFound />;
     }
+    let assessmentPassword: string | null = null;
+    // Only need to prompt for password the first time
+    if (overview.private && overview.status === AssessmentStatuses.not_attempted) {
+      // Attempt to load password-protected assessment
+      assessmentPassword = window.prompt('Please enter password.', '');
+      if (!assessmentPassword) {
+        // Cancelled action, redirect back to the Assessment overviews page
+        return <Navigate to={`/courses/${courseId}/${props.assessmentConfiguration.type}`} />;
+      }
+    }
+
     const assessmentWorkspaceProps: AssessmentWorkspaceProps = {
       assessmentId,
+      assessmentPassword,
       questionId,
       notAttempted: overview.status === AssessmentStatuses.not_attempted,
       canSave:

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -197,8 +197,6 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
       if (!assessmentPassword) {
         window.history.back();
         return;
-        // Cancelled action, redirect back to the Assessment overviews page
-        // return <Navigate to={`/courses/${courseId}/${props.assessmentConfiguration.type}`} />;
       }
     }
     handleAssessmentFetch(props.assessmentId, assessmentPassword || undefined);

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -95,6 +95,7 @@ import { WorkspaceLocation, WorkspaceState } from '../workspace/WorkspaceTypes';
 import AssessmentWorkspaceGradingResult from './AssessmentWorkspaceGradingResult';
 export type AssessmentWorkspaceProps = {
   assessmentId: number;
+  assessmentPassword: string | null;
   questionId: number;
   notAttempted: boolean;
   canSave: boolean;
@@ -162,7 +163,8 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
         dispatch(resetWorkspace(workspaceLocation, options)),
       handleRunAllTestcases: () => dispatch(runAllTestcases(workspaceLocation)),
       handleEditorEval: () => dispatch(evalEditor(workspaceLocation)),
-      handleAssessmentFetch: (assessmentId: number) => dispatch(fetchAssessment(assessmentId)),
+      handleAssessmentFetch: (assessmentId: number, assessmentPassword?: string) =>
+        dispatch(fetchAssessment(assessmentId, assessmentPassword)),
       handleEditorValueChange: (editorTabIndex: number, newEditorValue: string) =>
         dispatch(updateEditorValue(workspaceLocation, editorTabIndex, newEditorValue)),
       handleEditorUpdateBreakpoints: (editorTabIndex: number, newBreakpoints: string[]) =>
@@ -187,7 +189,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
    * and show the briefing.
    */
   useEffect(() => {
-    handleAssessmentFetch(props.assessmentId);
+    handleAssessmentFetch(props.assessmentId, props.assessmentPassword || undefined);
 
     if (props.questionId === 0 && props.notAttempted) {
       setShowOverlay(true);

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -95,7 +95,7 @@ import { WorkspaceLocation, WorkspaceState } from '../workspace/WorkspaceTypes';
 import AssessmentWorkspaceGradingResult from './AssessmentWorkspaceGradingResult';
 export type AssessmentWorkspaceProps = {
   assessmentId: number;
-  assessmentPassword: string | null;
+  needsPassword: boolean;
   questionId: number;
   notAttempted: boolean;
   canSave: boolean;
@@ -189,7 +189,19 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
    * and show the briefing.
    */
   useEffect(() => {
-    handleAssessmentFetch(props.assessmentId, props.assessmentPassword || undefined);
+    let assessmentPassword: string | null = null;
+    if (props.needsPassword) {
+      // Only need to prompt for password the first time
+      // Attempt to load password-protected assessment
+      assessmentPassword = window.prompt('Please enter password.', '');
+      if (!assessmentPassword) {
+        window.history.back();
+        return;
+        // Cancelled action, redirect back to the Assessment overviews page
+        // return <Navigate to={`/courses/${courseId}/${props.assessmentConfiguration.type}`} />;
+      }
+    }
+    handleAssessmentFetch(props.assessmentId, assessmentPassword || undefined);
 
     if (props.questionId === 0 && props.notAttempted) {
       setShowOverlay(true);

--- a/src/commons/assessmentWorkspace/__tests__/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/__tests__/AssessmentWorkspace.tsx
@@ -18,7 +18,7 @@ const acequireMock = acequire as jest.Mock;
 
 const defaultProps = assertType<AssessmentWorkspaceProps>()({
   assessmentId: 0,
-  assessmentPassword: null,
+  needsPassword: false,
   notAttempted: true,
   canSave: true,
   assessmentConfiguration: {

--- a/src/commons/assessmentWorkspace/__tests__/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/__tests__/AssessmentWorkspace.tsx
@@ -18,6 +18,7 @@ const acequireMock = acequire as jest.Mock;
 
 const defaultProps = assertType<AssessmentWorkspaceProps>()({
   assessmentId: 0,
+  assessmentPassword: null,
   notAttempted: true,
   canSave: true,
   assessmentConfiguration: {

--- a/src/commons/mocks/BackendMocks.ts
+++ b/src/commons/mocks/BackendMocks.ts
@@ -107,7 +107,7 @@ export function* mockBackendSaga(): SagaIterator {
   });
 
   yield takeEvery(FETCH_ASSESSMENT, function* (action: ReturnType<typeof actions.fetchAssessment>) {
-    const id = action.payload;
+    const { assessmentId: id } = action.payload;
     const assessment = mockAssessments[id - 1];
     yield put(actions.updateAssessment({ ...assessment }));
   });

--- a/src/commons/sagas/BackendSaga.ts
+++ b/src/commons/sagas/BackendSaga.ts
@@ -309,9 +309,15 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_ASSESSMENT, function* (action: ReturnType<typeof actions.fetchAssessment>) {
     const tokens: Tokens = yield selectTokens();
 
-    const { assessmentId } = action.payload;
+    const { assessmentId, assessmentPassword } = action.payload;
 
-    const assessment: Assessment | null = yield call(getAssessment, assessmentId, tokens);
+    const assessment: Assessment | null = yield call(
+      getAssessment,
+      assessmentId,
+      tokens,
+      undefined,
+      assessmentPassword
+    );
     if (assessment) {
       yield put(actions.updateAssessment(assessment));
     }

--- a/src/commons/sagas/BackendSaga.ts
+++ b/src/commons/sagas/BackendSaga.ts
@@ -309,7 +309,7 @@ function* BackendSaga(): SagaIterator {
   yield takeEvery(FETCH_ASSESSMENT, function* (action: ReturnType<typeof actions.fetchAssessment>) {
     const tokens: Tokens = yield selectTokens();
 
-    const assessmentId = action.payload;
+    const { assessmentId } = action.payload;
 
     const assessment: Assessment | null = yield call(getAssessment, assessmentId, tokens);
     if (assessment) {

--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -508,12 +508,13 @@ export const getAssessment = async (
     );
   } else {
     // Otherwise, we are getting the assessment for the current user
-    // After unlocking the first time, password is no longer necessary
-    resp = await request(`${courseId()}/assessments/${assessmentId}`, 'GET', {
-      ...tokens
-    });
-    if (!resp) {
-      // Try again with the password for the first time unlock
+    if (password === undefined) {
+      // No password required (either not password-protected, or already previously unlocked)
+      resp = await request(`${courseId()}/assessments/${assessmentId}`, 'GET', {
+        ...tokens
+      });
+    } else {
+      // First-time unlocking password-protected assessments
       resp = await request(`${courseId()}/assessments/${assessmentId}/unlock`, 'POST', {
         ...tokens,
         body: { password }

--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -517,7 +517,8 @@ export const getAssessment = async (
       // First-time unlocking password-protected assessments
       resp = await request(`${courseId()}/assessments/${assessmentId}/unlock`, 'POST', {
         ...tokens,
-        body: { password }
+        body: { password },
+        errorMessage: 'Incorrect password'
       });
     }
   }

--- a/src/commons/sagas/__tests__/BackendSaga.ts
+++ b/src/commons/sagas/__tests__/BackendSaga.ts
@@ -563,10 +563,10 @@ describe('Test FETCH_ASSESSMENT action', () => {
     const mockId = mockAssessment.id;
     return expectSaga(BackendSaga)
       .withState({ session: mockTokens })
-      .provide([[call(getAssessment, mockId, mockTokens), mockAssessment]])
+      .provide([[call(getAssessment, mockId, mockTokens, undefined, undefined), mockAssessment]])
       .put(updateAssessment(mockAssessment))
       .hasFinalState({ session: mockTokens })
-      .dispatch({ type: FETCH_ASSESSMENT, payload: { mockId } })
+      .dispatch({ type: FETCH_ASSESSMENT, payload: { assessmentId: mockId } })
       .silentRun();
   });
 
@@ -574,11 +574,11 @@ describe('Test FETCH_ASSESSMENT action', () => {
     const mockId = mockAssessment.id;
     return expectSaga(BackendSaga)
       .withState({ session: mockTokens })
-      .provide([[call(getAssessment, mockId, mockTokens), null]])
-      .call(getAssessment, mockId, mockTokens)
+      .provide([[call(getAssessment, mockId, mockTokens, undefined, undefined), null]])
+      .call(getAssessment, mockId, mockTokens, undefined, undefined)
       .not.put.actionType(UPDATE_ASSESSMENT)
       .hasFinalState({ session: mockTokens })
-      .dispatch({ type: FETCH_ASSESSMENT, payload: { mockId } })
+      .dispatch({ type: FETCH_ASSESSMENT, payload: { assessmentId: mockId } })
       .silentRun();
   });
 });

--- a/src/commons/sagas/__tests__/BackendSaga.ts
+++ b/src/commons/sagas/__tests__/BackendSaga.ts
@@ -566,7 +566,7 @@ describe('Test FETCH_ASSESSMENT action', () => {
       .provide([[call(getAssessment, mockId, mockTokens), mockAssessment]])
       .put(updateAssessment(mockAssessment))
       .hasFinalState({ session: mockTokens })
-      .dispatch({ type: FETCH_ASSESSMENT, payload: mockId })
+      .dispatch({ type: FETCH_ASSESSMENT, payload: { mockId } })
       .silentRun();
   });
 
@@ -578,7 +578,7 @@ describe('Test FETCH_ASSESSMENT action', () => {
       .call(getAssessment, mockId, mockTokens)
       .not.put.actionType(UPDATE_ASSESSMENT)
       .hasFinalState({ session: mockTokens })
-      .dispatch({ type: FETCH_ASSESSMENT, payload: mockId })
+      .dispatch({ type: FETCH_ASSESSMENT, payload: { mockId } })
       .silentRun();
   });
 });

--- a/src/pages/academy/Academy.tsx
+++ b/src/pages/academy/Academy.tsx
@@ -87,7 +87,7 @@ const Academy: React.FC<{}> = () => {
           }
         />
         {staffRoutes}
-        {role === Role.Admin && <Route path={'adminpanel'} element={<AdminPanel />} />}
+        {role === Role.Admin && <Route path="adminpanel" element={<AdminPanel />} />}
         <Route path="*" element={<NotFound />} />
       </Routes>
     </div>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #2702.

Regression was caused after #2531, as the `request` helper now does the error handling. This meant that callers like the sagas can't use the status codes anymore for conditional logic.

This PR eliminates that coupling and also improves the responsibilities of each component. It also improves the error messages displayed to the user

Please refer to the commit history for details of changes.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Password-protected assessments should work now.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [x] I have updated the documentation
