### PR TITLE
Persist current user's group in local storage

### DIFF
--- a/src/commons/dialogs/ConfirmDialog.tsx
+++ b/src/commons/dialogs/ConfirmDialog.tsx
@@ -1,10 +1,10 @@
 import {
   Button,
+  ButtonProps,
   Classes,
   Dialog,
-  IButtonProps,
+  DialogProps,
   IconName,
-  IDialogProps,
   Intent
 } from '@blueprintjs/core';
 import classNames from 'classnames';
@@ -14,12 +14,12 @@ export interface ConfirmDialogProps<T> {
   icon?: IconName;
   title?: string;
   contents?: React.ReactNode;
-  choices: Array<{ key: T; label: string; intent?: Intent; props?: IButtonProps }>;
+  choices: Array<{ key: T; label: string; intent?: Intent; props?: ButtonProps }>;
   largeButtons?: boolean;
   escapeResponse?: T;
   onResponse: (response: T) => void;
   isOpen?: boolean;
-  props?: Omit<IDialogProps, 'isOpen'>;
+  props?: Omit<DialogProps, 'isOpen'>;
 }
 
 export function ConfirmDialog<T>(

--- a/src/pages/__tests__/localStorage.test.ts
+++ b/src/pages/__tests__/localStorage.test.ts
@@ -9,6 +9,7 @@ const mockShortDefaultState: SavedState = {
     refreshToken: defaultState.session.refreshToken,
     courseRegId: defaultState.session.courseRegId,
     role: defaultState.session.role,
+    group: defaultState.session.group,
     name: defaultState.session.name,
     userId: defaultState.session.userId,
     courses: defaultState.session.courses,

--- a/src/pages/localStorage.ts
+++ b/src/pages/localStorage.ts
@@ -57,6 +57,7 @@ export const saveState = (state: OverallState) => {
         refreshToken: state.session.refreshToken,
         courseRegId: state.session.courseRegId,
         role: state.session.role,
+        group: state.session.group,
         name: state.session.name,
         userId: state.session.userId,
         courses: state.session.courses,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Somewhat part of #2665. The following bug was reported by @lizchow:

Accessing the grading dashboard will default to showing "my groups" for staff, but after refreshing the page, it defaults back to all groups.

The cause was that although the current user and their role is persisted in the browser, the same is not the case for the user's group. As our check involves showing all groups for admins *or* those without a group, the bug occurs upon the browser refresh.

Solution is simply to persist the group data together with the rest of current user information.

Sorry it took a while, thanks for reporting!

---

This PR also replaced deprecated interfaces with their replacements.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
