### PR TITLE
Fix regression to deployments without backend

### DIFF
--- a/src/commons/application/ApplicationWrapper.tsx
+++ b/src/commons/application/ApplicationWrapper.tsx
@@ -26,7 +26,9 @@ const ApplicationWrapper: React.FC = () => {
   const [isApiHealthy, setIsApiHealthy] = useState(true);
 
   useEffect(() => {
-    getHealth().then(res => setIsApiHealthy(!!res));
+    if (Constants.useBackend) {
+      getHealth().then(res => setIsApiHealthy(!!res));
+    }
   }, []);
 
   const router = useMemo(() => {


### PR DESCRIPTION
### Description

As of #2710, it seems that local testing deployments and deployments without backend are affected as it will show the maintenance page (as the backend is not present, and thus the API health check would fail).

The code in `RequestsSaga.tsx` remain unchanged and no checks are required, as it is assumed that a backend exists when calling any functions within.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Testing locally with `USE_BACKEND` environment config set to FALSE should work normally and as expected.
Note that the error shown in the playground is related to #2695 instead.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
