### PR TITLE
Rename contest leaderboard to score leaderboard

### DIFF
--- a/src/commons/assessment/AssessmentTypes.ts
+++ b/src/commons/assessment/AssessmentTypes.ts
@@ -121,7 +121,7 @@ export interface IContestVotingQuestion extends BaseQuestion {
   prepend: string;
   postpend: string;
   contestEntries: ContestEntry[];
-  contestLeaderboard: ContestEntry[];
+  scoreLeaderboard: ContestEntry[];
   type: 'voting';
 }
 

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -444,15 +444,15 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
           id: SideContentType.contestVoting
         },
         {
-          label: 'Contest Leaderboard',
+          label: 'Score Leaderboard',
           iconName: IconNames.CROWN,
           body: (
             <SideContentContestLeaderboard
               handleContestEntryClick={handleContestEntryClick}
-              orderedContestEntries={(question as IContestVotingQuestion)?.contestLeaderboard ?? []}
+              orderedContestEntries={(question as IContestVotingQuestion)?.scoreLeaderboard ?? []}
             />
           ),
-          id: SideContentType.contestLeaderboard
+          id: SideContentType.scoreLeaderboard
         }
       );
     } else {

--- a/src/commons/assessmentWorkspace/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
+++ b/src/commons/assessmentWorkspace/__tests__/__snapshots__/AssessmentWorkspace.tsx.snap
@@ -470,13 +470,13 @@ exports[`AssessmentWorkspace AssessmentWorkspace page with ContestVoting questio
                           </span>
                         </div>
                         <div
-                          aria-controls="bp5-tab-panel_side-content-tabs_contest_leaderboard"
+                          aria-controls="bp5-tab-panel_side-content-tabs_score_leaderboard"
                           aria-disabled="false"
                           aria-expanded="false"
                           aria-selected="false"
                           class="bp5-tab side-content-tab"
-                          data-tab-id="contest_leaderboard"
-                          id="bp5-tab-title_side-content-tabs_contest_leaderboard"
+                          data-tab-id="score_leaderboard"
+                          id="bp5-tab-title_side-content-tabs_score_leaderboard"
                           role="tab"
                           tabindex="-1"
                         >
@@ -486,7 +486,7 @@ exports[`AssessmentWorkspace AssessmentWorkspace page with ContestVoting questio
                             <div
                               aria-expanded="false"
                               class="side-content-tooltip"
-                              id="contest_leaderboard-icon"
+                              id="score_leaderboard-icon"
                               tabindex="0"
                             >
                               <span
@@ -735,9 +735,9 @@ exports[`AssessmentWorkspace AssessmentWorkspace page with ContestVoting questio
                       </div>
                       <div
                         aria-hidden="true"
-                        aria-labelledby="bp5-tab-title_side-content-tabs_contest_leaderboard"
+                        aria-labelledby="bp5-tab-title_side-content-tabs_score_leaderboard"
                         class="bp5-tab-panel side-content-tab"
-                        id="bp5-tab-panel_side-content-tabs_contest_leaderboard"
+                        id="bp5-tab-panel_side-content-tabs_score_leaderboard"
                         role="tabpanel"
                       >
                         <div
@@ -771,7 +771,7 @@ exports[`AssessmentWorkspace AssessmentWorkspace page with ContestVoting questio
                                 class="bp5-button-text"
                               >
                                 <span>
-                                  Contest Leaderboard
+                                  Score Leaderboard
                                 </span>
                                 <span
                                   class="bp5-popover-target"

--- a/src/commons/mocks/AssessmentMocks.ts
+++ b/src/commons/mocks/AssessmentMocks.ts
@@ -862,7 +862,7 @@ const mockContestEntryQuestion: Array<IContestVotingQuestion> = [
         answer: { code: 'function voting_test() { return true; }' }
       }
     ],
-    contestLeaderboard: [
+    scoreLeaderboard: [
       {
         submission_id: 1,
         student_name: 'student_1',

--- a/src/commons/sideContent/SideContentContestLeaderboard.tsx
+++ b/src/commons/sideContent/SideContentContestLeaderboard.tsx
@@ -79,7 +79,7 @@ const SideContentContestLeaderboard: React.FunctionComponent<
         minimal={true}
         onClick={() => setShowLeaderboard(!showLeaderboard)}
       >
-        <span>Contest Leaderboard</span>
+        <span>Score Leaderboard</span>
         <Tooltip2 content={contestLeaderboardTooltipContent}>
           <Icon icon={IconNames.HELP} />
         </Tooltip2>

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -8,7 +8,7 @@ export enum SideContentType {
   autograder = 'autograder',
   briefing = 'briefing',
   contestVoting = 'contest_voting',
-  contestLeaderboard = 'contest_leaderboard',
+  scoreLeaderboard = 'score_leaderboard',
   dataVisualizer = 'data_visualizer',
   editorGrading = 'editor_grading',
   editorAutograder = 'editor_autograder',

--- a/src/commons/sideContent/__tests__/__snapshots__/SideContentContestLeaderboard.tsx.snap
+++ b/src/commons/sideContent/__tests__/__snapshots__/SideContentContestLeaderboard.tsx.snap
@@ -11,7 +11,7 @@ exports[`SideContentContestLeaderboard matches snapshot 1`] = `
     onClick={[Function]}
   >
     <span>
-      Contest Leaderboard
+      Score Leaderboard
     </span>
     <Blueprint5.Tooltip
       compact={false}


### PR DESCRIPTION
### Description

This pull request changes the name of the contest leaderboard tabs and relevant strings to "Score Leaderboard." This is done in preparation for adding a new popular votes leaderboard and differentiating it from the usual contest leaderboard.

### Type of change

- [x] Rename contest leaderboard to score leaderboard
- [x] Update snapshots

### Checklist

- [x] I have tested this code
