### PR TITLE
finish ec-to-cse rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "flexboxgrid": "^6.3.1",
     "flexboxgrid-helpers": "^1.1.3",
     "hastscript": "^9.0.0",
-    "js-slang": "^1.0.42",
+    "js-slang": "^1.0.43",
     "js-yaml": "^4.1.0",
     "konva": "^9.2.0",
     "lodash": "^4.17.21",

--- a/src/features/envVisualizer/EnvVisualizerAnimation.tsx
+++ b/src/features/envVisualizer/EnvVisualizerAnimation.tsx
@@ -1,4 +1,4 @@
-import { InstrType } from 'js-slang/dist/ec-evaluator/types';
+import { InstrType } from 'js-slang/dist/cse-machine/types';
 import { Easings } from 'konva/lib/Tween';
 
 import { Animatable } from './animationComponents/AnimationComponents';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8310,10 +8310,10 @@ js-sdsl@4.3.0, js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
   integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
-js-slang@^1.0.42:
-  version "1.0.42"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-1.0.42.tgz#47cd5d0e50ec7a81778e077dfc94b5e69399fff3"
-  integrity sha512-Gesed5z+m18vRkCRpR06wEL4RSnQw4H54/rHVodtZD51EhQ5hEFb2oUpdIEIL8gOFQwwbeivFwaZELyqU5kVOg==
+js-slang@^1.0.43:
+  version "1.0.43"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-1.0.43.tgz#9707960804eb94b3dd79ed59626014a5255cd4f6"
+  integrity sha512-VgNHymRHWOe3CvcncFYmxktH98LCV8AuqPNmTCMX4SrQjh4D0kXMlzVHofMbb2GiLEq5foch+fr7gtvPWsdtMg==
   dependencies:
     "@babel/parser" "^7.19.4"
     "@joeychenofficial/alt-ergo-modified" "^2.4.0"
@@ -8326,7 +8326,7 @@ js-slang@^1.0.42:
     astring "^1.4.3"
     gpu.js "^2.16.0"
     js-base64 "^3.7.5"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     node-getopt "^0.3.2"
     source-map "0.7.3"
     xmlhttprequest-ts "^1.0.1"


### PR DESCRIPTION
### Description

There was still one reference to ec-evaluator in the frontend. This PR renames this reference to cse-machine, like the others that are renamed already.