### PR TITLE
Finish renaming ec-evaluator to cse-machine

### DIFF
--- a/src/features/envVisualizer/EnvVisualizerAnimation.tsx
+++ b/src/features/envVisualizer/EnvVisualizerAnimation.tsx
@@ -1,4 +1,4 @@
-import { InstrType } from 'js-slang/dist/ec-evaluator/types';
+import { InstrType } from 'js-slang/dist/cse-machine/types';
 import { Easings } from 'konva/lib/Tween';
 
 import { Animatable } from './animationComponents/AnimationComponents';


### PR DESCRIPTION
### Description

There was still one reference to ec-evaluator in the frontend. This PR renames this reference to cse-machine, like the others that are renamed already.