### PR TITLE
Temporary fix to resolve RTK freezing reducer states

### DIFF
--- a/src/pages/createStore.ts
+++ b/src/pages/createStore.ts
@@ -9,7 +9,7 @@ import MainSaga from '../commons/sagas/MainSaga';
 import { generateOctokitInstance } from '../commons/utils/GitHubPersistenceHelper';
 import { loadStoredState, SavedState, saveState } from './localStorage';
 
-// TEMP-FIX: Disable auto freezing of states for RTK as this breaks the code evaluation sagas
+// FIXME: Hotfix: Disable auto freezing of states for RTK as this breaks the code evaluation sagas
 setAutoFreeze(false);
 
 export const store = createStore();

--- a/src/pages/createStore.ts
+++ b/src/pages/createStore.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { setAutoFreeze } from 'immer';
 import { throttle } from 'lodash';
 import createSagaMiddleware from 'redux-saga';
 
@@ -7,6 +8,9 @@ import createRootReducer from '../commons/application/reducers/RootReducer';
 import MainSaga from '../commons/sagas/MainSaga';
 import { generateOctokitInstance } from '../commons/utils/GitHubPersistenceHelper';
 import { loadStoredState, SavedState, saveState } from './localStorage';
+
+// TEMP-FIX: Disable auto freezing of states for RTK as this breaks the code evaluation sagas
+setAutoFreeze(false);
 
 export const store = createStore();
 


### PR DESCRIPTION
### Description

As of dcd2c69, the playground code evaluation seems to have been broken and unusable. This is caused by the fact that Redux Toolkit uses `immer` as their state manager. By design of `immer`, it will auto freeze states causing mutations to fail, even in production.

Thus, as we are still in the progress in migrating to RTK, and that various current sagas and actions still depend on these state mutations to work correctly (i.e. code evaluation), it will be good to explicitly disable auto-freezing of the state until the reducer/actions depending on state mutations get refactored.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Ensure that playground code evaluates as normal, and that modules work as intended.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
