### PR TITLE
Fix Playground Command Palette not closing

### DIFF
--- a/src/commons/editor/Editor.tsx
+++ b/src/commons/editor/Editor.tsx
@@ -562,6 +562,7 @@ const EditorBase = React.memo((props: EditorProps & LocalStateProps) => {
 
   // Override the overlayPage function to add an id to the overlay div.
   // This allows the overlay div to be referenced and removed when the editor is unmounted.
+  // See https://github.com/source-academy/frontend/pull/2832
   acequire('ace/ext/menu_tools/overlay_page').overlayPage = function (
     editor: any,
     contentElement: HTMLElement,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #2747

The 'overlayPage' function in the external Ace Editor library adds the 'div' containing the Command Palette in the document body so it is not removed when the `Editor` component is unmounted.

Override the `overlayPage` function to add an `id` to the `div` that is overlayed. This allows the `div` to be referenced and manually removed.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. In Playground, open the Command Palette (On Desktop, click `F1`. On Mobile, use the options panel)
2. Navigate back or forward page and command palette will now close automatically.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
