### PR TITLE
Fix #2833

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -379,11 +379,7 @@ export const createDefaultWorkspace = (workspaceLocation: WorkspaceLocation): Wo
   isRunning: false,
   isDebugging: false,
   enableDebugging: true,
-  debuggerContext: {} as DebuggerContext,
-  sideContent: {
-    alerts: [],
-    dynamicTabs: []
-  }
+  debuggerContext: {} as DebuggerContext
 });
 
 const defaultFileName = 'program.js';
@@ -524,11 +520,7 @@ export const createDefaultStoriesEnv = (
   stepLimit: 1000,
   globals: [],
   usingSubst: false,
-  debuggerContext: {} as DebuggerContext,
-  sideContent: {
-    dynamicTabs: [],
-    alerts: []
-  }
+  debuggerContext: {} as DebuggerContext
 });
 
 export const defaultFileSystem: FileSystemState = {
@@ -537,7 +529,8 @@ export const defaultFileSystem: FileSystemState = {
 
 export const defaultSideContent: SideContentState = {
   dynamicTabs: [],
-  alerts: []
+  alerts: [],
+  dynamicTabsSpawned: false
 };
 
 export const defaultSideContentManager: SideContentManagerState = {

--- a/src/commons/sagas/SideContentSaga.ts
+++ b/src/commons/sagas/SideContentSaga.ts
@@ -1,13 +1,16 @@
 import { Action } from 'redux';
 import type { SagaIterator } from 'redux-saga';
-import { put, take } from 'redux-saga/effects';
+import { put, select, take } from 'redux-saga/effects';
 import { notifyStoriesEvaluated } from 'src/features/stories/StoriesActions';
 import { NOTIFY_STORIES_EVALUATED } from 'src/features/stories/StoriesTypes';
 
+import type { OverallState } from '../application/ApplicationTypes';
 import * as actions from '../sideContent/SideContentActions';
+import { getLocation } from '../sideContent/SideContentHelper';
 import {
   BEGIN_ALERT_SIDE_CONTENT,
   NOTIFY_PROGRAM_EVALUATED,
+  type SideContentState,
   SPAWN_SIDE_CONTENT
 } from '../sideContent/SideContentTypes';
 import { notifyProgramEvaluated } from '../workspace/WorkspaceActions';
@@ -23,13 +26,22 @@ export default function* SideContentSaga(): SagaIterator {
     function* ({
       payload: { id, workspaceLocation }
     }: ReturnType<typeof actions.beginAlertSideContent>) {
+      const sideContentState: SideContentState = yield select((state: OverallState) => {
+        const [loc, storyEnv] = getLocation(workspaceLocation);
+        return loc !== 'stories' ? state.sideContent[loc] : state.sideContent.stories[storyEnv];
+      });
+
       // When a program finishes evaluation, we clear all alerts,
       // So we must wait until after and all module tabs have been spawned
       // to process any kind of alerts that were raised by non-module side content
-      yield take(
-        (action: Action) =>
-          isSpawnSideContent(action) && action.payload.workspaceLocation === workspaceLocation
-      );
+      if (!sideContentState.dynamicTabsSpawned) {
+        // So if the dynamic tabs haven't been spawned yet, let's wait until
+        // they have been spawned first
+        yield take(
+          (action: Action) =>
+            isSpawnSideContent(action) && action.payload.workspaceLocation === workspaceLocation
+        );
+      }
       yield put(actions.endAlertSideContent(id, workspaceLocation));
     }
   );

--- a/src/commons/sideContent/SideContentReducer.ts
+++ b/src/commons/sideContent/SideContentReducer.ts
@@ -1,8 +1,10 @@
+import { NOTIFY_STORIES_EVALUATED } from 'src/features/stories/StoriesTypes';
+
 import { defaultSideContent, defaultSideContentManager } from '../application/ApplicationTypes';
 import { SourceActionType } from '../utils/ActionsHelper';
 import { getDynamicTabs, getTabId } from './SideContentHelper';
 import { getLocation } from './SideContentHelper';
-import { CHANGE_SIDE_CONTENT_HEIGHT } from './SideContentTypes';
+import { CHANGE_SIDE_CONTENT_HEIGHT, NOTIFY_PROGRAM_EVALUATED } from './SideContentTypes';
 import {
   END_ALERT_SIDE_CONTENT,
   REMOVE_SIDE_CONTENT_ALERT,
@@ -67,6 +69,25 @@ export function SideContentReducer(
       }
       return state;
     }
+    case NOTIFY_PROGRAM_EVALUATED:
+      return {
+        ...state,
+        [workspaceLocation]: {
+          ...state[workspaceLocation],
+          dynamicTabsSpawned: false
+        }
+      };
+    case NOTIFY_STORIES_EVALUATED:
+      return {
+        ...state,
+        stories: {
+          ...state.stories,
+          [storyEnv!]: {
+            ...state.stories[storyEnv!],
+            dynamicTabsSpawned: false
+          }
+        }
+      };
     case REMOVE_SIDE_CONTENT_ALERT:
       return workspaceLocation === 'stories'
         ? {
@@ -110,7 +131,8 @@ export function SideContentReducer(
               [storyEnv]: {
                 ...state.stories[storyEnv],
                 alerts,
-                dynamicTabs
+                dynamicTabs,
+                dynamicTabsSpawned: true
               }
             }
           }
@@ -119,7 +141,8 @@ export function SideContentReducer(
             [workspaceLocation]: {
               ...state[workspaceLocation],
               alerts,
-              dynamicTabs
+              dynamicTabs,
+              dynamicTabsSpawned: true
             }
           };
     }

--- a/src/commons/sideContent/SideContentTypes.ts
+++ b/src/commons/sideContent/SideContentTypes.ts
@@ -9,6 +9,7 @@ export const VISIT_SIDE_CONTENT = 'VISIT_SIDE_CONTENT';
 export const RESET_SIDE_CONTENT = 'RESET_SIDE_CONTENT';
 export const SPAWN_SIDE_CONTENT = 'SPAWN_SIDE_CONTENT';
 export const REMOVE_SIDE_CONTENT_ALERT = 'REMOVE_SIDE_CONTENT_ALERT';
+export const CHANGE_SIDE_CONTENT_HEIGHT = 'CHANGE_SIDE_CONTENT_HEIGHT';
 
 export enum SideContentType {
   autograder = 'autograder',
@@ -108,6 +109,7 @@ export type SideContentState = {
   dynamicTabs: SideContentTab[];
   alerts: string[];
   selectedTab?: SideContentType;
+  dynamicTabsSpawned: boolean;
 };
 
 export type ChangeTabsCallback = (
@@ -122,4 +124,3 @@ export type SideContentDispatchProps = {
    */
   alertSideContent: (newId: SideContentType) => void;
 };
-export const CHANGE_SIDE_CONTENT_HEIGHT = 'CHANGE_SIDE_CONTENT_HEIGHT';

--- a/src/commons/workspace/WorkspaceTypes.ts
+++ b/src/commons/workspace/WorkspaceTypes.ts
@@ -6,7 +6,6 @@ import { InterpreterOutput } from '../application/ApplicationTypes';
 import { ExternalLibraryName } from '../application/types/ExternalTypes';
 import { AutogradingResult, Testcase } from '../assessment/AssessmentTypes';
 import { HighlightedLines, Position } from '../editor/EditorTypes';
-import { SideContentState } from '../sideContent/SideContentTypes';
 
 export const ADD_HTML_CONSOLE_ERROR = 'ADD_HTML_CONSOLE_ERROR';
 export const BEGIN_CLEAR_CONTEXT = 'BEGIN_CLEAR_CONTEXT';
@@ -144,7 +143,6 @@ export type WorkspaceState = {
   readonly stepLimit: number;
   readonly globals: Array<[string, any]>;
   readonly debuggerContext: DebuggerContext;
-  readonly sideContent: SideContentState;
 };
 
 type ReplHistory = {

--- a/src/features/stories/StoriesTypes.ts
+++ b/src/features/stories/StoriesTypes.ts
@@ -1,5 +1,4 @@
 import { Context } from 'js-slang';
-import { SideContentState } from 'src/commons/sideContent/SideContentTypes';
 import { DebuggerContext } from 'src/commons/workspace/WorkspaceTypes';
 
 import { InterpreterOutput, StoriesRole } from '../../commons/application/ApplicationTypes';
@@ -60,7 +59,6 @@ export type StoriesEnvState = {
   readonly globals: Array<[string, any]>;
   readonly usingSubst: boolean;
   readonly debuggerContext: DebuggerContext;
-  readonly sideContent: SideContentState;
 };
 
 export type StoriesAuthState = {


### PR DESCRIPTION
Certain tabs (such as the substitution visualizer) could send their alert after dynamic tabs have already been spawned. This causes the alert to be displayed on the next evaluation, where `BEGIN_ALERT_SIDE_CONTENT` finally `take`s a `SPAWN_SIDE_CONTENT`.

This PR fixes this issue and also removes the `sideContent` object from workspaces.

Though this resolves #2833, work should probably be done to refactor and simplify how the frontend evaluates code.