### PR TITLE
Module interrupt

### DIFF
--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -58,9 +58,9 @@ export function* evalCode(
             .usingSubst
       )
     : isStoriesBlock
-      ? // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
-        yield select((state: OverallState) => state.stories.envs[storyEnv!].usingSubst)
-      : false;
+    ? // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
+      yield select((state: OverallState) => state.stories.envs[storyEnv!].usingSubst)
+    : false;
   const stepLimit: number = isStoriesBlock
     ? yield select((state: OverallState) => state.stories.envs[storyEnv!].stepLimit)
     : yield select((state: OverallState) => state.workspaces[workspaceLocation].stepLimit);
@@ -88,12 +88,12 @@ export function* evalCode(
   const currentStep: number = needUpdateCse
     ? -1
     : correctWorkspace
-      ? yield select(
-          (state: OverallState) =>
-            (state.workspaces[workspaceLocation] as PlaygroundWorkspaceState | SicpWorkspaceState)
-              .currentStep
-        )
-      : -1;
+    ? yield select(
+        (state: OverallState) =>
+          (state.workspaces[workspaceLocation] as PlaygroundWorkspaceState | SicpWorkspaceState)
+            .currentStep
+      )
+    : -1;
   const cseActiveAndCorrectChapter = context.chapter >= 3 && cseIsActive;
   if (cseActiveAndCorrectChapter) {
     context.executionMethod = 'cse-machine';
@@ -260,27 +260,27 @@ export function* evalCode(
       actionType === DEBUG_RESUME
         ? call(resume, lastDebuggerResult)
         : isNonDet || isLazy || isWasm
-          ? call_variant(context.variant)
-          : isC
-            ? call(cCompileAndRun, entrypointCode, context)
-            : call(
-                runFilesInContext,
-                isFolderModeEnabled
-                  ? files
-                  : {
-                      [entrypointFilePath]: files[entrypointFilePath]
-                    },
-                entrypointFilePath,
-                context,
-                {
-                  scheduler: 'preemptive',
-                  originalMaxExecTime: execTime,
-                  stepLimit: stepLimit,
-                  throwInfiniteLoops: true,
-                  useSubst: substActiveAndCorrectChapter,
-                  envSteps: currentStep
-                }
-              ),
+        ? call_variant(context.variant)
+        : isC
+        ? call(cCompileAndRun, entrypointCode, context)
+        : call(
+            runFilesInContext,
+            isFolderModeEnabled
+              ? files
+              : {
+                  [entrypointFilePath]: files[entrypointFilePath]
+                },
+            entrypointFilePath,
+            context,
+            {
+              scheduler: 'preemptive',
+              originalMaxExecTime: execTime,
+              stepLimit: stepLimit,
+              throwInfiniteLoops: true,
+              useSubst: substActiveAndCorrectChapter,
+              envSteps: currentStep
+            }
+          ),
 
     /**
      * A BEGIN_INTERRUPT_EXECUTION signals the beginning of an interruption,

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -4,7 +4,7 @@ import { Context, interrupt, Result, resume, runFilesInContext } from 'js-slang'
 import { ACORN_PARSE_OPTIONS, TRY_AGAIN } from 'js-slang/dist/constants';
 import { InterruptedError } from 'js-slang/dist/errors/errors';
 import { manualToggleDebugger } from 'js-slang/dist/stdlib/inspector';
-import { Chapter, ErrorSeverity,ErrorType, SourceError, Variant } from 'js-slang/dist/types';
+import { Chapter, ErrorSeverity, ErrorType, SourceError, Variant } from 'js-slang/dist/types';
 import { SagaIterator } from 'redux-saga';
 import { call, put, race, select, take } from 'redux-saga/effects';
 import * as Sourceror from 'sourceror';
@@ -58,9 +58,9 @@ export function* evalCode(
             .usingSubst
       )
     : isStoriesBlock
-    ? // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
-      yield select((state: OverallState) => state.stories.envs[storyEnv!].usingSubst)
-    : false;
+      ? // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
+        yield select((state: OverallState) => state.stories.envs[storyEnv!].usingSubst)
+      : false;
   const stepLimit: number = isStoriesBlock
     ? yield select((state: OverallState) => state.stories.envs[storyEnv!].stepLimit)
     : yield select((state: OverallState) => state.workspaces[workspaceLocation].stepLimit);
@@ -88,12 +88,12 @@ export function* evalCode(
   const currentStep: number = needUpdateCse
     ? -1
     : correctWorkspace
-    ? yield select(
-        (state: OverallState) =>
-          (state.workspaces[workspaceLocation] as PlaygroundWorkspaceState | SicpWorkspaceState)
-            .currentStep
-      )
-    : -1;
+      ? yield select(
+          (state: OverallState) =>
+            (state.workspaces[workspaceLocation] as PlaygroundWorkspaceState | SicpWorkspaceState)
+              .currentStep
+        )
+      : -1;
   const cseActiveAndCorrectChapter = context.chapter >= 3 && cseIsActive;
   if (cseActiveAndCorrectChapter) {
     context.executionMethod = 'cse-machine';
@@ -260,27 +260,27 @@ export function* evalCode(
       actionType === DEBUG_RESUME
         ? call(resume, lastDebuggerResult)
         : isNonDet || isLazy || isWasm
-        ? call_variant(context.variant)
-        : isC
-        ? call(cCompileAndRun, entrypointCode, context)
-        : call(
-            runFilesInContext,
-            isFolderModeEnabled
-              ? files
-              : {
-                  [entrypointFilePath]: files[entrypointFilePath]
-                },
-            entrypointFilePath,
-            context,
-            {
-              scheduler: 'preemptive',
-              originalMaxExecTime: execTime,
-              stepLimit: stepLimit,
-              throwInfiniteLoops: true,
-              useSubst: substActiveAndCorrectChapter,
-              envSteps: currentStep
-            }
-          ),
+          ? call_variant(context.variant)
+          : isC
+            ? call(cCompileAndRun, entrypointCode, context)
+            : call(
+                runFilesInContext,
+                isFolderModeEnabled
+                  ? files
+                  : {
+                      [entrypointFilePath]: files[entrypointFilePath]
+                    },
+                entrypointFilePath,
+                context,
+                {
+                  scheduler: 'preemptive',
+                  originalMaxExecTime: execTime,
+                  stepLimit: stepLimit,
+                  throwInfiniteLoops: true,
+                  useSubst: substActiveAndCorrectChapter,
+                  envSteps: currentStep
+                }
+              ),
 
     /**
      * A BEGIN_INTERRUPT_EXECUTION signals the beginning of an interruption,

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -249,9 +249,6 @@ export function* evalCode(
           }
           // This should not happen but we check just in case
           default: {
-            // @ts-expect-error This is used to force a type error if we miss a case
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const _: never = specialError;
             yield put(actions.evalInterpreterError(context.errors, workspaceLocation));
           }
         }
@@ -345,7 +342,7 @@ export function* evalCode(
 }
 
 // Special module errors
-const specialErrors = ['source_academy_interrupt', 'ajbwj'] as const;
+const specialErrors = ['source_academy_interrupt'] as const;
 type SpecialError = (typeof specialErrors)[number];
 
 function checkSpecialError(errors: SourceError[]): SpecialError | null {

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -3,7 +3,7 @@ import { Context, interrupt, Result, resume, runFilesInContext } from 'js-slang'
 import { ACORN_PARSE_OPTIONS, TRY_AGAIN } from 'js-slang/dist/constants';
 import { InterruptedError } from 'js-slang/dist/errors/errors';
 import { manualToggleDebugger } from 'js-slang/dist/stdlib/inspector';
-import { Chapter, Variant } from 'js-slang/dist/types';
+import { Chapter, SourceError, Variant } from 'js-slang/dist/types';
 import { SagaIterator } from 'redux-saga';
 import { call, put, race, select, take } from 'redux-saga/effects';
 import * as Sourceror from 'sourceror';
@@ -240,17 +240,34 @@ export function* evalCode(
   ) {
     yield* dumpDisplayBuffer(workspaceLocation, isStoriesBlock, storyEnv);
     if (!isStoriesBlock) {
-      yield put(actions.evalInterpreterError(context.errors, workspaceLocation));
-      // enable the CSE machine visualizer during errors
-      if (context.executionMethod === 'cse-machine' && needUpdateCse) {
-        yield put(actions.updateStepsTotal(context.runtime.envStepsTotal + 1, workspaceLocation));
-        yield put(actions.toggleUpdateCse(false, workspaceLocation as any));
-        yield put(
-          actions.updateBreakpointSteps(context.runtime.breakpointSteps, workspaceLocation)
-        );
-        yield put(
-          actions.updateChangePointSteps(context.runtime.changepointSteps, workspaceLocation)
-        );
+      const specialError = checkSpecialError(context.errors);
+      if (specialError !== null) {
+        switch (specialError) {
+          case 'source_academy_interrupt': {
+            yield* handleSourceAcademyInterrupt(context, entrypointCode, workspaceLocation);
+            break;
+          }
+          // This should not happen but we check just in case
+          default: {
+            // @ts-expect-error This is used to force a type error if we miss a case
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const _: never = specialError;
+            yield put(actions.evalInterpreterError(context.errors, workspaceLocation));
+          }
+        }
+      } else {
+        yield put(actions.evalInterpreterError(context.errors, workspaceLocation));
+        // enable the CSE machine visualizer during errors
+        if (context.executionMethod === 'cse-machine' && needUpdateCse) {
+          yield put(actions.updateStepsTotal(context.runtime.envStepsTotal + 1, workspaceLocation));
+          yield put(actions.toggleUpdateCse(false, workspaceLocation as any));
+          yield put(
+            actions.updateBreakpointSteps(context.runtime.breakpointSteps, workspaceLocation)
+          );
+          yield put(
+            actions.updateChangePointSteps(context.runtime.changepointSteps, workspaceLocation)
+          );
+        }
       }
     } else {
       // Safe to use ! as storyEnv will be defined from above when we call from EVAL_STORY
@@ -325,4 +342,35 @@ export function* evalCode(
     const introIcon = document.getElementById(SideContentType.introduction + '-icon');
     introIcon && introIcon.classList.remove('side-content-tab-alert-error');
   }
+}
+
+// Special module errors
+const specialErrors = ['source_academy_interrupt', 'ajbwj'] as const;
+type SpecialError = (typeof specialErrors)[number];
+
+function checkSpecialError(errors: SourceError[]): SpecialError | null {
+  if (errors.length !== 1) {
+    return null;
+  }
+  const firstError = errors[0] as any;
+  if (typeof firstError.error !== 'string') {
+    return null;
+  }
+  if (!specialErrors.includes(firstError.error)) {
+    return null;
+  }
+
+  return firstError.error as SpecialError;
+}
+
+function* handleSourceAcademyInterrupt(
+  context: Context,
+  entrypointCode: string,
+  workspaceLocation: WorkspaceLocation
+) {
+  yield put(
+    actions.evalInterpreterSuccess('Program has been interrupted by module', workspaceLocation)
+  );
+  context.errors = [];
+  yield put(actions.notifyProgramEvaluated(null, null, entrypointCode, context, workspaceLocation));
 }

--- a/src/commons/sagas/__tests__/WorkspaceSaga.ts
+++ b/src/commons/sagas/__tests__/WorkspaceSaga.ts
@@ -1,6 +1,6 @@
 import { Context, IOptions, Result, resume, runFilesInContext, runInContext } from 'js-slang';
 import createContext from 'js-slang/dist/createContext';
-import { Chapter, Finished, Variant } from 'js-slang/dist/types';
+import { Chapter, ErrorType, Finished, SourceError, Variant } from 'js-slang/dist/types';
 import { call } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
@@ -1093,6 +1093,32 @@ describe('evalCode', () => {
         })
         .put(endDebuggerPause(workspaceLocation))
         .call(showWarningMessage, 'Execution paused', 750)
+        .silentRun();
+    });
+  });
+
+  describe('special error', () => {
+    test('on throwing of special error, calls evalInterpreterSuccess ', async () => {
+      context.errors = [
+        { type: ErrorType.RUNTIME, error: 'source_academy_interrupt' } as unknown as SourceError
+      ];
+      return expectSaga(
+        evalCode,
+        files,
+        codeFilePath,
+        context,
+        execTime,
+        workspaceLocation,
+        actionType
+      )
+        .withState(state)
+        .provide([
+          [
+            call(runFilesInContext, files, codeFilePath, context, options),
+            { status: 'error', value }
+          ]
+        ])
+        .put(evalInterpreterSuccess('Program has been interrupted by module', workspaceLocation))
         .silentRun();
     });
   });


### PR DESCRIPTION
### Description
Currently, there is no way for modules to stop the execution of the program in source academy. 

This is a way for Source Academy modules to gracefully stop the execution of the program.

This is useful for modules who want to run their own execution environment within the tabs without changing js-slang directly. 

Modules can setup up their tab environment and call the special error. The frontend will stop gracefully and the tabs will spawn. Then modules can call js-slang's runFilesInContext directly inside the tabs.

This is a bit of a hacky solution but this simple method unlocks a lot of possibility for module writers. 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test
`yarn test` A test called special error has been added to test for the functionality

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [x] I have updated the documentation (Documentation will be added in the modules PR)
