### PR TITLE
fixed bug where grading editor could not open

### DIFF
--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -308,12 +308,12 @@ const GradingWorkspace: React.FC<Props> = props => {
             xpAdjustment={grading!.answers[questionId].grade.xpAdjustment}
             maxXp={grading!.answers[questionId].question.maxXp}
             studentNames={
-              grading![questionId].student.name
+              grading!.answers[questionId].student.name
                 ? [grading!.answers[questionId].student.name]
                 : grading!.answers[questionId].team!.map(member => member.name)
             }
             studentUsernames={
-              grading![questionId].student.username
+              grading!.answers[questionId].student.username
                 ? [grading!.answers[questionId].student.username]
                 : grading!.answers[questionId].team!.map(member => member.username)
             }


### PR DESCRIPTION
### Description
fixed a bug where grading editor could not be open
![image](https://github.com/source-academy/frontend/assets/52688525/baa42088-2a01-47c2-b36d-0cd049fa35db)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Go to grading page and click on the grade button for any submission, the grading editor will be able to open now.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
