### PR TITLE
Fixed Mobile CSE and Stepper tool not running.

### DIFF
--- a/src/commons/mobileWorkspace/MobileWorkspace.tsx
+++ b/src/commons/mobileWorkspace/MobileWorkspace.tsx
@@ -198,6 +198,7 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
         newTabId === SideContentType.mobileEditorRun &&
         !(
           prevTabId === SideContentType.substVisualizer ||
+          prevTabId === SideContentType.cseMachine ||
           prevTabId === SideContentType.autograder ||
           prevTabId === SideContentType.testcases
         )
@@ -207,12 +208,14 @@ const MobileWorkspace: React.FC<MobileWorkspaceProps> = props => {
         handleHideRepl();
       }
 
-      // Disable draggable REPL when on the files & stepper tab.
+      // Disable draggable REPL when on the files & stepper & cse tab.
       if (
         newTabId === SideContentType.folder ||
         newTabId === SideContentType.substVisualizer ||
+        newTabId === SideContentType.cseMachine ||
         (prevTabId === SideContentType.substVisualizer &&
-          newTabId === SideContentType.mobileEditorRun)
+          newTabId === SideContentType.mobileEditorRun) ||
+        (prevTabId === SideContentType.cseMachine && newTabId === SideContentType.mobileEditorRun)
       ) {
         setIsDraggableReplDisabled(true);
       } else {

--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -86,6 +86,13 @@ export const useSideContent = (location: SideContentLocation, defaultTab?: SideC
   const dispatch = useDispatch();
   const setSelectedTab = useCallback(
     (newId: SideContentType) => {
+      if (
+        (selectedTab === SideContentType.substVisualizer ||
+          selectedTab === SideContentType.cseMachine) &&
+        newId === SideContentType.mobileEditorRun
+      ) {
+        return;
+      }
       dispatch(visitSideContent(newId, selectedTab, location));
     },
     [dispatch, location, selectedTab]


### PR DESCRIPTION
### Description

Closes #2897

Clicking the run tab on mobile version of Source Academy would cause the current tab to go to the Editor tab instead of staying at the Stepper / CSE Machine. I've added a check before tabs are switched to ensure that on mobile, the correct tab would be displayed. Have experimented with changing the sagas code to achieve the similar effect but was not successful.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

On the mobile version of SourceAcademy, go to the Stepper/CSE Machine and click Run, it would no longer switch tabs back to the editor.

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
