### PR TITLE
Fix double window prompt when uploading users

### DIFF
--- a/src/pages/academy/adminPanel/subcomponents/AddStoriesUserPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/AddStoriesUserPanel.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
   Callout,
-  FileInput,
+  Classes,
   FormGroup,
   H2,
   H4,
@@ -177,7 +177,10 @@ const AddStoriesUserPanel: React.FC<Props> = props => {
               >
                 {({ getRootProps, acceptedFile, ProgressBar, getRemoveFileProps }: any) => (
                   <>
-                    <FileInput text="Upload CSV" inputProps={getRootProps()} />
+                    <label className={Classes.FILE_INPUT} {...getRootProps()}>
+                      <div style={{minWidth: 250}}> </div>
+                      <span className={Classes.FILE_UPLOAD_INPUT}>Upload CSV</span>
+                    </label>
                     <Popover
                       content={
                         <div>

--- a/src/pages/academy/adminPanel/subcomponents/AddUserPanel.tsx
+++ b/src/pages/academy/adminPanel/subcomponents/AddUserPanel.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
   Callout,
-  FileInput,
+  Classes,
   FormGroup,
   H2,
   H4,
@@ -176,7 +176,10 @@ const AddUserPanel: React.FC<Props> = props => {
               >
                 {({ getRootProps, acceptedFile, ProgressBar, getRemoveFileProps }: any) => (
                   <>
-                    <FileInput text="Upload CSV" inputProps={getRootProps()} />
+                    <label className={Classes.FILE_INPUT} {...getRootProps()}>
+                      <div style={{minWidth: 250}}> </div>
+                      <span className={Classes.FILE_UPLOAD_INPUT}>Upload CSV</span>
+                    </label>
                     <Popover
                       content={
                         <div>


### PR DESCRIPTION
### Description

Fix #2177 

Previously, two window prompts were shown when uploading a csv file. The first window was caused by the rootProps from the CSVReader component. The second window was caused by the FileInput's input element.

Can't see any neat way to keep using `<FileInput>` without its `<input>` behavior, so I replaced it entirely with something that looks roughly the same

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements


### Checklist

- [x] I have tested this code
