### PR TITLE
Freeze Sentry CLI at version 2.31.0

### DIFF
--- a/.github/workflows/build-development.yml
+++ b/.github/workflows/build-development.yml
@@ -23,7 +23,7 @@ jobs:
           cache: yarn
       - name: Setup Sentry CLI
         run: |
-          curl -sL https://sentry.io/get-cli/ | INSTALL_DIR=. bash
+          curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.31.0 INSTALL_DIR=. bash
       - id: get-time
         run: echo "time=$(date -Iseconds)" >> $GITHUB_OUTPUT
       - name: yarn install and build


### PR DESCRIPTION
### Description

Fixes the deploy error in the last few commits.

I don't see a need for us to always have the latest CLI version; we should freeze it to prioritise stable deployment.

See: https://github.com/getsentry/sentry-cli/issues/2053
See: https://github.com/getsentry/sentry-cli/issues/2052#issuecomment-2087888846

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
