### PR TITLE
Remove GENERATE_CONT and RESUME_CONT

### DIFF
--- a/src/features/cseMachine/CseMachineUtils.ts
+++ b/src/features/cseMachine/CseMachineUtils.ts
@@ -827,24 +827,6 @@ export function getControlItemComponent(
           unhighlightOnHover,
           topItem
         );
-      case InstrType.GENERATE_CONT:
-        return new ControlItemComponent(
-          'generate cont',
-          'Generate continuation',
-          stackHeight,
-          highlightOnHover,
-          unhighlightOnHover,
-          topItem
-        );
-      case InstrType.RESUME_CONT:
-        return new ControlItemComponent(
-          'call cont',
-          'call a continuation',
-          stackHeight,
-          highlightOnHover,
-          unhighlightOnHover,
-          topItem
-        );
       default:
         return new ControlItemComponent(
           'INSTRUCTION',


### PR DESCRIPTION
### Description

Removes the visualisations of GENERATE_CONT and RESUME_CONT from the CSE machine. Required as [js-slang PR](https://github.com/source-academy/js-slang/pull/1711) removes the types associated with these visualisations.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
