### PR TITLE
Add concurrency configuration for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   TZ: Asia/Singapore
@@ -17,6 +18,7 @@ concurrency:
   
 jobs:
   lint:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ env:
   NODE_OPTIONS: --max_old_space_size=8192
   GENERATE_SOURCEMAP: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

I had the honour of working with @RichDom2185 this summer in the company that we are interning at. I made a change that saved some build minutes at our company and he asked me to do this for source acad as well hence this PR exists.

So this PR aims to cancel existing github action runs for the same branch. So when we make multiple commits in the same branch within a short period of time, it should cancel the prexisting ones to save build minutes. In addition, when this PR is marked as draft, it should not trigger `ci.yml`. Instead, it should trigger that when you mark it ready for review.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test
I will make an empty commit shortly after this PR is created and that should cancel the workflow for this PR.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
