### PR TITLE
Game: Save game state for staff and admin

### DIFF
--- a/src/features/game/save/GameSaveRequests.ts
+++ b/src/features/game/save/GameSaveRequests.ts
@@ -12,7 +12,6 @@ import { FullSaveState } from './GameSaveTypes';
  * @param fullSaveState - the entire game data that needs to be saved, including game state and userstate
  */
 export async function saveData(fullSaveState: FullSaveState) {
-
   const options = {
     method: 'PUT',
     headers: createHeaders(SourceAcademyGame.getInstance().getAccountInfo().accessToken),

--- a/src/features/game/save/GameSaveRequests.ts
+++ b/src/features/game/save/GameSaveRequests.ts
@@ -12,9 +12,6 @@ import { FullSaveState } from './GameSaveTypes';
  * @param fullSaveState - the entire game data that needs to be saved, including game state and userstate
  */
 export async function saveData(fullSaveState: FullSaveState) {
-  if (SourceAcademyGame.getInstance().getAccountInfo().role !== 'student') {
-    return;
-  }
 
   const options = {
     method: 'PUT',


### PR DESCRIPTION
### Description

Resolves #2649.

Removes the role check from game state saving. This now allows game state to be saved for staff and admin accounts as well.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
