### PR TITLE
Fix reversed condition for filtering by group

### DIFF
--- a/src/pages/academy/grading/Grading.tsx
+++ b/src/pages/academy/grading/Grading.tsx
@@ -54,7 +54,7 @@ const Grading: React.FC = () => {
     (page: number, filterParams: Object) => {
       dispatch(
         SessionActions.fetchGradingOverviews(
-          showAllGroups,
+          !showAllGroups,
           unpublishedToBackendParams(showAllSubmissions),
           paginationToBackendParams(page, pageSize),
           filterParams


### PR DESCRIPTION
### Description

Right now in the Grading tab of the Academy, the default filter (of all groups) only shows submissions from the user's own groups (filter condition reversed), and this PR fixes it.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
