### PR TITLE
Replace `act` import deprecation warnings

### DIFF
--- a/src/commons/assessment/__tests__/Assessment.tsx
+++ b/src/commons/assessment/__tests__/Assessment.tsx
@@ -1,5 +1,6 @@
 import { Store } from '@reduxjs/toolkit';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { OverallState, Role } from 'src/commons/application/ApplicationTypes';

--- a/src/commons/assessmentWorkspace/__tests__/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/__tests__/AssessmentWorkspace.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { mockInitialStore } from 'src/commons/mocks/StoreMocks';

--- a/src/commons/gitHubOverlay/__tests__/FileExplorerDialog.tsx
+++ b/src/commons/gitHubOverlay/__tests__/FileExplorerDialog.tsx
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
 
 import * as GitHubUtils from '../../../features/github/GitHubUtils';
 import FileExplorerDialog from '../FileExplorerDialog';

--- a/src/commons/gitHubOverlay/__tests__/RepositoryDialog.tsx
+++ b/src/commons/gitHubOverlay/__tests__/RepositoryDialog.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
 
 import * as NotificationHelper from '../../utils/notifications/NotificationsHelper';
 import RepositoryDialog from '../RepositoryDialog';

--- a/src/commons/profile/__tests__/Profile.tsx
+++ b/src/commons/profile/__tests__/Profile.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { OverallState, Role } from 'src/commons/application/ApplicationTypes';

--- a/src/commons/sideContent/__tests__/SideContentAutograder.tsx
+++ b/src/commons/sideContent/__tests__/SideContentAutograder.tsx
@@ -1,5 +1,6 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ErrorSeverity, ErrorType, SourceError } from 'js-slang/dist/types';
+import { act } from 'react';
 import { shallowRender } from 'src/commons/utils/TestUtils';
 
 import { AutogradingResult, Testcase, TestcaseTypes } from '../../assessment/AssessmentTypes';

--- a/src/commons/sideContent/__tests__/SideContentContestLeaderboard.tsx
+++ b/src/commons/sideContent/__tests__/SideContentContestLeaderboard.tsx
@@ -1,5 +1,6 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react';
 import { shallowRender } from 'src/commons/utils/TestUtils';
 
 import SideContentContestLeaderboard from '../content/SideContentContestLeaderboard';

--- a/src/commons/sideContent/__tests__/SideContentContestVoting.tsx
+++ b/src/commons/sideContent/__tests__/SideContentContestVoting.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
 import { renderTreeJson } from 'src/commons/utils/TestUtils';
 
 import SideContentContestVotingContainer from '../content/SideContentContestVotingContainer';

--- a/src/commons/sideContent/__tests__/SideContentCseMachine.tsx
+++ b/src/commons/sideContent/__tests__/SideContentCseMachine.tsx
@@ -1,5 +1,6 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { runInContext } from 'js-slang/dist/';
+import { act } from 'react';
 import { Provider } from 'react-redux';
 import { mockInitialStore } from 'src/commons/mocks/StoreMocks';
 import { renderTreeJson } from 'src/commons/utils/TestUtils';

--- a/src/commons/utils/TestUtils.ts
+++ b/src/commons/utils/TestUtils.ts
@@ -1,5 +1,4 @@
-import { act } from '@testing-library/react';
-import React from 'react';
+import React, { act } from 'react';
 import renderer from 'react-test-renderer';
 import { createRenderer } from 'react-test-renderer/shallow';
 

--- a/src/features/sicp/errors/__tests__/SicpErrors.tsx
+++ b/src/features/sicp/errors/__tests__/SicpErrors.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
 import { shallowRender } from 'src/commons/utils/TestUtils';
 
 import getSicpError, { SicpErrorType } from '../SicpErrors';

--- a/src/pages/githubCallback/__tests__/GitHubCallback.tsx
+++ b/src/pages/githubCallback/__tests__/GitHubCallback.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
 import { Route, Routes } from 'react-router';
 import { StaticRouter } from 'react-router-dom/server';
 

--- a/src/pages/playground/__tests__/Playground.tsx
+++ b/src/pages/playground/__tests__/Playground.tsx
@@ -1,8 +1,9 @@
 import { Dispatch, Store } from '@reduxjs/toolkit';
 import { Router } from '@remix-run/router';
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { FSModule } from 'browserfs/dist/node/core/FS';
 import { Chapter } from 'js-slang/dist/types';
+import { act } from 'react';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouteObject, RouterProvider } from 'react-router';
 import {


### PR DESCRIPTION
### Description

Gets rid of the warning when running tests:
> ```Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.```

Reference: https://react.dev/warnings/react-dom-test-utils#reactdomtestutilsact-warning

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code quality improvements

### Checklist

- [x] I have tested this code