### PR TITLE
fix: Memoize achievement inferencer

### DIFF
--- a/src/pages/achievement/control/AchievementControl.tsx
+++ b/src/pages/achievement/control/AchievementControl.tsx
@@ -35,8 +35,18 @@ const AchievementControl: React.FC = () => {
     [dispatch]
   );
 
-  const inferencer = useTypedSelector(
-    state => new AchievementInferencer(state.achievement.achievements, state.achievement.goals)
+  // TODO: This is a hacky fix. By right, we shouldn't need to use an
+  // inferencer instance since we can encapsulate the logic using hooks
+  // and component state.
+  const [initialAchievements, initialGoals] = useTypedSelector(state => [
+    state.achievement.achievements,
+    state.achievement.goals
+  ]);
+  const inferencer = useMemo(
+    () => new AchievementInferencer(initialAchievements, initialGoals),
+    // We only want to create the inferencer once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
 
   /**


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Uses a per-component instance singleton and memoizes it, as we only need to keep track of the initial states of the control panel.

Also added a TODO comment for future refactoring to more modern React principles using component state and hooks.

Closes #3060.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements


### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
