### PR TITLE
Fix export CSV to retrieve all assessement entries

### DIFF
--- a/src/commons/sagas/RequestsSaga.ts
+++ b/src/commons/sagas/RequestsSaga.ts
@@ -640,47 +640,22 @@ export const getGradingOverviews = async (
   }
   const gradingOverviews = await resp.json();
 
-  return {
-    count: gradingOverviews.count,
-    data: gradingOverviews.data.map((overview: any) => {
-      const gradingOverview: GradingOverview = {
-        assessmentId: overview.assessment.id,
-        assessmentNumber: overview.assessment.assessmentNumber,
-        assessmentName: overview.assessment.title,
-        assessmentType: overview.assessment.type,
-        studentId: overview.student ? overview.student.id : -1,
-        studentName: overview.student ? overview.student.name : undefined,
-        studentNames: overview.team
-          ? overview.team.team_members.map((member: { name: any }) => member.name)
-          : undefined,
-        studentUsername: overview.student ? overview.student.username : undefined,
-        studentUsernames: overview.team
-          ? overview.team.team_members.map((member: { username: any }) => member.username)
-          : undefined,
-        submissionId: overview.id,
-        submissionStatus: overview.status,
-        groupName: overview.student ? overview.student.groupName : '-',
-        groupLeaderId: overview.student ? overview.student.groupLeaderId : undefined,
-        isGradingPublished: overview.isGradingPublished,
-        progress: backendParamsToProgressStatus(
-          overview.assessment.isManuallyGraded,
-          overview.isGradingPublished,
-          overview.status,
-          overview.gradedCount,
-          overview.assessment.questionCount
-        ),
-        questionCount: overview.assessment.questionCount,
-        gradedCount: overview.gradedCount,
-        // XP
-        initialXp: overview.xp,
-        xpAdjustment: overview.xpAdjustment,
-        currentXp: overview.xp + overview.xpAdjustment,
-        maxXp: overview.assessment.maxXp,
-        xpBonus: overview.xpBonus
-      };
-      return gradingOverview;
-    })
-  };
+  return respToGradingOverviews(gradingOverviews);
+};
+
+/*
+ * GET /courses/{courseId}/admin/grading/all_submissions
+ */
+export const getAllGradingOverviews = async (tokens: Tokens): Promise<GradingOverviews | null> => {
+  const resp = await request(`${courseId()}/admin/grading/all_submissions`, 'GET', {
+    ...tokens
+  });
+  if (!resp) {
+    return null; // invalid accessToken _and_ refreshToken
+  }
+  const gradingOverviews = await resp.json();
+
+  return respToGradingOverviews(gradingOverviews);
 };
 
 /*
@@ -1555,6 +1530,50 @@ export function* handleResponseError(resp: Response | null): any {
 
   yield call(showWarningMessage, respText);
 }
+
+const respToGradingOverviews = (gradingOverviews: any): GradingOverviews => {
+  return {
+    count: gradingOverviews.count,
+    data: gradingOverviews.data.map((overview: any) => {
+      const gradingOverview: GradingOverview = {
+        assessmentId: overview.assessment.id,
+        assessmentNumber: overview.assessment.assessmentNumber,
+        assessmentName: overview.assessment.title,
+        assessmentType: overview.assessment.type,
+        studentId: overview.student ? overview.student.id : -1,
+        studentName: overview.student ? overview.student.name : undefined,
+        studentNames: overview.team
+          ? overview.team.team_members.map((member: { name: any }) => member.name)
+          : undefined,
+        studentUsername: overview.student ? overview.student.username : undefined,
+        studentUsernames: overview.team
+          ? overview.team.team_members.map((member: { username: any }) => member.username)
+          : undefined,
+        submissionId: overview.id,
+        submissionStatus: overview.status,
+        groupName: overview.student ? overview.student.groupName : '-',
+        groupLeaderId: overview.student ? overview.student.groupLeaderId : undefined,
+        isGradingPublished: overview.isGradingPublished,
+        progress: backendParamsToProgressStatus(
+          overview.assessment.isManuallyGraded,
+          overview.isGradingPublished,
+          overview.status,
+          overview.gradedCount,
+          overview.assessment.questionCount
+        ),
+        questionCount: overview.assessment.questionCount,
+        gradedCount: overview.gradedCount,
+        // XP
+        initialXp: overview.xp,
+        xpAdjustment: overview.xpAdjustment,
+        currentXp: overview.xp + overview.xpAdjustment,
+        maxXp: overview.assessment.maxXp,
+        xpBonus: overview.xpBonus
+      };
+      return gradingOverview;
+    })
+  };
+};
 
 const courseId: () => string = () => {
   const id = store.getState().session.courseId;

--- a/src/pages/academy/grading/Grading.tsx
+++ b/src/pages/academy/grading/Grading.tsx
@@ -7,6 +7,7 @@ import SessionActions from 'src/commons/application/actions/SessionActions';
 import { Role } from 'src/commons/application/ApplicationTypes';
 import GradingFlex from 'src/commons/grading/GradingFlex';
 import GradingText from 'src/commons/grading/GradingText';
+import { getAllGradingOverviews } from 'src/commons/sagas/RequestsSaga';
 import SimpleDropdown from 'src/commons/SimpleDropdown';
 import { useSession, useTypedSelector } from 'src/commons/utils/Hooks';
 import WorkspaceActions from 'src/commons/workspace/WorkspaceActions';
@@ -58,6 +59,10 @@ const Grading: React.FC = () => {
   const allColsSortStates = useTypedSelector(state => state.workspaces.grading.allColsSortStates);
   const hasLoadedBefore = useTypedSelector(state => state.workspaces.grading.hasLoadedBefore);
   const requestCounter = useTypedSelector(state => state.workspaces.grading.requestCounter);
+  const tokens = useTypedSelector(state => ({
+    accessToken: state.session.accessToken || 'Invalid',
+    refreshToken: state.session.refreshToken || 'Invalid'
+  }));
 
   const isLoading = useMemo(() => requestCounter > 0, [requestCounter]);
 
@@ -165,7 +170,9 @@ const Grading: React.FC = () => {
                 <Button
                   minimal
                   icon={IconNames.EXPORT}
-                  onClick={() => exportGradingCSV(gradingOverviews.data)}
+                  onClick={() => {
+                    getAllGradingOverviews(tokens).then(resp => exportGradingCSV(resp?.data));
+                  }}
                   className="export-csv-btn"
                 >
                   Export to CSV

--- a/src/pages/academy/grading/Grading.tsx
+++ b/src/pages/academy/grading/Grading.tsx
@@ -59,10 +59,8 @@ const Grading: React.FC = () => {
   const allColsSortStates = useTypedSelector(state => state.workspaces.grading.allColsSortStates);
   const hasLoadedBefore = useTypedSelector(state => state.workspaces.grading.hasLoadedBefore);
   const requestCounter = useTypedSelector(state => state.workspaces.grading.requestCounter);
-  const tokens = useTypedSelector(state => ({
-    accessToken: state.session.accessToken || 'Invalid',
-    refreshToken: state.session.refreshToken || 'Invalid'
-  }));
+  const accessToken = useTypedSelector(state => state.session.accessToken);
+  const refreshToken = useTypedSelector(state => state.session.refreshToken);
 
   const isLoading = useMemo(() => requestCounter > 0, [requestCounter]);
 
@@ -171,6 +169,10 @@ const Grading: React.FC = () => {
                   minimal
                   icon={IconNames.EXPORT}
                   onClick={() => {
+                    const tokens = {
+                      accessToken: accessToken!,
+                      refreshToken: refreshToken!
+                    };
                     getAllGradingOverviews(tokens).then(resp => exportGradingCSV(resp?.data));
                   }}
                   className="export-csv-btn"


### PR DESCRIPTION
Resolves #2814 

### Description

Resolves the issue of export CSV being unable to export all entries due to backend pagination. The solution is to connect to a backend endpoint outside of the Redux loop so that data can be exported independently of what is shown to the user. (This will be an admin-only button to avoid excess server fees)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Start up both the updated backend and updated frontend. 
- Enter the 'Grading' tab.
- Click the 'Export CSV' button at the grading table.
- If you are logged in as an admin, you will receive a notification to download the CSV file.
- If you are logged in as a staff, you will receive a 401 error.

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
