### PR TITLE
update session details with latest course information before switchin…

### DIFF
--- a/src/commons/dropdown/DropdownCourses.tsx
+++ b/src/commons/dropdown/DropdownCourses.tsx
@@ -1,10 +1,13 @@
 import { Dialog, DialogBody, HTMLSelect } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 
+import SessionActions from '../application/actions/SessionActions';
 import { Role } from '../application/ApplicationTypes';
 import { UserCourse } from '../application/types/SessionTypes';
+import { useTypedSelector } from '../utils/Hooks';
 
 type Props = {
   isOpen: boolean;
@@ -15,6 +18,8 @@ type Props = {
 
 const DropdownCourses: React.FC<Props> = ({ isOpen, onClose, courses, courseId }) => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const latestCourse = useTypedSelector(state => state.session.courseId);
 
   const options = courses.map(course => ({
     value: course.courseId,
@@ -22,10 +27,16 @@ const DropdownCourses: React.FC<Props> = ({ isOpen, onClose, courses, courseId }
     disabled: !course.viewable && course.role !== Role.Admin
   }));
 
-  const onChangeHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    navigate(`/courses/${e.currentTarget.value}`);
+  const onChangeHandler = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    await dispatch(SessionActions.updateLatestViewedCourse(Number(e.currentTarget.value)));
     onClose();
   };
+
+  useEffect(() => {
+    if (latestCourse) {
+      navigate(`/courses/${latestCourse}`);
+    }
+  }, [latestCourse, navigate]);
 
   return (
     <Dialog


### PR DESCRIPTION
…g courses

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the bug where switching courses redirects the user to the 'game' page, even when games are not enabled for the course.

The reason for this bug is because the loader function at `src/pages/academy/academyRoutes` checks for the `enableGame` flag in the Redux store before deciding whether to redirect, but the `enableGame` flag value belongs to the previous course and not the course it's about to switch to. The solution adopted in this MR is to update the latest viewed course to the course that the user is about to navigate to, before actually navigating to that course.

Closes #3040.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Course configuration: create two courses - one with games enabled and one without games enabled.
2. Switch to the other course using the 'My courses' dropdown - it should redirect to the games page if the course has games enabled, and to the missions page otherwise.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
