### PR TITLE
Remove lazy and GPU variants

### DIFF
--- a/src/commons/__tests__/Markdown.tsx
+++ b/src/commons/__tests__/Markdown.tsx
@@ -22,17 +22,11 @@ test('Markdown page renders correct Source information', () => {
   const source1Default = <Markdown {...mockProps(Chapter.SOURCE_1, Variant.DEFAULT)} />;
   expect(source1Default.props.content).toContain('Source \xa71');
 
-  const source1Lazy = <Markdown {...mockProps(Chapter.SOURCE_1, Variant.LAZY)} />;
-  expect(source1Lazy.props.content).toContain('Source \xa71 Lazy');
-
   const source1Wasm = <Markdown {...mockProps(Chapter.SOURCE_1, Variant.WASM)} />;
   expect(source1Wasm.props.content).toContain('Source \xa71 WebAssembly');
 
   const source2Default = <Markdown {...mockProps(Chapter.SOURCE_2, Variant.DEFAULT)} />;
   expect(source2Default.props.content).toContain('Source \xa72');
-
-  const source2Lazy = <Markdown {...mockProps(Chapter.SOURCE_2, Variant.LAZY)} />;
-  expect(source2Lazy.props.content).toContain('Source \xa72 Lazy');
 
   const source3Default = <Markdown {...mockProps(Chapter.SOURCE_3, Variant.DEFAULT)} />;
   expect(source3Default.props.content).toContain('Source \xa73');
@@ -42,7 +36,4 @@ test('Markdown page renders correct Source information', () => {
 
   const source4Default = <Markdown {...mockProps(Chapter.SOURCE_4, Variant.DEFAULT)} />;
   expect(source4Default.props.content).toContain('Source \xa74');
-
-  const source4GPU = <Markdown {...mockProps(Chapter.SOURCE_4, Variant.GPU)} />;
-  expect(source4GPU.props.content).toContain('Source \xa74 GPU');
 });

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -161,8 +161,6 @@ const variantDisplay: Map<Variant, string> = new Map([
   [Variant.TYPED, 'Typed'],
   [Variant.WASM, 'WebAssembly'],
   [Variant.CONCURRENT, 'Concurrent'],
-  [Variant.LAZY, 'Lazy'],
-  [Variant.GPU, 'GPU'],
   [Variant.NATIVE, 'Native'],
   [Variant.EXPLICIT_CONTROL, 'Explicit-Control']
 ]);
@@ -260,12 +258,10 @@ const sourceSubLanguages: Array<Pick<SALanguage, 'chapter' | 'variant'>> = [
   { chapter: Chapter.SOURCE_1, variant: Variant.DEFAULT },
   { chapter: Chapter.SOURCE_1, variant: Variant.TYPED },
   { chapter: Chapter.SOURCE_1, variant: Variant.WASM },
-  { chapter: Chapter.SOURCE_1, variant: Variant.LAZY },
   { chapter: Chapter.SOURCE_1, variant: Variant.NATIVE },
 
   { chapter: Chapter.SOURCE_2, variant: Variant.DEFAULT },
   { chapter: Chapter.SOURCE_2, variant: Variant.TYPED },
-  { chapter: Chapter.SOURCE_2, variant: Variant.LAZY },
   { chapter: Chapter.SOURCE_2, variant: Variant.NATIVE },
 
   { chapter: Chapter.SOURCE_3, variant: Variant.DEFAULT },
@@ -275,7 +271,6 @@ const sourceSubLanguages: Array<Pick<SALanguage, 'chapter' | 'variant'>> = [
 
   { chapter: Chapter.SOURCE_4, variant: Variant.DEFAULT },
   { chapter: Chapter.SOURCE_4, variant: Variant.TYPED },
-  { chapter: Chapter.SOURCE_4, variant: Variant.GPU },
   { chapter: Chapter.SOURCE_4, variant: Variant.NATIVE },
   { chapter: Chapter.SOURCE_4, variant: Variant.EXPLICIT_CONTROL }
 ];

--- a/src/commons/application/__tests__/ApplicationTypes.ts
+++ b/src/commons/application/__tests__/ApplicationTypes.ts
@@ -27,7 +27,6 @@ describe('available Source language configurations', () => {
       { chapter: Chapter.SOURCE_1, variant: Variant.DEFAULT, supports: { substVisualizer: true } },
       { chapter: Chapter.SOURCE_1, variant: Variant.TYPED, supports: { substVisualizer: true } },
       { chapter: Chapter.SOURCE_1, variant: Variant.WASM },
-      { chapter: Chapter.SOURCE_1, variant: Variant.LAZY },
       { chapter: Chapter.SOURCE_1, variant: Variant.NATIVE, supports: { substVisualizer: true } },
       // Source 2
       {
@@ -40,7 +39,6 @@ describe('available Source language configurations', () => {
         variant: Variant.TYPED,
         supports: { dataVisualizer: true, substVisualizer: true }
       },
-      { chapter: Chapter.SOURCE_2, variant: Variant.LAZY, supports: { dataVisualizer: true } },
       {
         chapter: Chapter.SOURCE_2,
         variant: Variant.NATIVE,
@@ -76,11 +74,6 @@ describe('available Source language configurations', () => {
       {
         chapter: Chapter.SOURCE_4,
         variant: Variant.TYPED,
-        supports: { dataVisualizer: true, cseMachine: true }
-      },
-      {
-        chapter: Chapter.SOURCE_4,
-        variant: Variant.GPU,
         supports: { dataVisualizer: true, cseMachine: true }
       },
       {

--- a/src/commons/application/__tests__/__snapshots__/ApplicationTypes.ts.snap
+++ b/src/commons/application/__tests__/__snapshots__/ApplicationTypes.ts.snap
@@ -112,19 +112,6 @@ Array [
   },
   Object {
     "chapter": 1,
-    "displayName": "Source §1 Lazy",
-    "mainLanguage": "JavaScript",
-    "supports": Object {
-      "cseMachine": false,
-      "dataVisualizer": false,
-      "multiFile": false,
-      "repl": true,
-      "substVisualizer": false,
-    },
-    "variant": "lazy",
-  },
-  Object {
-    "chapter": 1,
     "displayName": "Source §1 Native",
     "mainLanguage": "JavaScript",
     "supports": Object {
@@ -161,19 +148,6 @@ Array [
       "substVisualizer": true,
     },
     "variant": "typed",
-  },
-  Object {
-    "chapter": 2,
-    "displayName": "Source §2 Lazy",
-    "mainLanguage": "JavaScript",
-    "supports": Object {
-      "cseMachine": false,
-      "dataVisualizer": true,
-      "multiFile": true,
-      "repl": true,
-      "substVisualizer": false,
-    },
-    "variant": "lazy",
   },
   Object {
     "chapter": 2,
@@ -265,19 +239,6 @@ Array [
       "substVisualizer": false,
     },
     "variant": "typed",
-  },
-  Object {
-    "chapter": 4,
-    "displayName": "Source §4 GPU",
-    "mainLanguage": "JavaScript",
-    "supports": Object {
-      "cseMachine": true,
-      "dataVisualizer": true,
-      "multiFile": true,
-      "repl": true,
-      "substVisualizer": false,
-    },
-    "variant": "gpu",
   },
   Object {
     "chapter": 4,

--- a/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/evalCode.ts
@@ -130,15 +130,7 @@ export function* evalCodeSaga(
   const entrypointCode = files[entrypointFilePath];
 
   function call_variant(variant: Variant) {
-    if (variant === Variant.LAZY) {
-      return call(runFilesInContext, files, entrypointFilePath, context, {
-        scheduler: 'preemptive',
-        originalMaxExecTime: execTime,
-        stepLimit: stepLimit,
-        useSubst: substActiveAndCorrectChapter,
-        envSteps: currentStep
-      });
-    } else if (variant === Variant.WASM) {
+    if (variant === Variant.WASM) {
       // Note: WASM does not support multiple file programs.
       return call(
         wasm_compile_and_run,
@@ -256,7 +248,6 @@ export function* evalCodeSaga(
       });
   }
 
-  const isLazy: boolean = context.variant === Variant.LAZY;
   const isWasm: boolean = context.variant === Variant.WASM;
   const isC: boolean = context.chapter === Chapter.FULL_C;
   const isJava: boolean = context.chapter === Chapter.FULL_JAVA;
@@ -284,7 +275,7 @@ export function* evalCodeSaga(
     result:
       actionType === InterpreterActions.debuggerResume.type
         ? call(resume, lastDebuggerResult)
-        : isLazy || isWasm
+        : isWasm
           ? call_variant(context.variant)
           : isC
             ? call(cCompileAndRun, entrypointCode, context)

--- a/src/commons/sagas/__tests__/BackendSaga.ts
+++ b/src/commons/sagas/__tests__/BackendSaga.ts
@@ -832,8 +832,8 @@ describe('Test CHANGE_SUBLANGUAGE action', () => {
   test('when chapter is changed', () => {
     const sublang: SALanguage = {
       chapter: Chapter.SOURCE_4,
-      variant: Variant.GPU,
-      displayName: 'Source \xa74 GPU',
+      variant: Variant.CONCURRENT,
+      displayName: 'Source \xa74 Concurrent',
       mainLanguage: SupportedLanguage.JAVASCRIPT,
       supports: {}
     };
@@ -854,7 +854,7 @@ describe('Test CHANGE_SUBLANGUAGE action', () => {
         [
           call(putCourseConfig, mockTokens, {
             sourceChapter: Chapter.SOURCE_4,
-            sourceVariant: Variant.GPU
+            sourceVariant: Variant.CONCURRENT
           }),
           { ok: true }
         ]

--- a/src/commons/sagas/__tests__/PersistenceSaga.ts
+++ b/src/commons/sagas/__tests__/PersistenceSaga.ts
@@ -20,7 +20,7 @@ const FILE_ID = '123';
 const FILE_NAME = 'file';
 const FILE_DATA = '// Hello world';
 const SOURCE_CHAPTER = Chapter.SOURCE_3;
-const SOURCE_VARIANT = Variant.LAZY;
+const SOURCE_VARIANT = Variant.DEFAULT;
 const SOURCE_LIBRARY = ExternalLibraryName.SOUNDS;
 
 beforeAll(() => {


### PR DESCRIPTION
### Description

Removes the lazy and GPU variants that are no longer provided in the latest version of js-slang. Resolves #3108 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### Checklist

- [x] I have tested this code

