### PR TITLE
i18n support for sicp

### DIFF
--- a/src/routes/routerConfig.tsx
+++ b/src/routes/routerConfig.tsx
@@ -49,7 +49,7 @@ const Features = () => import('../pages/featureFlags/FeatureFlags');
 const commonChildrenRoutes: RouteObject[] = [
   { path: 'contributors', lazy: Contributors },
   { path: 'callback/github', lazy: GitHubCallback },
-  { path: 'sicpjs/:section?', lazy: Sicp },
+  { path: 'sicpjs/:lang/:section?', lazy: Sicp },
   { path: 'features', lazy: Features }
 ];
 


### PR DESCRIPTION
### Description
updated router to read language params from url and request for the corresponding page in the backend
added button in sicp page to switch between languages
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test
use the updated backend that supports i18n when starting the frontend
navigate to the sicp page in the frontend and switch between languages

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
