### PR TITLE
Disable renovate package grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     ":dependencyDashboard",
-    "group:allNonMajor",
     ":label(dependencies)"
   ],
   "major": {

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,6 @@
     ":dependencyDashboard",
     ":label(dependencies)"
   ],
-  "major": {
-    "dependencyDashboardApproval": true
-  },
   "packageRules": [
     {
       "rangeStrategy": "update-lockfile",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

While the original intention in https://github.com/source-academy/frontend/pull/2172#issuecomment-1221554088 makes sense, over the years the following usability issues with this config arise:

1. Grouping all minor+patch across all dependencies into 1 PR more often that not just makes it hard to figure out which packages have breaking changes, as opposed to having a separate PR for each dependency (easy to isolate)
2. Having to edit the config file just to pin/ignore a dependency is tedious as it involves making a PR (as opposed to simply closing a PR and have renovate auto ignore it for as long as the PR remains closed without being merged)
3. Grouping all dependencies' updates into one PR results in big bang update which more often than not lead to more trouble when bisecting a problematic issue should bugs arise and get discovered in the future.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
