### PR TITLE
Messages to handle breakpoints in vscode

### DIFF
--- a/src/commons/application/Application.tsx
+++ b/src/commons/application/Application.tsx
@@ -138,6 +138,15 @@ const Application: React.FC = () => {
         case MessageTypeNames.AssessmentAnswer:
           dispatch(SessionActions.submitAnswer(message.questionId, message.answer));
           break;
+        case MessageTypeNames.SetEditorBreakpoints:
+          dispatch(
+            WorkspaceActions.setEditorBreakpoint(
+              message.workspaceLocation,
+              0,
+              message.newBreakpoints
+            )
+          );
+          break;
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
+++ b/src/commons/assessmentWorkspace/AssessmentWorkspace.tsx
@@ -412,6 +412,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
       case QuestionTypes.programming || QuestionTypes.voting:
         const prepend = question.prepend;
         const code = question.answer ?? question.solutionTemplate;
+        const breakpoints = editorTabs[0]?.breakpoints ?? [];
         sendToWebview(
           Messages.NewEditor(
             workspaceLocation,
@@ -419,7 +420,8 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
             props.questionId,
             chapter,
             prepend,
-            code
+            code,
+            breakpoints
           )
         );
         break;
@@ -449,6 +451,7 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
       // TODO: Hardcoded to make use of the first editor tab. Refactoring is needed for this workspace to enable Folder mode.
       handleEditorValueChange(0, answer);
       // Hacky way to view the editor, might cause issues
+      const breakpoints = editorTabs[0]?.breakpoints ?? [];
       sendToWebview(
         Messages.NewEditor(
           workspaceLocation,
@@ -456,7 +459,8 @@ const AssessmentWorkspace: React.FC<AssessmentWorkspaceProps> = props => {
           questionId,
           question.library.chapter,
           '',
-          answer
+          answer,
+          breakpoints
         )
       );
       //

--- a/src/features/vscode/messages.ts
+++ b/src/features/vscode/messages.ts
@@ -33,14 +33,16 @@ const Messages = createMessages({
     questionId: number,
     chapter: number,
     prepend: string,
-    initialCode: string
+    initialCode: string,
+    breakpoints: string[]
   ) => ({
     workspaceLocation,
     assessmentName,
     questionId,
     chapter,
     prepend,
-    initialCode
+    initialCode,
+    breakpoints
   }),
   Text: (workspaceLocation: VscWorkspaceLocation, code: string) => ({
     workspaceLocation,
@@ -99,7 +101,11 @@ const Messages = createMessages({
     questionId,
     answer
   }),
-  LoginWithBrowser: (route: string) => ({ route })
+  LoginWithBrowser: (route: string) => ({ route }),
+  SetEditorBreakpoints: (workspaceLocation: VscWorkspaceLocation, newBreakpoints: string[]) => ({
+    workspaceLocation,
+    newBreakpoints
+  })
 });
 
 export default Messages;

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -381,6 +381,7 @@ const Playground: React.FC<PlaygroundProps> = props => {
       return;
     }
     const initialCode = editorTabs[0]?.value ?? '';
+    const breakpoints = editorTabs[0]?.breakpoints ?? [];
     sendToWebview(
       Messages.NewEditor(
         workspaceLocation,
@@ -388,7 +389,8 @@ const Playground: React.FC<PlaygroundProps> = props => {
         1,
         playgroundSourceChapter,
         '',
-        initialCode
+        initialCode,
+        breakpoints
       )
     );
     // We don't want to re-send this message even when the variables change


### PR DESCRIPTION
### Description

This is a small PR that implements messages for breakpoints to be passed between the webview and vscode.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
