### PR TITLE
Downgrade immer to fix playground not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "hastscript": "^9.0.0",
     "i18next": "^25.0.0",
     "i18next-browser-languagedetector": "^8.0.0",
-    "immer": "^10.1.1",
+    "immer": "^9.0.21",
     "java-slang": "^1.0.13",
     "js-cookie": "^3.0.5",
     "js-slang": "^1.0.84",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7557,7 +7557,7 @@ __metadata:
     i18next: "npm:^25.0.0"
     i18next-browser-languagedetector: "npm:^8.0.0"
     identity-obj-proxy: "npm:^3.0.0"
-    immer: "npm:^10.1.1"
+    immer: "npm:^9.0.21"
     java-slang: "npm:^1.0.13"
     js-cookie: "npm:^3.0.5"
     js-slang: "npm:^1.0.84"
@@ -8290,13 +8290,6 @@ __metadata:
   version: 7.0.5
   resolution: "ignore@npm:7.0.5"
   checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
-  languageName: node
-  linkType: hard
-
-"immer@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "immer@npm:10.1.1"
-  checksum: 10c0/b749e10d137ccae91788f41bd57e9387f32ea6d6ea8fd7eb47b23fd7766681575efc7f86ceef7fe24c3bc9d61e38ff5d2f49c2663b2b0c056e280a4510923653
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

In #3140, `immer@10` was added to make use of `castDraft` to fix typescript type errors, however this caused a version conflict with redux toolkit which was still using `immer@9`. As a result, playground execution no longer works.

This PR downgrades `immer` back to 9.0.21, thanks @martin-henz for quickly bringing up the issue!

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Playground/code execution should be working again.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
