### PR TITLE
Fix incorrect assessment overview memoization

### DIFF
--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -1,15 +1,9 @@
 import {
   Button,
-  Card,
   Collapse,
   Dialog,
   DialogBody,
   DialogFooter,
-  Elevation,
-  H4,
-  H6,
-  Icon,
-  IconName,
   Intent,
   NonIdealState,
   Position,
@@ -18,16 +12,13 @@ import {
   Tooltip
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import classNames from 'classnames';
 import { sortBy } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { Navigate, NavLink, useLoaderData, useParams } from 'react-router';
+import { Navigate, useLoaderData, useParams } from 'react-router';
 import { numberRegExp } from 'src/features/academy/AcademyTypes';
 import Messages, { sendToWebview } from 'src/features/vscode/messages';
-import classes from 'src/styles/Academy.module.scss';
 
-import defaultCoverImage from '../../assets/default_cover_image.jpg';
 import SessionActions from '../application/actions/SessionActions';
 import { Role } from '../application/ApplicationTypes';
 import AssessmentWorkspace, {
@@ -35,14 +26,12 @@ import AssessmentWorkspace, {
 } from '../assessmentWorkspace/AssessmentWorkspace';
 import ContentDisplay from '../ContentDisplay';
 import ControlButton from '../ControlButton';
-import Markdown from '../Markdown';
-import NotificationBadge from '../notificationBadge/NotificationBadge';
-import { filterNotificationsByAssessment } from '../notificationBadge/NotificationBadgeHelper';
 import Constants from '../utils/Constants';
-import { beforeNow, getPrettyDate, getPrettyDateAfterHours } from '../utils/DateHelper';
-import { useResponsive, useSession, useTypedSelector } from '../utils/Hooks';
-import { assessmentTypeLink, convertParamToInt } from '../utils/ParamParseHelper';
+import { beforeNow } from '../utils/DateHelper';
+import { useSession, useTypedSelector } from '../utils/Hooks';
+import { convertParamToInt } from '../utils/ParamParseHelper';
 import AssessmentNotFound from './AssessmentNotFound';
+import AssessmentOverviewCard from './AssessmentOverviewCard';
 import {
   AssessmentConfiguration,
   AssessmentOverview,
@@ -52,7 +41,6 @@ import {
 
 const Assessment: React.FC = () => {
   const params = useParams<AssessmentWorkspaceParams>();
-  const { isMobileBreakpoint } = useResponsive();
   const [betchaAssessment, setBetchaAssessment] = useState<AssessmentOverview | null>(null);
   const [showClosedAssessments, setShowClosedAssessments] = useState(false);
   const [showOpenedAssessments, setShowOpenedAssessments] = useState(true);
@@ -112,166 +100,6 @@ const Assessment: React.FC = () => {
     </Tooltip>
   );
 
-  const makeAssessmentInteractButton = (overview: AssessmentOverview) => {
-    let icon: IconName;
-    let label: string;
-    let optionalLabel: string = '';
-
-    switch (overview.status) {
-      case AssessmentStatuses.not_attempted:
-        icon = IconNames.PLAY;
-        label = 'Attempt';
-        break;
-      case AssessmentStatuses.attempting:
-        icon = IconNames.PLAY;
-        label = 'Continue';
-        optionalLabel = ' Attempt';
-        break;
-      case AssessmentStatuses.attempted:
-        icon = IconNames.EDIT;
-        label = 'Review';
-        optionalLabel = ' Attempt';
-        break;
-      case AssessmentStatuses.submitted:
-        icon = IconNames.EYE_OPEN;
-        label = 'Review';
-        optionalLabel = ' Submission';
-        break;
-      default:
-        // If we reach this case, backend data did not fit IAssessmentOverview
-        icon = IconNames.PLAY;
-        label = 'Review';
-        break;
-    }
-    return (
-      <NavLink
-        to={`/courses/${courseId}/${assessmentTypeLink(overview.type)}/${overview.id.toString()}/${
-          Constants.defaultQuestionId
-        }`}
-      >
-        <Button
-          icon={icon}
-          minimal={true}
-          onClick={() =>
-            dispatch(
-              SessionActions.acknowledgeNotifications(filterNotificationsByAssessment(overview.id))
-            )
-          }
-        >
-          <span data-testid="Assessment-Attempt-Button">{label}</span>
-          <span className="custom-hidden-xxxs">{optionalLabel}</span>
-        </Button>
-      </NavLink>
-    );
-  };
-
-  /**
-   * Create a series of cards to display IAssessmentOverviews.
-   * @param {AssessmentOverview} overview the assessment overview to display
-   * @param {number} index a unique number for this card (required for sequential rendering).
-   *   See {@link https://reactjs.org/docs/lists-and-keys.html#keys}
-   * @param renderAttemptButton will only render the attempt button if true, regardless
-   *   of attempt status.
-   * @param notifications the notifications to be passed in.
-   */
-  const makeOverviewCard = (
-    overview: AssessmentOverview,
-    index: number,
-    renderAttemptButton: boolean,
-    renderGradingTooltip: boolean
-  ) => {
-    return (
-      <div key={index}>
-        <Card className="row listing" elevation={Elevation.ONE}>
-          <div className={classNames('listing-picture', !isMobileBreakpoint && 'col-xs-3')}>
-            <NotificationBadge
-              className="badge"
-              notificationFilter={filterNotificationsByAssessment(overview.id)}
-              large={true}
-            />
-            <img
-              alt="Assessment"
-              className={`cover-image-${overview.status}`}
-              src={overview.coverImage ? overview.coverImage : defaultCoverImage}
-            />
-          </div>
-          <div className={classNames('listing-text', !isMobileBreakpoint && 'col-xs-9')}>
-            {makeOverviewCardTitle(overview, index, renderGradingTooltip)}
-            <div className={classes['listing-xp']}>
-              <H6>
-                {overview.isGradingPublished
-                  ? `XP: ${overview.xp} / ${overview.maxXp}`
-                  : `Max XP: ${overview.maxXp}`}
-              </H6>
-              {overview.earlySubmissionXp > 0 && (
-                <Tooltip
-                  content={`Max XP ends on ${getPrettyDateAfterHours(overview.openAt, overview.hoursBeforeEarlyXpDecay)}`}
-                >
-                  <Icon icon={IconNames.InfoSign} />
-                </Tooltip>
-              )}
-            </div>
-            <div className="listing-description">
-              <Markdown content={overview.shortSummary} />
-            </div>
-            {overview.maxTeamSize > 1 ? (
-              <div className="listing-team_information">
-                <H6> This is a team assessment. </H6>
-              </div>
-            ) : (
-              <div>
-                <H6> This is an individual assessment. </H6>
-              </div>
-            )}
-            <div className="listing-footer">
-              <div>
-                <Text className="listing-due-date">
-                  <Icon className="listing-due-icon" size={12} icon={IconNames.CALENDAR} />
-                  {`${beforeNow(overview.openAt) ? 'Opened' : 'Opens'}: ${getPrettyDate(
-                    overview.openAt
-                  )}`}
-                </Text>
-                {beforeNow(overview.openAt) && (
-                  <Text className="listing-due-date">
-                    <Icon className="listing-due-icon" size={12} icon={IconNames.TIME} />
-                    {`Due: ${getPrettyDate(overview.closeAt)}`}
-                  </Text>
-                )}
-              </div>
-              <div className="listing-button">
-                {renderAttemptButton ? makeAssessmentInteractButton(overview) : null}
-              </div>
-            </div>
-          </div>
-        </Card>
-      </div>
-    );
-  };
-
-  const makeOverviewCardTitle = (
-    overview: AssessmentOverview,
-    index: number,
-    renderProgressStatus: boolean
-  ) => (
-    <div className="listing-header">
-      <Text ellipsize={true}>
-        <H4 className="listing-title">
-          {overview.title}
-          {overview.private ? (
-            <Tooltip
-              className="listing-title-tooltip"
-              content="This assessment is password-protected."
-            >
-              <Icon icon="lock" />
-            </Tooltip>
-          ) : null}
-          {renderProgressStatus ? showGradingTooltip(overview.isGradingPublished) : null}
-        </H4>
-      </Text>
-      <div className="listing-button">{makeSubmissionButton(overview, index)}</div>
-    </div>
-  );
-
   // Rendering Logic
   const assessmentConfigToLoad = useLoaderData() as AssessmentConfiguration;
   const assessmentOverviews = useMemo(
@@ -326,7 +154,15 @@ const Assessment: React.FC = () => {
     const isOverviewUpcoming = (overview: AssessmentOverview) =>
       !beforeNow(overview.closeAt) && !beforeNow(overview.openAt);
     const upcomingCards = sortAssessments(assessmentOverviews.filter(isOverviewUpcoming)).map(
-      (overview, index) => makeOverviewCard(overview, index, role !== Role.Student, false)
+      (overview, index) => (
+        <AssessmentOverviewCard
+          overview={overview}
+          index={index}
+          renderAttemptButton={role !== Role.Student}
+          renderGradingTooltip={false}
+          makeSubmissionButton={makeSubmissionButton}
+        />
+      )
     );
 
     /** Opened assessments, that are released and can be attempted. */
@@ -336,14 +172,30 @@ const Assessment: React.FC = () => {
       overview.status !== AssessmentStatuses.submitted;
     const openedCards = sortAssessments(
       assessmentOverviews.filter(overview => isOverviewOpened(overview))
-    ).map((overview, index) => makeOverviewCard(overview, index, true, false));
+    ).map((overview, index) => (
+      <AssessmentOverviewCard
+        overview={overview}
+        index={index}
+        renderAttemptButton
+        renderGradingTooltip={false}
+        makeSubmissionButton={makeSubmissionButton}
+      />
+    ));
 
     /** Closed assessments, that are past the due date or cannot be attempted further. */
     const closedCards = sortAssessments(
       assessmentOverviews.filter(
         overview => !isOverviewOpened(overview) && !isOverviewUpcoming(overview)
       )
-    ).map((overview, index) => makeOverviewCard(overview, index, true, true));
+    ).map((overview, index) => (
+      <AssessmentOverviewCard
+        overview={overview}
+        index={index}
+        renderAttemptButton
+        renderGradingTooltip
+        makeSubmissionButton={makeSubmissionButton}
+      />
+    ));
 
     /** Render cards */
     const upcomingCardsCollapsible = (
@@ -445,29 +297,6 @@ const Assessment: React.FC = () => {
       />
       {betchaDialog}
     </div>
-  );
-};
-
-const showGradingTooltip = (isGradingPublished: boolean) => {
-  let iconName: IconName;
-  let intent: Intent;
-  let tooltip: string;
-
-  if (isGradingPublished) {
-    iconName = IconNames.TICK;
-    intent = Intent.SUCCESS;
-    tooltip = 'Fully graded';
-  } else {
-    // shh, hide actual grading progress from users even if graded
-    iconName = IconNames.TIME;
-    intent = Intent.WARNING;
-    tooltip = 'Grading in progress';
-  }
-
-  return (
-    <Tooltip className="listing-title-tooltip" content={tooltip} placement={Position.RIGHT}>
-      <Icon icon={iconName} intent={intent} />
-    </Tooltip>
   );
 };
 

--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -154,10 +154,10 @@ const Assessment: React.FC = () => {
     const isOverviewUpcoming = (overview: AssessmentOverview) =>
       !beforeNow(overview.closeAt) && !beforeNow(overview.openAt);
     const upcomingCards = sortAssessments(assessmentOverviews.filter(isOverviewUpcoming)).map(
-      (overview, index) => (
+      overview => (
         <AssessmentOverviewCard
+          key={overview.id}
           overview={overview}
-          index={index}
           renderAttemptButton={role !== Role.Student}
           renderGradingTooltip={false}
           makeSubmissionButton={makeSubmissionButton}
@@ -172,10 +172,10 @@ const Assessment: React.FC = () => {
       overview.status !== AssessmentStatuses.submitted;
     const openedCards = sortAssessments(
       assessmentOverviews.filter(overview => isOverviewOpened(overview))
-    ).map((overview, index) => (
+    ).map(overview => (
       <AssessmentOverviewCard
+        key={overview.id}
         overview={overview}
-        index={index}
         renderAttemptButton
         renderGradingTooltip={false}
         makeSubmissionButton={makeSubmissionButton}
@@ -187,10 +187,10 @@ const Assessment: React.FC = () => {
       assessmentOverviews.filter(
         overview => !isOverviewOpened(overview) && !isOverviewUpcoming(overview)
       )
-    ).map((overview, index) => (
+    ).map(overview => (
       <AssessmentOverviewCard
+        key={overview.id}
         overview={overview}
-        index={index}
         renderAttemptButton
         renderGradingTooltip
         makeSubmissionButton={makeSubmissionButton}

--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -79,7 +79,7 @@ const Assessment: React.FC = () => {
 
   const sortAssessments = (assessments: AssessmentOverview[]) => sortBy(assessments, [a => -a.id]);
 
-  const makeSubmissionButton = (overview: AssessmentOverview, index: number) => (
+  const makeSubmissionButton = (overview: AssessmentOverview) => (
     <Tooltip
       disabled={overview.status === AssessmentStatuses.attempted}
       content={'You can finalize after saving an answer for each question!'}

--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -89,7 +89,7 @@ const Assessment: React.FC = () => {
         disabled={overview.status !== AssessmentStatuses.attempted}
         icon={IconNames.CONFIRM}
         intent={overview.status === AssessmentStatuses.attempted ? Intent.DANGER : Intent.NONE}
-        minimal={true}
+        variant="minimal"
         // intentional: each listing renders its own version of onClick
         // tslint:disable-next-line:jsx-no-lambda
         onClick={() => setBetchaAssessment(overview)}

--- a/src/commons/assessment/AssessmentInteractButton.tsx
+++ b/src/commons/assessment/AssessmentInteractButton.tsx
@@ -27,7 +27,7 @@ const AssessmentInteractButton: React.FC<Props> = ({ overview }) => {
     >
       <Button
         icon={icon}
-        minimal={true}
+        variant="minimal"
         onClick={() =>
           dispatch(
             SessionActions.acknowledgeNotifications(filterNotificationsByAssessment(overview.id))

--- a/src/commons/assessment/AssessmentInteractButton.tsx
+++ b/src/commons/assessment/AssessmentInteractButton.tsx
@@ -1,0 +1,87 @@
+import { Button } from '@blueprintjs/core';
+import { IconName, IconNames } from '@blueprintjs/icons';
+import { useDispatch } from 'react-redux';
+import { NavLink } from 'react-router';
+
+import SessionActions from '../application/actions/SessionActions';
+import { filterNotificationsByAssessment } from '../notificationBadge/NotificationBadgeHelper';
+import Constants from '../utils/Constants';
+import { useTypedSelector } from '../utils/Hooks';
+import { assessmentTypeLink } from '../utils/ParamParseHelper';
+import { AssessmentOverview, AssessmentStatuses } from './AssessmentTypes';
+
+type Props = {
+  overview: AssessmentOverview;
+};
+
+const AssessmentInteractButton: React.FC<Props> = ({ overview }) => {
+  const courseId = useTypedSelector(state => state.session.courseId);
+  const dispatch = useDispatch();
+  const { icon, label, optionalLabel } = createButtonConfiguration(overview.status);
+
+  return (
+    <NavLink
+      to={`/courses/${courseId}/${assessmentTypeLink(overview.type)}/${overview.id.toString()}/${
+        Constants.defaultQuestionId
+      }`}
+    >
+      <Button
+        icon={icon}
+        minimal={true}
+        onClick={() =>
+          dispatch(
+            SessionActions.acknowledgeNotifications(filterNotificationsByAssessment(overview.id))
+          )
+        }
+      >
+        <span data-testid="Assessment-Attempt-Button">{label}</span>
+        {optionalLabel && <span className="custom-hidden-xxxs">{optionalLabel}</span>}
+      </Button>
+    </NavLink>
+  );
+};
+
+type ButtonConfiguration = {
+  icon: IconName;
+  label: string;
+  optionalLabel?: string;
+};
+
+const createButtonConfiguration = (
+  overviewStatus: AssessmentOverview['status']
+): ButtonConfiguration => {
+  let icon: IconName;
+  let label: string;
+  let optionalLabel: string | undefined;
+
+  switch (overviewStatus) {
+    case AssessmentStatuses.not_attempted:
+      icon = IconNames.PLAY;
+      label = 'Attempt';
+      break;
+    case AssessmentStatuses.attempting:
+      icon = IconNames.PLAY;
+      label = 'Continue';
+      optionalLabel = ' Attempt';
+      break;
+    case AssessmentStatuses.attempted:
+      icon = IconNames.EDIT;
+      label = 'Review';
+      optionalLabel = ' Attempt';
+      break;
+    case AssessmentStatuses.submitted:
+      icon = IconNames.EYE_OPEN;
+      label = 'Review';
+      optionalLabel = ' Submission';
+      break;
+    default:
+      // If we reach this case, backend data did not fit IAssessmentOverview
+      icon = IconNames.PLAY;
+      label = 'Review';
+      break;
+  }
+
+  return { icon, label, optionalLabel };
+};
+
+export default AssessmentInteractButton;

--- a/src/commons/assessment/AssessmentOverviewCard.tsx
+++ b/src/commons/assessment/AssessmentOverviewCard.tsx
@@ -23,7 +23,7 @@ type AssessmentOverviewCardProps = {
   /** Will only render the attempt button if true, regardless of attempt status. */
   renderAttemptButton: boolean;
   renderGradingTooltip: boolean;
-  makeSubmissionButton: (overview: AssessmentOverview, index: number) => JSX.Element;
+  makeSubmissionButton: (overview: AssessmentOverview) => JSX.Element;
 };
 
 /** A card to display `AssessmentOverview`s. */
@@ -112,7 +112,7 @@ type AssessmentOverviewCardTitleProps = {
   overview: AssessmentOverview;
   index: number;
   renderProgressStatus: boolean;
-  makeSubmissionButton: (overview: AssessmentOverview, index: number) => JSX.Element;
+  makeSubmissionButton: (overview: AssessmentOverview) => JSX.Element;
 };
 
 const AssessmentOverviewCardTitle: React.FC<AssessmentOverviewCardTitleProps> = ({
@@ -136,7 +136,7 @@ const AssessmentOverviewCardTitle: React.FC<AssessmentOverviewCardTitleProps> = 
         {renderProgressStatus ? showGradingTooltip(overview.isGradingPublished) : null}
       </H4>
     </Text>
-    <div className="listing-button">{makeSubmissionButton(overview, index)}</div>
+    <div className="listing-button">{makeSubmissionButton(overview)}</div>
   </div>
 );
 

--- a/src/commons/assessment/AssessmentOverviewCard.tsx
+++ b/src/commons/assessment/AssessmentOverviewCard.tsx
@@ -1,31 +1,16 @@
-import {
-  Button,
-  Card,
-  Elevation,
-  H4,
-  H6,
-  Icon,
-  Intent,
-  Position,
-  Text,
-  Tooltip
-} from '@blueprintjs/core';
+import { Card, Elevation, H4, H6, Icon, Intent, Position, Text, Tooltip } from '@blueprintjs/core';
 import { IconName, IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import { useDispatch } from 'react-redux';
-import { NavLink } from 'react-router';
 import classes from 'src/styles/Academy.module.scss';
 
 import defaultCoverImage from '../../assets/default_cover_image.jpg';
-import SessionActions from '../application/actions/SessionActions';
 import Markdown from '../Markdown';
 import NotificationBadge from '../notificationBadge/NotificationBadge';
 import { filterNotificationsByAssessment } from '../notificationBadge/NotificationBadgeHelper';
-import Constants from '../utils/Constants';
 import { beforeNow, getPrettyDate, getPrettyDateAfterHours } from '../utils/DateHelper';
-import { useResponsive, useTypedSelector } from '../utils/Hooks';
-import { assessmentTypeLink } from '../utils/ParamParseHelper';
-import { AssessmentOverview, AssessmentStatuses } from './AssessmentTypes';
+import { useResponsive } from '../utils/Hooks';
+import AssessmentInteractButton from './AssessmentInteractButton';
+import { AssessmentOverview } from './AssessmentTypes';
 
 type AssessmentOverviewCardProps = {
   /** The assessment overview to display */
@@ -41,9 +26,7 @@ type AssessmentOverviewCardProps = {
   makeSubmissionButton: (overview: AssessmentOverview, index: number) => JSX.Element;
 };
 
-/**
- * A card to display `AssessmentOverview`s.
- */
+/** A card to display `AssessmentOverview`s. */
 const AssessmentOverviewCard: React.FC<AssessmentOverviewCardProps> = ({
   overview,
   index,
@@ -156,67 +139,6 @@ const AssessmentOverviewCardTitle: React.FC<AssessmentOverviewCardTitleProps> = 
     <div className="listing-button">{makeSubmissionButton(overview, index)}</div>
   </div>
 );
-
-type AssessmentInteractButtonProps = {
-  overview: AssessmentOverview;
-};
-
-const AssessmentInteractButton: React.FC<AssessmentInteractButtonProps> = ({ overview }) => {
-  let icon: IconName;
-  let label: string;
-  let optionalLabel: string = '';
-
-  switch (overview.status) {
-    case AssessmentStatuses.not_attempted:
-      icon = IconNames.PLAY;
-      label = 'Attempt';
-      break;
-    case AssessmentStatuses.attempting:
-      icon = IconNames.PLAY;
-      label = 'Continue';
-      optionalLabel = ' Attempt';
-      break;
-    case AssessmentStatuses.attempted:
-      icon = IconNames.EDIT;
-      label = 'Review';
-      optionalLabel = ' Attempt';
-      break;
-    case AssessmentStatuses.submitted:
-      icon = IconNames.EYE_OPEN;
-      label = 'Review';
-      optionalLabel = ' Submission';
-      break;
-    default:
-      // If we reach this case, backend data did not fit IAssessmentOverview
-      icon = IconNames.PLAY;
-      label = 'Review';
-      break;
-  }
-
-  const courseId = useTypedSelector(state => state.session.courseId);
-  const dispatch = useDispatch();
-
-  return (
-    <NavLink
-      to={`/courses/${courseId}/${assessmentTypeLink(overview.type)}/${overview.id.toString()}/${
-        Constants.defaultQuestionId
-      }`}
-    >
-      <Button
-        icon={icon}
-        minimal={true}
-        onClick={() =>
-          dispatch(
-            SessionActions.acknowledgeNotifications(filterNotificationsByAssessment(overview.id))
-          )
-        }
-      >
-        <span data-testid="Assessment-Attempt-Button">{label}</span>
-        <span className="custom-hidden-xxxs">{optionalLabel}</span>
-      </Button>
-    </NavLink>
-  );
-};
 
 const showGradingTooltip = (isGradingPublished: boolean) => {
   let iconName: IconName;

--- a/src/commons/assessment/AssessmentOverviewCard.tsx
+++ b/src/commons/assessment/AssessmentOverviewCard.tsx
@@ -1,0 +1,244 @@
+import {
+  Button,
+  Card,
+  Elevation,
+  H4,
+  H6,
+  Icon,
+  Intent,
+  Position,
+  Text,
+  Tooltip
+} from '@blueprintjs/core';
+import { IconName, IconNames } from '@blueprintjs/icons';
+import classNames from 'classnames';
+import { useDispatch } from 'react-redux';
+import { NavLink } from 'react-router';
+import classes from 'src/styles/Academy.module.scss';
+
+import defaultCoverImage from '../../assets/default_cover_image.jpg';
+import SessionActions from '../application/actions/SessionActions';
+import Markdown from '../Markdown';
+import NotificationBadge from '../notificationBadge/NotificationBadge';
+import { filterNotificationsByAssessment } from '../notificationBadge/NotificationBadgeHelper';
+import Constants from '../utils/Constants';
+import { beforeNow, getPrettyDate, getPrettyDateAfterHours } from '../utils/DateHelper';
+import { useResponsive, useTypedSelector } from '../utils/Hooks';
+import { assessmentTypeLink } from '../utils/ParamParseHelper';
+import { AssessmentOverview, AssessmentStatuses } from './AssessmentTypes';
+
+type AssessmentOverviewCardProps = {
+  /** The assessment overview to display */
+  overview: AssessmentOverview;
+  /**
+   * A unique number for this card (required for sequential rendering).
+   * See {@link https://reactjs.org/docs/lists-and-keys.html#keys}
+   */
+  index: number;
+  /** Will only render the attempt button if true, regardless of attempt status. */
+  renderAttemptButton: boolean;
+  renderGradingTooltip: boolean;
+  makeSubmissionButton: (overview: AssessmentOverview, index: number) => JSX.Element;
+};
+
+/**
+ * A card to display `AssessmentOverview`s.
+ */
+const AssessmentOverviewCard: React.FC<AssessmentOverviewCardProps> = ({
+  overview,
+  index,
+  renderAttemptButton,
+  renderGradingTooltip,
+  makeSubmissionButton
+}) => {
+  const { isMobileBreakpoint } = useResponsive();
+  return (
+    <div key={index}>
+      <Card className="row listing" elevation={Elevation.ONE}>
+        <div className={classNames('listing-picture', !isMobileBreakpoint && 'col-xs-3')}>
+          <NotificationBadge
+            className="badge"
+            notificationFilter={filterNotificationsByAssessment(overview.id)}
+            large={true}
+          />
+          <img
+            alt="Assessment"
+            className={`cover-image-${overview.status}`}
+            src={overview.coverImage ? overview.coverImage : defaultCoverImage}
+          />
+        </div>
+        <div className={classNames('listing-text', !isMobileBreakpoint && 'col-xs-9')}>
+          <AssessmentOverviewCardTitle
+            overview={overview}
+            index={index}
+            renderProgressStatus={renderGradingTooltip}
+            makeSubmissionButton={makeSubmissionButton}
+          />
+          <div className={classes['listing-xp']}>
+            <H6>
+              {overview.isGradingPublished
+                ? `XP: ${overview.xp} / ${overview.maxXp}`
+                : `Max XP: ${overview.maxXp}`}
+            </H6>
+            {overview.earlySubmissionXp > 0 && (
+              <Tooltip
+                content={`Max XP ends on ${getPrettyDateAfterHours(overview.openAt, overview.hoursBeforeEarlyXpDecay)}`}
+              >
+                <Icon icon={IconNames.INFO_SIGN} />
+              </Tooltip>
+            )}
+          </div>
+          <div className="listing-description">
+            <Markdown content={overview.shortSummary} />
+          </div>
+          {overview.maxTeamSize > 1 ? (
+            <div className="listing-team_information">
+              <H6> This is a team assessment. </H6>
+            </div>
+          ) : (
+            <div>
+              <H6> This is an individual assessment. </H6>
+            </div>
+          )}
+          <div className="listing-footer">
+            <div>
+              <Text className="listing-due-date">
+                <Icon className="listing-due-icon" size={12} icon={IconNames.CALENDAR} />
+                {`${beforeNow(overview.openAt) ? 'Opened' : 'Opens'}: ${getPrettyDate(
+                  overview.openAt
+                )}`}
+              </Text>
+              {beforeNow(overview.openAt) && (
+                <Text className="listing-due-date">
+                  <Icon className="listing-due-icon" size={12} icon={IconNames.TIME} />
+                  {`Due: ${getPrettyDate(overview.closeAt)}`}
+                </Text>
+              )}
+            </div>
+            <div className="listing-button">
+              {renderAttemptButton ? <AssessmentInteractButton overview={overview} /> : null}
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+type AssessmentOverviewCardTitleProps = {
+  overview: AssessmentOverview;
+  index: number;
+  renderProgressStatus: boolean;
+  makeSubmissionButton: (overview: AssessmentOverview, index: number) => JSX.Element;
+};
+
+const AssessmentOverviewCardTitle: React.FC<AssessmentOverviewCardTitleProps> = ({
+  overview,
+  index,
+  renderProgressStatus,
+  makeSubmissionButton
+}) => (
+  <div className="listing-header">
+    <Text ellipsize={true}>
+      <H4 className="listing-title">
+        {overview.title}
+        {overview.private ? (
+          <Tooltip
+            className="listing-title-tooltip"
+            content="This assessment is password-protected."
+          >
+            <Icon icon="lock" />
+          </Tooltip>
+        ) : null}
+        {renderProgressStatus ? showGradingTooltip(overview.isGradingPublished) : null}
+      </H4>
+    </Text>
+    <div className="listing-button">{makeSubmissionButton(overview, index)}</div>
+  </div>
+);
+
+type AssessmentInteractButtonProps = {
+  overview: AssessmentOverview;
+};
+
+const AssessmentInteractButton: React.FC<AssessmentInteractButtonProps> = ({ overview }) => {
+  let icon: IconName;
+  let label: string;
+  let optionalLabel: string = '';
+
+  switch (overview.status) {
+    case AssessmentStatuses.not_attempted:
+      icon = IconNames.PLAY;
+      label = 'Attempt';
+      break;
+    case AssessmentStatuses.attempting:
+      icon = IconNames.PLAY;
+      label = 'Continue';
+      optionalLabel = ' Attempt';
+      break;
+    case AssessmentStatuses.attempted:
+      icon = IconNames.EDIT;
+      label = 'Review';
+      optionalLabel = ' Attempt';
+      break;
+    case AssessmentStatuses.submitted:
+      icon = IconNames.EYE_OPEN;
+      label = 'Review';
+      optionalLabel = ' Submission';
+      break;
+    default:
+      // If we reach this case, backend data did not fit IAssessmentOverview
+      icon = IconNames.PLAY;
+      label = 'Review';
+      break;
+  }
+
+  const courseId = useTypedSelector(state => state.session.courseId);
+  const dispatch = useDispatch();
+
+  return (
+    <NavLink
+      to={`/courses/${courseId}/${assessmentTypeLink(overview.type)}/${overview.id.toString()}/${
+        Constants.defaultQuestionId
+      }`}
+    >
+      <Button
+        icon={icon}
+        minimal={true}
+        onClick={() =>
+          dispatch(
+            SessionActions.acknowledgeNotifications(filterNotificationsByAssessment(overview.id))
+          )
+        }
+      >
+        <span data-testid="Assessment-Attempt-Button">{label}</span>
+        <span className="custom-hidden-xxxs">{optionalLabel}</span>
+      </Button>
+    </NavLink>
+  );
+};
+
+const showGradingTooltip = (isGradingPublished: boolean) => {
+  let iconName: IconName;
+  let intent: Intent;
+  let tooltip: string;
+
+  if (isGradingPublished) {
+    iconName = IconNames.TICK;
+    intent = Intent.SUCCESS;
+    tooltip = 'Fully graded';
+  } else {
+    // shh, hide actual grading progress from users even if graded
+    iconName = IconNames.TIME;
+    intent = Intent.WARNING;
+    tooltip = 'Grading in progress';
+  }
+
+  return (
+    <Tooltip className="listing-title-tooltip" content={tooltip} placement={Position.RIGHT}>
+      <Icon icon={iconName} intent={intent} />
+    </Tooltip>
+  );
+};
+
+export default AssessmentOverviewCard;

--- a/src/commons/assessment/AssessmentOverviewCard.tsx
+++ b/src/commons/assessment/AssessmentOverviewCard.tsx
@@ -15,11 +15,6 @@ import { AssessmentOverview } from './AssessmentTypes';
 type AssessmentOverviewCardProps = {
   /** The assessment overview to display */
   overview: AssessmentOverview;
-  /**
-   * A unique number for this card (required for sequential rendering).
-   * See {@link https://reactjs.org/docs/lists-and-keys.html#keys}
-   */
-  index: number;
   /** Will only render the attempt button if true, regardless of attempt status. */
   renderAttemptButton: boolean;
   renderGradingTooltip: boolean;
@@ -29,14 +24,13 @@ type AssessmentOverviewCardProps = {
 /** A card to display `AssessmentOverview`s. */
 const AssessmentOverviewCard: React.FC<AssessmentOverviewCardProps> = ({
   overview,
-  index,
   renderAttemptButton,
   renderGradingTooltip,
   makeSubmissionButton
 }) => {
   const { isMobileBreakpoint } = useResponsive();
   return (
-    <div key={index}>
+    <div>
       <Card className="row listing" elevation={Elevation.ONE}>
         <div className={classNames('listing-picture', !isMobileBreakpoint && 'col-xs-3')}>
           <NotificationBadge
@@ -53,7 +47,6 @@ const AssessmentOverviewCard: React.FC<AssessmentOverviewCardProps> = ({
         <div className={classNames('listing-text', !isMobileBreakpoint && 'col-xs-9')}>
           <AssessmentOverviewCardTitle
             overview={overview}
-            index={index}
             renderProgressStatus={renderGradingTooltip}
             makeSubmissionButton={makeSubmissionButton}
           />
@@ -110,14 +103,12 @@ const AssessmentOverviewCard: React.FC<AssessmentOverviewCardProps> = ({
 
 type AssessmentOverviewCardTitleProps = {
   overview: AssessmentOverview;
-  index: number;
   renderProgressStatus: boolean;
   makeSubmissionButton: (overview: AssessmentOverview) => JSX.Element;
 };
 
 const AssessmentOverviewCardTitle: React.FC<AssessmentOverviewCardTitleProps> = ({
   overview,
-  index,
   renderProgressStatus,
   makeSubmissionButton
 }) => (

--- a/src/commons/assessment/__tests__/__snapshots__/Assessment.test.tsx.snap
+++ b/src/commons/assessment/__tests__/__snapshots__/Assessment.test.tsx.snap
@@ -1130,9 +1130,6 @@ exports[`Assessment page with multiple loaded missions renders correctly 1`] = `
                             >
                               Attempt
                             </span>
-                            <span
-                              className="custom-hidden-xxxs"
-                            />
                           </span>
                         </button>
                       </a>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Wow, this bug is 4 years old.

Indices should not be used as memoization keys. When switching between assessment types, the old image is still shown while the new one loads. Thus if the image load fails, nothing happens.

This fixes it, ensuring the entire assessment card is tied to the assessment ID, thus switching immediately updates the UI to loading state.

Also moves components to use FC instead of function calls as part of the fix (so that `key` prop works without drilling).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
