### PR TITLE
Fix error when grading assessment where student has empty name

### DIFF
--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -53,6 +53,20 @@ type Props = {
   questionId: number;
 };
 
+const getDisplayName = (
+  studentName?: string | null,
+  team?: {
+    username: any;
+    name: string;
+    id: number;
+  }[]
+): string[] => {
+  if (studentName != null) return [studentName];
+  if (team != null) return team.map(member => member.name);
+
+  return [''];
+};
+
 const GradingWorkspace: React.FC<Props> = props => {
   const navigate = useNavigate();
   const { selectedTab, setSelectedTab } = useSideContent(
@@ -294,11 +308,10 @@ const GradingWorkspace: React.FC<Props> = props => {
             initialXp={grading!.answers[questionId].grade.xp}
             xpAdjustment={grading!.answers[questionId].grade.xpAdjustment}
             maxXp={grading!.answers[questionId].question.maxXp}
-            studentNames={
-              grading!.answers[questionId].student.name
-                ? [grading!.answers[questionId].student.name]
-                : grading!.answers[questionId].team!.map(member => member.name)
-            }
+            studentNames={getDisplayName(
+              grading!.answers[questionId].student.name,
+              grading!.answers[questionId].team
+            )}
             studentUsernames={
               grading!.answers[questionId].student.username
                 ? [grading!.answers[questionId].student.username]

--- a/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
+++ b/src/pages/academy/grading/subcomponents/GradingWorkspace.tsx
@@ -61,7 +61,7 @@ const getDisplayName = (
     id: number;
   }[]
 ): string[] => {
-  if (studentName != null) return [studentName];
+  if (studentName) return [studentName];
   if (team != null) return team.map(member => member.name);
 
   return [''];


### PR DESCRIPTION
### Description

Resolve #3324. Caused by a parsing error on the frontend side when determining the name to show in the grading workspace.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Check that you can enter grading workspace for a student with an empty name

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
- [ ] I have updated the documentation
