### PR TITLE
Fix mobile Stepper Run evaluator

### DIFF
--- a/src/commons/sideContent/SideContentHelper.test.tsx
+++ b/src/commons/sideContent/SideContentHelper.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import createMockStore from 'redux-mock-store';
+import { CONDUCTOR_STEPPER_TAB_ID } from 'src/features/conductor/stepperTab';
+import { describe, expect, test } from 'vitest';
+
+import type { OverallState } from '../application/ApplicationTypes';
+import { useSideContent } from './SideContentHelper';
+import { type SideContentTabId, SideContentType } from './SideContentTypes';
+
+const renderUseSideContent = (selectedTab: SideContentTabId) => {
+  const store = createMockStore<OverallState>()({
+    sideContent: {
+      playground: {
+        alerts: [],
+        dynamicTabs: [],
+        selectedTab,
+      },
+    },
+  } as unknown as OverallState);
+  const hook = renderHook(() => useSideContent('playground'), {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  });
+  return { hook, store };
+};
+
+describe('useSideContent', () => {
+  test('keeps the conductor Stepper selected when mobile Run is pressed', () => {
+    const { hook, store } = renderUseSideContent(CONDUCTOR_STEPPER_TAB_ID);
+
+    act(() => hook.result.current.setSelectedTab(SideContentType.mobileEditorRun));
+
+    expect(store.getActions()).toEqual([]);
+  });
+
+  test('selects mobile Run from a regular tab', () => {
+    const { hook, store } = renderUseSideContent(SideContentType.mobileEditor);
+
+    act(() => hook.result.current.setSelectedTab(SideContentType.mobileEditorRun));
+
+    expect(store.getActions()).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({ newId: SideContentType.mobileEditorRun }),
+      }),
+    ]);
+  });
+});

--- a/src/commons/sideContent/SideContentHelper.ts
+++ b/src/commons/sideContent/SideContentHelper.ts
@@ -19,6 +19,7 @@ import ReactDOM from 'react-dom';
 import * as ReactDOMClient from 'react-dom/client';
 import * as ReactKonva from 'react-konva';
 import { useAppDispatch } from 'src/commons/utils/Hooks';
+import { CONDUCTOR_STEPPER_TAB_ID } from 'src/features/conductor/stepperTab';
 
 import { useAppSelector } from '../utils/Hooks';
 import type { DebuggerContext } from '../workspace/WorkspaceTypes';
@@ -103,7 +104,8 @@ export const useSideContent = (location: SideContentLocation, defaultTab?: SideC
     (newId: SideContentTabId) => {
       if (
         (selectedTab === SideContentType.substVisualizer ||
-          selectedTab === SideContentType.cseMachine) &&
+          selectedTab === SideContentType.cseMachine ||
+          selectedTab === CONDUCTOR_STEPPER_TAB_ID) &&
         newId === SideContentType.mobileEditorRun
       ) {
         return;


### PR DESCRIPTION
### Description

Keeps the Conductor Stepper tab selected when mobile Run is pressed, so execution continues with the Stepper evaluator.

Fixes #4262.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

- `yarn test src/commons/sideContent/SideContentHelper.test.tsx`
- `yarn test`
- `yarn run tsc`
- `yarn lint`
- `yarn build`

### Checklist

- [x] I have tested this code