### PR TITLE
Fix Stepper tab stuck on "Loading the stepper..." after a preload failure

### DIFF
--- a/src/commons/sagas/helpers/conductorEvaluatorCache.test.ts
+++ b/src/commons/sagas/helpers/conductorEvaluatorCache.test.ts
@@ -205,4 +205,40 @@ describe('conductorEvaluatorCache', () => {
     expect(conductor.conduit.terminate).toHaveBeenCalled();
     expect(unregisterAllSpy).toHaveBeenCalled();
   });
+
+  test('a preload that fails once still activates on a later retry for the same path', async () => {
+    // Regression: activation used to be gated on "did the requested path change since the last
+    // call", which stays false forever once a path is requested - even if that attempt failed
+    // (e.g. the evaluator's own fetch failing, such as a transient failure fetching the
+    // plugin/evaluator from an external host). So once a transient failure hit here, no amount of
+    // re-selecting the very same path (e.g. re-opening the Stepper tab) would ever activate it
+    // again, even after the underlying issue resolved - only a differently-triggered Run (which
+    // bypasses this gate entirely - see getPreparedConductorSaga) could still show it.
+    const languageId = 'lang-retry-after-failure';
+    const env = makeEnv(() => languageId);
+    const activateSpy = vi.spyOn(DeferredConductorTabService.prototype, 'activate');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    );
+    await expect(
+      runSaga(env, preloadConductorEvaluatorSaga, '/evaluator-flaky.mjs').toPromise(),
+    ).rejects.toThrow();
+    expect(createConductorMock).not.toHaveBeenCalled();
+    expect(activateSpy).not.toHaveBeenCalled();
+
+    // The network recovers; re-selecting the very same path (e.g. re-opening the Stepper tab)
+    // must still activate it now that preparation actually succeeds.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, blob: async () => new Blob() }) as unknown as Response),
+    );
+    mockCreateConductorOnce();
+    await runSaga(env, preloadConductorEvaluatorSaga, '/evaluator-flaky.mjs').toPromise();
+
+    expect(activateSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/commons/sagas/helpers/conductorEvaluatorCache.ts
+++ b/src/commons/sagas/helpers/conductorEvaluatorCache.ts
@@ -334,7 +334,17 @@ export function* preloadConductorEvaluatorSaga(
   }
 
   const session: ConductorSession = yield call(ensureConductorSessionSaga);
-  const evaluatorChanged = session.currentEvaluatorPath !== path;
+  // Whether *activation* is still needed for `path`, i.e. whether it isn't already the one whose
+  // tabs are surfaced. Deliberately checked against activeConductor (what actually got activated),
+  // not currentEvaluatorPath (what was last *requested*, set unconditionally just below regardless
+  // of outcome) - otherwise a preload that fails here (e.g. the evaluator fetch itself failing,
+  // such as a transient fetch of the plugin/evaluator from an external host) would leave
+  // currentEvaluatorPath already pointing at `path`, so every later retry for the very same path
+  // (e.g. re-opening the Stepper tab) would see "no change" and skip activateConductor even once
+  // preparation finally succeeds - stuck showing the tab's loading placeholder indefinitely, since
+  // nothing but a differently-pathed Run (which never consults this flag - see
+  // getPreparedConductorSaga) would ever surface it.
+  const needsActivation = session.activeConductor?.path !== path;
   session.currentEvaluatorPath = path;
 
   let prepared: PreparedConductor;
@@ -352,10 +362,11 @@ export function* preloadConductorEvaluatorSaga(
     throw error;
   }
 
-  // On an evaluator switch, surface the newly-prepared conductor's tabs (e.g. show the Stepper's
-  // empty welcome tab on selection). A same-evaluator warm-up spawned after a Run leaves the active
-  // conductor untouched, so its populated tab is not replaced by the idle spare.
-  if (evaluatorChanged) {
+  // Surface the newly-prepared conductor's tabs (e.g. show the Stepper's empty welcome tab on
+  // selection) whenever it isn't already the active one. A same-evaluator warm-up spawned after a
+  // Run leaves the active conductor untouched, so its populated tab is not replaced by the idle
+  // spare.
+  if (needsActivation) {
     activateConductor(session, prepared);
   }
 }


### PR DESCRIPTION
## Summary

Reported on SICPy (`https://sourceacademy.org/sicpy/1.1.1`, but not SICPy-specific — see below): opening the Stepper tab on a code snippet showed "Loading the stepper..." indefinitely, regardless of how long you waited. Only pressing Run made the actual stepper bar appear.

Reproduced live and caught the trigger in the console:
```
Failed to preload: TypeError: Failed to fetch (source-academy.github.io)
Conductor: no web resolution for plugin "stepper" (is directory.plugin.url set?)
```
A transient network failure fetching the stepper plugin. But the real bug is what happens *after*: even once the network recovered, re-opening the Stepper tab still didn't work — only Run did (confirmed live: "for a while the stepper didn't work at all, even after pressing Run. but now it works again after pressing Run. the message is still there until Run is pressed").

## Root cause

`preloadConductorEvaluatorSaga` decided whether to surface a newly-prepared conductor's tabs (`activateConductor`) by comparing the requested path against `currentEvaluatorPath` — but that field is set unconditionally, *before* knowing whether preparation actually succeeded:

```ts
const evaluatorChanged = session.currentEvaluatorPath !== path;
session.currentEvaluatorPath = path;          // set regardless of outcome
try {
  prepared = yield call(ensurePreparedConductorSaga, session, path, options);
} catch (error) { ... throw error; }
if (evaluatorChanged) {
  activateConductor(session, prepared);       // never reached on failure
}
```

So once a path's preload failed once, `currentEvaluatorPath` already equalled that path. Every later retry for the *very same path* (e.g. re-opening the Stepper tab) then saw `evaluatorChanged === false` and silently skipped activation — forever, even after a later attempt genuinely succeeded. Only Run recovered, since `getPreparedConductorSaga` (its code path) never consults this flag at all — it always forces a fresh attempt.

## Fix

Bases the decision on whether the *active* conductor's path already matches (`session.activeConductor?.path !== path`) instead. That field only updates inside `activateConductor` itself, on an actual successful activation — so a failed attempt leaves it untouched, and every later retry for that path keeps trying to activate until one finally succeeds. Verified this preserves both cases the original gate existed for: switching evaluators still activates, and a post-Run same-evaluator warm spare still doesn't clobber the populated tab already on screen (existing tests for both still pass).

## Test plan

- [x] Added a regression test reproducing the exact failure → retry sequence (mocked `fetch` failure, then a successful retry for the same path); confirmed it **fails without the fix** (`activate()` called 0 times instead of 1) and **passes with it**
- [x] All existing tests in `conductorEvaluatorCache.test.ts` and `deferredConductorTabService.test.ts` still pass (20/20)
- [x] `tsc`, `eslint`, `oxfmt` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsEaJ8SQRH4QkXir4JSs4S