### PR TITLE
Fix Stepper tab stuck on "Loading the stepper..." on SICPy pages

### DIFF
--- a/src/commons/sagas/helpers/conductorEvaluatorCache.test.ts
+++ b/src/commons/sagas/helpers/conductorEvaluatorCache.test.ts
@@ -184,6 +184,50 @@ describe('conductorEvaluatorCache', () => {
     expect(abandonedConductor!.conduit.terminate).toHaveBeenCalled();
   });
 
+  test('a stale preload for an older selection does not deactivate a newer one that already won', async () => {
+    // Regression for source-academy/frontend#4275: on SICP pages, opening a snippet auto-selects the
+    // default evaluator (kicking off its own preload) and the user can click straight into the
+    // Stepper tab - a second, concurrent preload for a different path - before the first settles.
+    // Nothing guarantees the two resolve in request order; if the older, slower preload wins the
+    // race, it must not retroactively deactivate the newer conductor's tabService.
+    const languageId = 'lang-tab-race';
+    const env = makeEnv(() => languageId);
+    let resolveOld: () => void = () => {};
+    const oldGate = new Promise<void>(resolve => {
+      resolveOld = resolve;
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (path: string) => {
+        if (path === '/evaluator-old.mjs') {
+          await oldGate;
+        }
+        return { ok: true, blob: async () => new Blob() } as unknown as Response;
+      }),
+    );
+    mockCreateConductorOnce();
+    mockCreateConductorOnce();
+
+    const activateSpy = vi.spyOn(DeferredConductorTabService.prototype, 'activate');
+
+    // The older (default-evaluator) selection starts first but is stuck resolving its evaluator...
+    const oldTask = runSaga(env, preloadConductorEvaluatorSaga, '/evaluator-old.mjs').toPromise();
+    // ...the user immediately picks something else (e.g. clicking the Stepper tab) before it settles.
+    await runSaga(env, preloadConductorEvaluatorSaga, '/evaluator-new.mjs').toPromise();
+    const activatedPaths = () =>
+      activateSpy.mock.instances.map(
+        instance => (instance as DeferredConductorTabService).evaluatorPath,
+      );
+    expect(activatedPaths()).toEqual(['/evaluator-new.mjs']);
+
+    // Now let the stale, older request finally resolve - it must not activate at all, since a newer
+    // selection has since superseded it.
+    resolveOld();
+    await oldTask;
+    expect(activatedPaths()).toEqual(['/evaluator-new.mjs']);
+  });
+
   test('a conductor whose conduit.terminate() throws still gets its tabs unregistered', async () => {
     let languageId = 'lang-throw-old';
     const env = makeEnv(() => languageId);

--- a/src/commons/sagas/helpers/conductorEvaluatorCache.ts
+++ b/src/commons/sagas/helpers/conductorEvaluatorCache.ts
@@ -366,7 +366,18 @@ export function* preloadConductorEvaluatorSaga(
   // selection) whenever it isn't already the active one. A same-evaluator warm-up spawned after a
   // Run leaves the active conductor untouched, so its populated tab is not replaced by the idle
   // spare.
-  if (needsActivation) {
+  //
+  // Also re-checked against currentEvaluatorPath (the most recently *requested* path, set
+  // synchronously above before any yield) rather than acting unconditionally on `needsActivation`
+  // alone: two preloads for different paths can run concurrently (e.g. a hash-driven default-
+  // evaluator selection racing a near-immediate Stepper-tab click), and nothing here guarantees
+  // they resolve in request order. Without this check, a stale request for the *older* selection
+  // resolving after a newer one would call activateConductor and deactivate the newer conductor's
+  // tabService - and if that conductor's web plugin hadn't registered its tab yet, the
+  // registration would land after deactivation and never reach the shared sideContentManager,
+  // leaving the tab (e.g. the Stepper) stuck on its loading placeholder forever. See
+  // source-academy/frontend#4275.
+  if (needsActivation && session.currentEvaluatorPath === path) {
     activateConductor(session, prepared);
   }
 }


### PR DESCRIPTION
## Summary
- Fixes a residual case of the Stepper tab getting stuck on its "Loading the stepper…" placeholder, reported specifically on SICPy pages (not reproducible in the plain Playground) even after #4274.
- Root cause: on a SICPy snippet page, opening a snippet auto-selects the default evaluator via the URL hash, which kicks off `preloadConductorEvaluatorSaga` for its path. If the user clicks the Stepper tab before that settles, a second, concurrent preload starts for the Stepper's own evaluator path (`takeEvery` doesn't cancel the first). Nothing guaranteed the two resolved in request order — if the older (default-evaluator) preload happened to finish *after* the Stepper's, it called `activateConductor` again and deactivated the Stepper's `tabService`. If the Stepper's web plugin hadn't registered its tab yet at that point, the registration landed after deactivation and never reached the shared `sideContentManager`, leaving the tab stuck on its placeholder forever — only a subsequent Run (which bypasses this activation path entirely) could force it to appear. This exact race was previously documented in #4275.
- Fix: gate `activateConductor` on `session.currentEvaluatorPath === path` — that field already tracks the most recently *requested* path (set synchronously before any yield), so a stale, late-resolving preload can no longer clobber a newer one's activation, regardless of which one's async preparation happens to finish first.

## Test plan
- [x] Added a regression test (`conductorEvaluatorCache.test.ts`) that races two concurrent preloads for different paths where the older one resolves last, and asserts it never activates once superseded. Verified it fails without the fix and passes with it.
- [x] `yarn vitest run src/commons/sagas/helpers/conductorEvaluatorCache.test.ts` — 8/8 passing
- [x] `npx tsc --noEmit` and `eslint` clean on touched files
- [x] Manually reproduced the bug on production (sourceacademy.org/sicpy) prior to this fix: opening a snippet then clicking the Stepper tab left it stuck on "Loading the stepper…" indefinitely with no network/console errors, resolving only after clicking Run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsEaJ8SQRH4QkXir4JSs4S