### PR TITLE
Fix Stepper tab staying stuck on "Loading the stepper..." on SICP pages

### DIFF
--- a/src/pages/playground/Playground.test.tsx
+++ b/src/pages/playground/Playground.test.tsx
@@ -214,21 +214,28 @@ describe('Playground tests', () => {
       initialEntries: ['/sicpy'],
       initialIndex: 0,
     });
-    await renderTree(router);
 
-    sideContentManager.registerTab({
-      id: 'stepper',
-      label: 'Stepper',
-      iconName: 'flow-review',
-      body: null,
-    });
-    sideContentManager.revealTab('stepper');
-
-    expect(sideContentManager.getTabs('sicp').map(t => t.id)).toContain('stepper');
-
-    // Avoid leaking singleton state into other tests in this file.
-    sideContentManager.unregisterTab('stepper');
+    // Deterministic regardless of what a prior test in this file left the singleton on - otherwise
+    // this test could pass for the wrong reason if something upstream already left it at 'sicp'.
     sideContentManager.setWorkspaceLocation('playground');
+    try {
+      await renderTree(router);
+
+      sideContentManager.registerTab({
+        id: 'stepper',
+        label: 'Stepper',
+        iconName: 'flow-review',
+        body: null,
+      });
+      sideContentManager.revealTab('stepper');
+
+      expect(sideContentManager.getTabs('sicp').map(t => t.id)).toContain('stepper');
+    } finally {
+      // Runs even if the assertion above fails, so a failure here can't leak singleton state into
+      // other tests in this file.
+      sideContentManager.unregisterTab('stepper');
+      sideContentManager.setWorkspaceLocation('playground');
+    }
   });
 
   describe('handleHash', () => {

--- a/src/pages/playground/Playground.test.tsx
+++ b/src/pages/playground/Playground.test.tsx
@@ -14,6 +14,7 @@ import {
 } from 'src/commons/application/ApplicationTypes';
 import type { Router } from 'src/commons/application/types/CommonsTypes';
 import { visitSideContent } from 'src/commons/sideContent/SideContentActions';
+import sideContentManager from 'src/commons/sideContent/SideContentManager';
 import { SideContentType } from 'src/commons/sideContent/SideContentTypes';
 import WorkspaceActions from 'src/commons/workspace/WorkspaceActions';
 import { EditorBinding, WorkspaceSettingsContext } from 'src/commons/WorkspaceSettingsContext';
@@ -185,6 +186,49 @@ describe('Playground tests', () => {
     });
 
     expect(mockStore.getState().workspaces.playground.isFolderModeEnabled).toBe(false);
+  });
+
+  test('a conductor tab registered before any Run is visible immediately on a SICP page (#4277 follow-up)', async () => {
+    // sideContentManager is a single app-wide singleton keyed by one "current" workspace location
+    // (see its own getTabs()/setWorkspaceLocation()), and previously only Run's own
+    // getPreparedConductorSaga ever called setWorkspaceLocation() - so a conductor tab (e.g. the
+    // Stepper's) registered by a mere preload, before any Run, forwarded into sideContentManager
+    // correctly but stayed invisible: getTabs('sicp') still saw whichever location the singleton
+    // was last left on (typically 'playground'). Reproduced here without the conductor machinery -
+    // registerTab()/revealTab() stand in for what its web plugin does once loaded.
+    const sicpRoutes: RouteObject[] = [
+      {
+        path: '/sicpy',
+        element: (
+          <Provider store={mockStore}>
+            <WorkspaceSettingsContext.Provider
+              value={[{ editorBinding: EditorBinding.NONE }, vi.fn()]}
+            >
+              <Playground isSicpEditor initialEditorValueHash="" />
+            </WorkspaceSettingsContext.Provider>
+          </Provider>
+        ),
+      },
+    ];
+    const router = createMemoryRouter(sicpRoutes, {
+      initialEntries: ['/sicpy'],
+      initialIndex: 0,
+    });
+    await renderTree(router);
+
+    sideContentManager.registerTab({
+      id: 'stepper',
+      label: 'Stepper',
+      iconName: 'flow-review',
+      body: null,
+    });
+    sideContentManager.revealTab('stepper');
+
+    expect(sideContentManager.getTabs('sicp').map(t => t.id)).toContain('stepper');
+
+    // Avoid leaking singleton state into other tests in this file.
+    sideContentManager.unregisterTab('stepper');
+    sideContentManager.setWorkspaceLocation('playground');
   });
 
   describe('handleHash', () => {

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -25,7 +25,7 @@ import makeHtmlDisplayTabFrom from 'src/commons/sideContent/content/SideContentH
 import makeUploadTabFrom from 'src/commons/sideContent/content/SideContentUpload';
 import { changeSideContentHeight } from 'src/commons/sideContent/SideContentActions';
 import { useSideContent } from 'src/commons/sideContent/SideContentHelper';
-import { useTabOwnerPath } from 'src/commons/sideContent/SideContentManager';
+import sideContentManager, { useTabOwnerPath } from 'src/commons/sideContent/SideContentManager';
 import type { SourceActionType } from 'src/commons/utils/ActionsHelper';
 import { useAppDispatch, useAppSelector, useResponsive } from 'src/commons/utils/Hooks';
 import {
@@ -221,6 +221,18 @@ const EMPTY_EVALUATORS: readonly IEvaluatorDefinition[] = [];
 function Playground(props: PlaygroundProps) {
   const { isSicpEditor } = props;
   const workspaceLocation: WorkspaceLocation = isSicpEditor ? 'sicp' : 'playground';
+  // sideContentManager only shows tabs registered for whichever workspace it currently thinks is
+  // active (see its own getTabs()/setWorkspaceLocation() - it's a single app-wide value, not scoped
+  // per Provider). Previously the only place that ever called setWorkspaceLocation() was Run's own
+  // getPreparedConductorSaga, so a conductor tab (e.g. the Stepper's) that got registered by a mere
+  // preload - selecting the Stepper tab before ever pressing Run - forwarded into sideContentManager
+  // correctly, but stayed invisible: getTabs('sicp') still saw whatever location the last Run (on
+  // any workspace) had left behind, most often the default 'playground'. The tab only appeared once
+  // a Run finally called setWorkspaceLocation('sicp'). Setting it here as soon as this Playground
+  // instance knows its own location closes that gap for every conductor tab, not just the Stepper's.
+  useEffect(() => {
+    sideContentManager.setWorkspaceLocation(workspaceLocation);
+  }, [workspaceLocation]);
   const { isMobileBreakpoint } = useResponsive();
   const isVscode = useAppSelector(state => state.vscode.isVscode);
 


### PR DESCRIPTION
## Summary
- Follow-up to #4277: after that fix, opening a SICPy snippet and clicking the Stepper tab *still* got stuck on "Loading the stepper…" forever, with no network or console errors — confirmed live on production even on the already-deployed #4277 fix, and reproduced locally with full debug tracing.
- Root cause: `sideContentManager` (`src/commons/sideContent/SideContentManager.ts`) is a single app-wide singleton keyed by one "current" workspace location — `getTabs(loc)` returns nothing unless `loc` matches whatever `setWorkspaceLocation()` last set. The *only* call site for `setWorkspaceLocation()` was inside `getPreparedConductorSaga`, itself only invoked by an actual Run. So on a SICP page (workspace location `'sicp'`), a conductor tab (e.g. the Stepper's) that registers itself from a mere preload — selecting the Stepper tab before ever pressing Run — forwards into `sideContentManager` correctly (traced and confirmed: `activate()` → `registerTab()` → `active: true`), but stays invisible, because `getTabs('sicp')` still sees whatever location the singleton was last left on (typically the default `'playground'`). The tab only appeared once a Run finally called `setWorkspaceLocation('sicp')`.
- This is a different, deeper bug than the activation-ordering race fixed in #4277 — that fix was necessary but not sufficient. A conductor tab can activate and register *perfectly* and still never be visible if the shared manager's location hasn't been synced yet.
- Fix (`src/pages/playground/Playground.tsx`): sync `sideContentManager`'s workspace location eagerly, in an effect keyed on `workspaceLocation`, as soon as a `Playground` instance knows its own location — instead of waiting for a Run to do it as a side effect.

## Test plan
- [x] Added a regression test (`Playground.test.tsx`) that renders `<Playground isSicpEditor />`, registers a tab directly on the shared `sideContentManager` singleton (standing in for what a conductor's web plugin does once loaded, without needing to stand up the whole conductor/worker machinery), and asserts it's visible under the `'sicp'` workspace location immediately, with no Run. Verified it fails without the fix and passes with it.
- [x] `yarn vitest run src/pages/playground/Playground.test.tsx` — 7/7 passing; broader sweep of `src/pages/playground`, `src/commons/sideContent`, `src/features/conductor`, and `conductorEvaluatorCache.test.ts` — 63/63 passing
- [x] `npx tsc --noEmit` and `eslint` clean on touched files (two pre-existing, unrelated warnings on `Playground.tsx` confirmed present on `master` too)
- [x] Manually reproduced end-to-end on a local dev server pointed at the real SICPy content backend: opening a snippet then clicking the Stepper tab (before Run) previously stuck on "Loading the stepper…" indefinitely; with this fix, "Welcome to the Stepper!" appears immediately, verified repeatedly across different sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsEaJ8SQRH4QkXir4JSs4S