### PR TITLE
Bump language-directory to 0.0.22; use per-language defaultProgram

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/common-tabs": "^0.0.1",
     "@sourceacademy/conductor": "^0.8.3",
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.21",
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.22",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.4",
     "@sourceacademy/runner-module-loader": "^0.1.0",
     "@sourceacademy/sharedb-ace": "2.1.1",

--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -78,21 +78,18 @@ const languageDirectoryHandlers = combineSagaHandlers({
   },
   [LanguageDirectoryActions.setSelectedEvaluator.type]: function* () {
     const evaluator = yield call(getEvaluatorDefinitionSaga);
+    const language: ILanguageDefinition = yield call(getLanguageDefinitionSaga);
 
-    // Set the evaluator's default editor program when switching evaluators, but only while the
-    // editor still holds the untouched default (never clobber code the user has written).
-    if (evaluator?.defaultProgram != null) {
+    // Set the default editor program when switching evaluators, preferring the evaluator's own
+    // default and falling back to the language's, but only while the editor still holds the
+    // untouched default (never clobber code the user has written).
+    const defaultProgram = evaluator?.defaultProgram ?? language?.defaultProgram;
+    if (defaultProgram != null) {
       const playground = yield select((state: OverallState) => state.workspaces.playground);
       const activeTabIndex: number = playground.activeEditorTabIndex ?? 0;
       const editorValue: string = playground.editorTabs[activeTabIndex]?.value ?? '';
       if (editorValue === defaultEditorValue) {
-        yield put(
-          WorkspaceActions.updateEditorValue(
-            'playground',
-            activeTabIndex,
-            evaluator.defaultProgram,
-          ),
-        );
+        yield put(WorkspaceActions.updateEditorValue('playground', activeTabIndex, defaultProgram));
       }
     }
 

--- a/src/pages/playground/Playground.test.tsx
+++ b/src/pages/playground/Playground.test.tsx
@@ -79,7 +79,10 @@ describe('Playground tests', () => {
     expect(tree).toMatchSnapshot();
 
     expect(getSourceChapterFromStore(mockStore)).toBe(defaultPlayground.languageConfig.chapter);
-    expect(getEditorValueFromStore(mockStore)).toBe(defaultEditorValue);
+    // The bundled language directory's first language (Python §1) supplies its own
+    // defaultProgram, which should replace the generic JS-flavoured defaultEditorValue.
+    expect(getEditorValueFromStore(mockStore)).not.toBe(defaultEditorValue);
+    expect(getEditorValueFromStore(mockStore)).toBe('# Type your program in here!\n\n');
   });
 
   test('Playground with link renders correctly', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4268,10 +4268,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.21":
-  version: 0.0.21
-  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=b6b2f163dc4f6be6ea9574c7e105a4971292470b"
-  checksum: 10c0/691fd19d517a7ec2709a3cfe6e7f6be5fe0aaf87b825481ad9df98beab9702d756c23444ba8c7cd01ce78d4319180c64af41fd456d3f684c0000258a5a5b81b2
+"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.22":
+  version: 0.0.22
+  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=bd2198d2fa9d2311dea5b8cf200937c9b80f857e"
+  checksum: 10c0/c153c3c0eb0c449ec323c4e2d95b29614724cb04192a31479bfaae641839959285a27d546385b25ff52c90c9d598a16ae39adbfb0476d7fa40efffd59b93784c
   languageName: node
   linkType: hard
 
@@ -8611,7 +8611,7 @@ __metadata:
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/common-tabs": "npm:^0.0.1"
     "@sourceacademy/conductor": "npm:^0.8.3"
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.21"
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.22"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.4"
     "@sourceacademy/runner-module-loader": "npm:^0.1.0"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"


### PR DESCRIPTION
## Summary
- Bump `@sourceacademy/language-directory` to `0.0.22`, which adds a `defaultProgram` field to `ILanguageDefinition` (alongside the existing evaluator-level field of the same name).
- The Playground's `setSelectedEvaluator` saga handler now falls back to the language's `defaultProgram` when the selected evaluator doesn't specify its own, so a fresh Playground load (no share link/history) shows a language-appropriate starter program instead of the hard-wired, JS-flavoured `// Type your program in here!`.
- Existing "don't clobber user code" guard is preserved: the default is only applied while the editor tab still holds the untouched `defaultEditorValue` sentinel.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn eslint src/commons/sagas/LanguageDirectorySaga.ts src/pages/playground/Playground.test.tsx`
- [x] `yarn vitest run src/commons/sagas/WorkspaceSaga.test.ts src/commons/sagas/BackendSaga.test.ts src/pages/playground/Playground.test.tsx` — updated `Playground.test.tsx`'s "no history" assertion, since the bundled directory's first language (Python §1) now correctly supplies `# Type your program in here!\n\n` instead of the generic JS default.

https://claude.ai/code/session_01PgNkhgJHhkRapqxhfF9uXS