### PR TITLE
Bump language-directory to 0.0.23; drop evaluator-level defaultProgram fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/common-tabs": "^0.0.1",
     "@sourceacademy/conductor": "^0.8.3",
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.22",
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.23",
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.4",
     "@sourceacademy/runner-module-loader": "^0.1.0",
     "@sourceacademy/sharedb-ace": "2.1.1",

--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -80,16 +80,16 @@ const languageDirectoryHandlers = combineSagaHandlers({
     const evaluator = yield call(getEvaluatorDefinitionSaga);
     const language: ILanguageDefinition = yield call(getLanguageDefinitionSaga);
 
-    // Set the default editor program when switching evaluators, preferring the evaluator's own
-    // default and falling back to the language's, but only while the editor still holds the
-    // untouched default (never clobber code the user has written).
-    const defaultProgram = evaluator?.defaultProgram ?? language?.defaultProgram;
-    if (defaultProgram != null) {
+    // Set the language's default editor program when switching evaluators, but only while the
+    // editor still holds the untouched default (never clobber code the user has written).
+    if (language?.defaultProgram != null) {
       const playground = yield select((state: OverallState) => state.workspaces.playground);
       const activeTabIndex: number = playground.activeEditorTabIndex ?? 0;
       const editorValue: string = playground.editorTabs[activeTabIndex]?.value ?? '';
       if (editorValue === defaultEditorValue) {
-        yield put(WorkspaceActions.updateEditorValue('playground', activeTabIndex, defaultProgram));
+        yield put(
+          WorkspaceActions.updateEditorValue('playground', activeTabIndex, language.defaultProgram),
+        );
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4268,10 +4268,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.22":
-  version: 0.0.22
-  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=bd2198d2fa9d2311dea5b8cf200937c9b80f857e"
-  checksum: 10c0/c153c3c0eb0c449ec323c4e2d95b29614724cb04192a31479bfaae641839959285a27d546385b25ff52c90c9d598a16ae39adbfb0476d7fa40efffd59b93784c
+"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.23":
+  version: 0.0.23
+  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=0647ccbff31cbff834d2e3350cc6a339c2e8d907"
+  checksum: 10c0/3063018f8b8911b795093664cc897a39cf53c5e0a8669a84a92bb8f6e36798b4a9de9b947856fc24c58b515fce145844598e60c366d0ae6014585613f3ff7d59
   languageName: node
   linkType: hard
 
@@ -8611,7 +8611,7 @@ __metadata:
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/common-tabs": "npm:^0.0.1"
     "@sourceacademy/conductor": "npm:^0.8.3"
-    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.22"
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.23"
     "@sourceacademy/plugin-directory": "https://github.com/source-academy/plugin-directory.git#0.0.4"
     "@sourceacademy/runner-module-loader": "npm:^0.1.0"
     "@sourceacademy/sharedb-ace": "npm:2.1.1"


### PR DESCRIPTION
## Summary

Follow-up to #4279, which was squash-merged before these two commits were pushed to that PR's branch — they never made it into `master`. Re-submitting them here against current `master`.

- Drops the `evaluator?.defaultProgram` fallback from `LanguageDirectorySaga`'s `setSelectedEvaluator` handler, now that the language-level `defaultProgram` (already in `master` via #4279) covers every language on its own.
- Bumps `@sourceacademy/language-directory` to `0.0.23` (source-academy/language-directory#59), which removes the now-unused evaluator-level `defaultProgram` field and its use on `python3`/`python4`'s CSE/Py2js evaluators.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn vitest run src/commons/sagas/WorkspaceSaga.test.ts src/commons/sagas/BackendSaga.test.ts src/pages/playground/Playground.test.tsx`

https://claude.ai/code/session_01PgNkhgJHhkRapqxhfF9uXS