### PR TITLE
Change build status badge to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Source Academy Frontend
 
-[![Build Status](https://travis-ci.org/source-academy/frontend.svg?branch=master)](https://travis-ci.org/source-academy/frontend)
+[![Build Status](https://github.com/source-academy/frontend/actions/workflows/build-development.yml/badge.svg)](https://github.com/source-academy/frontend/actions)
 [![Coverage Status](https://coveralls.io/repos/github/source-academy/frontend/badge.svg?branch=master)](https://coveralls.io/github/source-academy/frontend?branch=master)
 [![License](https://img.shields.io/github/license/source-academy/frontend)](https://github.com/source-academy/frontend/blob/master/LICENSE)
 


### PR DESCRIPTION
### Description

Updated build status badge to GitHub Actions in the README. I don't think we use Travis CI anymore
(Also, is the issue with the `canvas` Node module still present on M1 and M2 chips, and does it apply to all M-series chips?)

### Checklist

- [x] I have updated the documentation
