### PR TITLE
Exclude prepend from Conductor testcase error line numbers

### DIFF
--- a/src/commons/sagas/WorkspaceSaga.test.ts
+++ b/src/commons/sagas/WorkspaceSaga.test.ts
@@ -1175,6 +1175,108 @@ describe('EVAL_TESTCASE under Conductor (runTestCaseConductor)', () => {
       })
       .silentRun();
   });
+
+  test('excludes prepend from a Conductor testcase error location (source-academy/frontend#4244)', () => {
+    const context = createContext();
+    // Two lines, so combinedCode's own line 3 is `editorValue`'s line 1 - see
+    // runTestCaseConductor's combinedCode, which joins prepend/value/.../testcase with '\n'.
+    const twoLinePrepend = 'COUNTER = 0\nDOUBLE = 2';
+    const errors: SourceError[] = [
+      {
+        type: ErrorType.RUNTIME,
+        severity: 'Error' as any,
+        location: { start: { line: 3, column: 2 }, end: { line: 3, column: 2 } },
+        explain: () => 'boom',
+        elaborate: () => '',
+      },
+    ];
+    let capturedErrors: SourceError[] | undefined;
+
+    return expectSaga(
+      runTestCaseConductor,
+      workspaceLocation,
+      testcaseId,
+      editorValue,
+      testcaseProgram,
+      TestcaseTypes.public,
+      twoLinePrepend,
+      programPostpendValue,
+      execTime,
+    )
+      .withState(
+        generateDefaultState(workspaceLocation, {
+          context,
+          output: [{ type: 'errors', errors } as any],
+        }),
+      )
+      .provide([
+        [matchers.call.fn(evalCodeSaga), undefined],
+        {
+          put(effect, next) {
+            if (effect.action.type === InterpreterActions.evalTestcaseFailure.type) {
+              capturedErrors = effect.action.payload.value;
+            }
+            return next();
+          },
+        },
+      ])
+      .silentRun()
+      .then(() => {
+        expect(capturedErrors).toHaveLength(1);
+        // Reported as line 1 of the student's own code, not line 3 of the prepend-inclusive
+        // combined file.
+        expect(capturedErrors![0].location.start.line).toBe(1);
+        expect(capturedErrors![0].location.end.line).toBe(1);
+      });
+  });
+
+  test('leaves a Conductor testcase error with no location info (line 0) unshifted', () => {
+    const context = createContext();
+    const errors: SourceError[] = [
+      {
+        type: ErrorType.RUNTIME,
+        severity: 'Error' as any,
+        location: { start: { line: 0, column: 0 }, end: { line: 0, column: 0 } },
+        explain: () => 'boom',
+        elaborate: () => '',
+      },
+    ];
+    let capturedErrors: SourceError[] | undefined;
+
+    return expectSaga(
+      runTestCaseConductor,
+      workspaceLocation,
+      testcaseId,
+      editorValue,
+      testcaseProgram,
+      TestcaseTypes.public,
+      programPrependValue,
+      programPostpendValue,
+      execTime,
+    )
+      .withState(
+        generateDefaultState(workspaceLocation, {
+          context,
+          output: [{ type: 'errors', errors } as any],
+        }),
+      )
+      .provide([
+        [matchers.call.fn(evalCodeSaga), undefined],
+        {
+          put(effect, next) {
+            if (effect.action.type === InterpreterActions.evalTestcaseFailure.type) {
+              capturedErrors = effect.action.payload.value;
+            }
+            return next();
+          },
+        },
+      ])
+      .silentRun()
+      .then(() => {
+        expect(capturedErrors).toHaveLength(1);
+        expect(capturedErrors![0].location.start.line).toBe(0);
+      });
+  });
 });
 
 describe('CHAPTER_SELECT', () => {

--- a/src/commons/sagas/WorkspaceSaga/helpers/runTestCase.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/runTestCase.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'js-slang';
+import type { SourceError } from 'js-slang/dist/errors/base';
 import { random } from 'lodash-es';
 import { call, put, select, type StrictEffect } from 'redux-saga/effects';
 
@@ -46,6 +47,30 @@ import { restoreExtraMethods } from './restoreExtraMethods';
  * wrapped in a toReplString() so stringify() renders it verbatim instead of adding
  * the JSON-style quoting it'd otherwise apply to a plain string.
  */
+
+/**
+ * Shifts a Conductor-reported error's line numbers back by the number of prepend lines baked
+ * into runTestCaseConductor's combined file, mirroring evalCode.ts's toConductorSourceError -
+ * without this, an error in the student's own first line is reported at
+ * `prepend line count + 1` (source-academy/frontend#4244), same off-by-N bug, different call
+ * site: this saga concatenates prepend into the combined file itself (see runTestCaseConductor's
+ * own doc comment) rather than going through evalEditorSaga's Run-only concatenation, so
+ * evalCodeConductorSaga's own prepend-offset correction (gated on an editor Run's actionType)
+ * never applies here. A location's line of 0 means "no location info"
+ * (toConductorSourceError's own fallback for an error shape it doesn't recognise) and is left
+ * untouched rather than shifted into a misleadingly specific line 1.
+ */
+function shiftErrorLines(error: SourceError, lineOffset: number): SourceError {
+  const shift = (line: number) => (line > 0 ? Math.max(1, line - lineOffset) : line);
+  return {
+    ...error,
+    location: {
+      start: { ...error.location.start, line: shift(error.location.start.line) },
+      end: { ...error.location.end, line: shift(error.location.end.line) },
+    },
+  };
+}
+
 export function* runTestCaseConductor(
   workspaceLocation: WorkspaceLocation,
   index: number,
@@ -88,6 +113,9 @@ export function* runTestCaseConductor(
   const combinedCode = [prepend, value, studentSourceLiteral, postpend, testcase]
     .filter(part => part && part.trim().length > 0)
     .join('\n');
+  // Matches the filter above: an empty/whitespace-only prepend contributes no line to
+  // combinedCode at all, so it must not shift error line numbers either.
+  const prependLineOffset = prepend.trim().length > 0 ? prepend.split('\n').length : 0;
 
   yield put(actions.resetTestcase(workspaceLocation, index));
 
@@ -136,7 +164,10 @@ export function* runTestCaseConductor(
 
   let passed: boolean;
   if (lastOutput?.type === 'errors') {
-    yield put(actions.evalTestcaseFailure(lastOutput.errors, workspaceLocation, index));
+    const errors: SourceError[] = lastOutput.errors;
+    const correctedErrors =
+      prependLineOffset > 0 ? errors.map(error => shiftErrorLines(error, prependLineOffset)) : errors;
+    yield put(actions.evalTestcaseFailure(correctedErrors, workspaceLocation, index));
     passed = false;
   } else {
     // The testcase's own print(...) is the last line printed, since nothing runs

--- a/src/commons/sagas/WorkspaceSaga/helpers/runTestCase.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/runTestCase.ts
@@ -166,7 +166,9 @@ export function* runTestCaseConductor(
   if (lastOutput?.type === 'errors') {
     const errors: SourceError[] = lastOutput.errors;
     const correctedErrors =
-      prependLineOffset > 0 ? errors.map(error => shiftErrorLines(error, prependLineOffset)) : errors;
+      prependLineOffset > 0
+        ? errors.map(error => shiftErrorLines(error, prependLineOffset))
+        : errors;
     yield put(actions.evalTestcaseFailure(correctedErrors, workspaceLocation, index));
     passed = false;
   } else {


### PR DESCRIPTION
## Summary
- `runTestCaseConductor` concatenates `prepend`/student code/`postpend`/testcase into one combined file before sending it to the Conductor evaluator, but never subtracted the prepend's line count back out of a resulting error's reported line - so an error on the student's own first line was reported at `prepend line count + 1`.
- This is the same off-by-N bug #4244/#4245 fixed for the plain Run path (`evalCode.ts`'s `toConductorSourceError`/`preludeLineOffset`), but that fix doesn't reach this call site: it's gated on an editor Run's `actionType`, and `runTestCaseConductor` calls `evalCodeSaga` with `EVAL_SILENT` instead. Testcase/grading errors in assessments were still shifted.
- Shifts the line back out locally in `runTestCase.ts`, using the same `prepend` value this saga already concatenates into the combined file. A location's line of `0` (toConductorSourceError's "no location info" fallback) is left untouched rather than shifted into a misleading line `1`.

## Test plan
- [x] Added a test asserting a testcase error's line number is corrected back to the student's own line (multi-line prepend case).
- [x] Added a test asserting a line-`0` (unknown location) error is left unshifted.
- [x] `yarn test src/commons/sagas/WorkspaceSaga.test.ts` - 69 passed.
- [x] `yarn eslint` on changed files - clean.
- [x] `tsc --noEmit` - clean.

https://claude.ai/code/session_01FYm9pttcp3nixtDLKiPh2k