### PR TITLE
Disable autosave triggering for finalised or due assessments 

### DIFF
--- a/src/commons/assessment/Assessment.tsx
+++ b/src/commons/assessment/Assessment.tsx
@@ -17,6 +17,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Navigate, useLoaderData, useParams } from 'react-router';
 import { useAppDispatch } from 'src/commons/utils/Hooks';
 import { numberRegExp } from 'src/features/academy/AcademyTypes';
+import { canSaveAssessment } from 'src/features/assessments/AssessmentUtils';
 import Messages, { sendToWebview } from 'src/features/vscode/messages';
 
 import SessionActions from '../application/actions/SessionActions';
@@ -134,9 +135,7 @@ function Assessment() {
       questionId,
       notAttempted,
       needsPassword: !!overview.private && notAttempted,
-      canSave:
-        role !== Role.Student ||
-        (overview.status !== AssessmentStatuses.submitted && !beforeNow(overview.closeAt)),
+      canSave: canSaveAssessment(role, overview),
       assessmentConfiguration: assessmentConfigToLoad,
       fromContestLeaderboard: fromLeaderboard,
     };

--- a/src/commons/sagas/WorkspaceSaga/helpers/versionHistory.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/versionHistory.ts
@@ -14,9 +14,10 @@ import { getVersionCode, getVersionHistory, updateVersionName } from '../../Requ
 /**
  * Checks whether autosave is enabled for the current assessment workspace.
  * Defaults to false if the config cannot be found.
- * Defaults to true for assessments created before feature implementation
+ * Defaults to true for assessments created before feature implementation.
+ * Also disabled once the student can no longer save (finalised/closed).
  */
-function* isAutosaveEnabledForCurrentAssessment(): SagaIterator<boolean> {
+function* shouldAutoSaveCurrentAssessment(): SagaIterator<boolean> {
   return yield select((state: OverallState) => {
     const assessmentId = state.workspaces.assessment.currentAssessment;
     if (assessmentId === undefined) {
@@ -26,7 +27,7 @@ function* isAutosaveEnabledForCurrentAssessment(): SagaIterator<boolean> {
     if (!overview) {
       return false;
     }
-    return overview.isAutosaveEnabled ?? true;
+    return (overview.isAutosaveEnabled ?? true) && canSaveAssessment(state.session.role, overview);
   });
 }
 
@@ -203,7 +204,7 @@ export function* restoreVersionSaga(
     return overview ? overview.maxTeamSize !== 1 : false;
   });
 
-  const autosaveEnabled: boolean = yield call(isAutosaveEnabledForCurrentAssessment);
+  const autosaveEnabled: boolean = yield call(shouldAutoSaveCurrentAssessment);
 
   if (isTeamAssessment || !autosaveEnabled) {
     // For team assessments, dont submit
@@ -265,22 +266,8 @@ function* performAutoSave(workspaceLocation: WorkspaceLocation): SagaIterator {
   }
 
   // Skip auto-save if autosave is disabled for this assessment
-  const autosaveEnabled: boolean = yield call(isAutosaveEnabledForCurrentAssessment);
+  const autosaveEnabled: boolean = yield call(shouldAutoSaveCurrentAssessment);
   if (!autosaveEnabled) {
-    return false;
-  }
-
-  const canSave: boolean = yield select((state: OverallState) => {
-    const assessmentId = state.workspaces.assessment.currentAssessment;
-    if (assessmentId === undefined) {
-      return false;
-    }
-    const overview = state.session.assessmentOverviews?.find(o => o.id === assessmentId);
-    return overview ? canSaveAssessment(state.session.role, overview) : false;
-  });
-
-  // Disable auto-save if cannot save (i.e. finalised/closed)
-  if (!canSave) {
     return false;
   }
 
@@ -405,7 +392,7 @@ export function* watchAutoSave() {
       if (workspaceLocation !== 'assessment') {
         return;
       }
-      const autosaveEnabled: boolean = yield call(isAutosaveEnabledForCurrentAssessment);
+      const autosaveEnabled: boolean = yield call(shouldAutoSaveCurrentAssessment);
       if (!autosaveEnabled) {
         return;
       }
@@ -426,7 +413,7 @@ export function* watchSavingStatus() {
       if (workspaceLocation !== 'assessment') {
         return;
       }
-      const autosaveEnabled: boolean = yield call(isAutosaveEnabledForCurrentAssessment);
+      const autosaveEnabled: boolean = yield call(shouldAutoSaveCurrentAssessment);
       if (!autosaveEnabled) {
         return;
       }

--- a/src/commons/sagas/WorkspaceSaga/helpers/versionHistory.ts
+++ b/src/commons/sagas/WorkspaceSaga/helpers/versionHistory.ts
@@ -1,6 +1,7 @@
 import type { SagaIterator } from 'redux-saga';
 import { call, debounce, delay, put, race, select, take, takeEvery } from 'redux-saga/effects';
 
+import { canSaveAssessment } from '../../../../features/assessments/AssessmentUtils';
 import SessionActions from '../../../application/actions/SessionActions';
 import type { OverallState } from '../../../application/ApplicationTypes';
 import type { Tokens } from '../../../application/types/SessionTypes';
@@ -266,6 +267,20 @@ function* performAutoSave(workspaceLocation: WorkspaceLocation): SagaIterator {
   // Skip auto-save if autosave is disabled for this assessment
   const autosaveEnabled: boolean = yield call(isAutosaveEnabledForCurrentAssessment);
   if (!autosaveEnabled) {
+    return false;
+  }
+
+  const canSave: boolean = yield select((state: OverallState) => {
+    const assessmentId = state.workspaces.assessment.currentAssessment;
+    if (assessmentId === undefined) {
+      return false;
+    }
+    const overview = state.session.assessmentOverviews?.find(o => o.id === assessmentId);
+    return overview ? canSaveAssessment(state.session.role, overview) : false;
+  });
+
+  // Disable auto-save if cannot save (i.e. finalised/closed)
+  if (!canSave) {
     return false;
   }
 

--- a/src/features/assessments/AssessmentUtils.ts
+++ b/src/features/assessments/AssessmentUtils.ts
@@ -1,12 +1,27 @@
 import { stringify } from 'js-slang/dist/utils/stringify';
 
+import { Role } from '../../commons/application/ApplicationTypes';
 import {
+  type AssessmentOverview,
+  AssessmentStatuses,
   type IMCQQuestion,
   type Question,
   QuestionTypes,
   type Testcase,
 } from '../../commons/assessment/AssessmentTypes';
+import { beforeNow } from '../../commons/utils/DateHelper';
 import { showWarningMessage } from '../../commons/utils/notifications/NotificationsHelper';
+
+/**
+ * Whether the user may save answers: students cannot once the submission is finalised
+ * or past the close date; staff/admin always can.
+ */
+export const canSaveAssessment = (
+  role: Role | undefined,
+  overview: AssessmentOverview,
+): boolean =>
+  role !== Role.Student ||
+  (overview.status !== AssessmentStatuses.submitted && !beforeNow(overview.closeAt));
 
 /**
  * Returns a nullary function that defers the navigation of the browser window, until the

--- a/src/features/assessments/AssessmentUtils.ts
+++ b/src/features/assessments/AssessmentUtils.ts
@@ -16,10 +16,7 @@ import { showWarningMessage } from '../../commons/utils/notifications/Notificati
  * Whether the user may save answers: students cannot once the submission is finalised
  * or past the close date; staff/admin always can.
  */
-export const canSaveAssessment = (
-  role: Role | undefined,
-  overview: AssessmentOverview,
-): boolean =>
+export const canSaveAssessment = (role: Role | undefined, overview: AssessmentOverview): boolean =>
   role !== Role.Student ||
   (overview.status !== AssessmentStatuses.submitted && !beforeNow(overview.closeAt));
 


### PR DESCRIPTION
### Description

This PR attempts to fix the bug where the autosave indicator and autosave feature will still trigger if a student makes changes to an assessment after it has already been finalized or closed, and leading up to the 403 error seen.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code quality improvements

### How to test

Autosave should not longer spin and try to save the assessment when already finalized/past due for a student.

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
