### PR TITLE
Apply the course-configured default language in the Playground

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -513,6 +513,7 @@ export const defaultVscode: VscodeState = {
 export const defaultLanguageDirectory: LanguageDirectoryState = {
   selectedLanguageId: null,
   selectedEvaluatorId: null,
+  isDefaultSelection: true,
   languages: [],
   languageMap: {},
 };

--- a/src/commons/mocks/BackendMocks.ts
+++ b/src/commons/mocks/BackendMocks.ts
@@ -30,6 +30,7 @@ import type {
 import { routerNavigate } from '../sagas/BackendSaga';
 import { actions } from '../utils/ActionsHelper';
 import { showSuccessMessage, showWarningMessage } from '../utils/notifications/NotificationsHelper';
+import WorkspaceActions from '../workspace/WorkspaceActions';
 import {
   mockAssessmentConfigurations,
   mockAssessmentOverviews,
@@ -99,6 +100,23 @@ export function* mockBackendSaga(): SagaIterator {
     const courseConfiguration = { ...mockCourseConfigurations[0] };
     yield put(actions.setCourseConfiguration(courseConfiguration));
   });
+
+  // Mirrors BackendSaga's changeSublanguage handler (Ground Control's "Default language"
+  // selector), minus the network round-trip - lets that control be exercised against the mock
+  // backend instead of silently no-oping.
+  yield takeEvery(
+    WorkspaceActions.changeSublanguage.type,
+    function* (action: ReturnType<typeof WorkspaceActions.changeSublanguage>) {
+      const { sublang } = action.payload;
+      yield put(
+        actions.setCourseConfiguration({
+          sourceChapter: sublang.chapter,
+          sourceVariant: sublang.variant,
+        }),
+      );
+      yield call(showSuccessMessage, 'Updated successfully!', 1000);
+    },
+  );
 
   yield takeEvery(SessionActions.fetchAssessmentOverviews.type, function* () {
     yield put(actions.updateAssessmentOverviews([...mockAssessmentOverviews]));

--- a/src/commons/sagas/LanguageDirectorySaga.test.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.test.ts
@@ -106,6 +106,26 @@ describe('setCourseConfiguration', () => {
       .silentRun();
   });
 
+  test('falls back to the first directory entry when the newly-loaded course has no valid configured language', () => {
+    // Regression: previously this bailed out and left python2 (the prior course's language)
+    // selected, even though the selection was still marked as a default rather than something
+    // the user picked for this course.
+    return expectSaga(languageDirectoryHandlers)
+      .withState({
+        session: { sourceChapter: 99 },
+        featureFlags: conductorEnabledFlags,
+        languageDirectory: {
+          ...defaultLanguageDirectory,
+          languages,
+          selectedLanguageId: 'python2',
+          isDefaultSelection: true,
+        },
+      })
+      .put(LanguageDirectoryActions.setSelectedLanguage('python1', undefined, true))
+      .dispatch(SessionActions.setCourseConfiguration({ sourceChapter: 99 } as any))
+      .silentRun();
+  });
+
   test('does not clobber a deliberate selection the user already made', () => {
     return expectSaga(languageDirectoryHandlers)
       .withState({

--- a/src/commons/sagas/LanguageDirectorySaga.test.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.test.ts
@@ -1,6 +1,6 @@
 import type { ILanguageDefinition } from '@sourceacademy/language-directory/dist/types';
 import { expectSaga } from 'redux-saga-test-plan';
-import { describe, expect, test } from 'vitest';
+import { describe, test } from 'vitest';
 
 import LanguageDirectoryActions from '../../features/directory/LanguageDirectoryActions';
 import SessionActions from '../application/actions/SessionActions';

--- a/src/commons/sagas/LanguageDirectorySaga.test.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.test.ts
@@ -1,0 +1,137 @@
+import type { ILanguageDefinition } from '@sourceacademy/language-directory/dist/types';
+import { expectSaga } from 'redux-saga-test-plan';
+import { describe, expect, test } from 'vitest';
+
+import LanguageDirectoryActions from '../../features/directory/LanguageDirectoryActions';
+import SessionActions from '../application/actions/SessionActions';
+import { defaultLanguageDirectory } from '../application/ApplicationTypes';
+import { languageDirectoryHandlers } from './LanguageDirectorySaga';
+
+function makeMockLanguageDefinition(id: string, evaluatorIds: string[]): ILanguageDefinition {
+  return {
+    id,
+    name: id,
+    evaluators: evaluatorIds.map(evaluatorId => ({
+      id: evaluatorId,
+      name: evaluatorId,
+      path: `https://example.com/${evaluatorId}.js`,
+      capabilities: [],
+    })),
+  };
+}
+
+const languages = [
+  makeMockLanguageDefinition('python1', ['python1Py2js']),
+  makeMockLanguageDefinition('python2', ['python2Py2js']),
+  makeMockLanguageDefinition('python3', ['python3Py2js']),
+];
+
+const conductorEnabledFlags = { modifiedFlags: { 'conductor.enable': true } };
+
+describe('setLanguages', () => {
+  test('selects the course-configured default language, derived from sourceChapter, when Conductor is enabled', () => {
+    return expectSaga(languageDirectoryHandlers)
+      .withState({
+        session: { sourceChapter: 2 },
+        featureFlags: conductorEnabledFlags,
+        // A dispatched action's reducer runs before the saga middleware sees it, so by the time
+        // this handler's `select` executes, `state.languageDirectory.languages` already reflects
+        // the action being dispatched below - mirror that here rather than leaving it empty.
+        languageDirectory: { ...defaultLanguageDirectory, languages },
+      })
+      .put(LanguageDirectoryActions.setSelectedLanguage('python2', 'python2Py2js', true))
+      .dispatch(LanguageDirectoryActions.setLanguages(languages))
+      .silentRun();
+  });
+
+  test('falls back to the first directory entry when there is no course', () => {
+    return expectSaga(languageDirectoryHandlers)
+      .withState({
+        session: {},
+        featureFlags: conductorEnabledFlags,
+        languageDirectory: { ...defaultLanguageDirectory, languages },
+      })
+      .put(LanguageDirectoryActions.setSelectedLanguage('python1', undefined, true))
+      .dispatch(LanguageDirectoryActions.setLanguages(languages))
+      .silentRun();
+  });
+
+  test('falls back to the first directory entry when Conductor is disabled', () => {
+    return expectSaga(languageDirectoryHandlers)
+      .withState({
+        session: { sourceChapter: 2 },
+        featureFlags: { modifiedFlags: { 'conductor.enable': false } },
+        languageDirectory: { ...defaultLanguageDirectory, languages },
+      })
+      .put(LanguageDirectoryActions.setSelectedLanguage('python1', undefined, true))
+      .dispatch(LanguageDirectoryActions.setLanguages(languages))
+      .silentRun();
+  });
+
+  test('re-resolves a pending deliberate selection (e.g. a share link) instead of applying the course default', () => {
+    return expectSaga(languageDirectoryHandlers)
+      .withState({
+        session: { sourceChapter: 2 },
+        featureFlags: conductorEnabledFlags,
+        languageDirectory: {
+          ...defaultLanguageDirectory,
+          languages,
+          selectedLanguageId: 'python3',
+          isDefaultSelection: false,
+        },
+      })
+      .put(LanguageDirectoryActions.setSelectedLanguage('python3', undefined))
+      .dispatch(LanguageDirectoryActions.setLanguages(languages))
+      .silentRun();
+  });
+});
+
+describe('setCourseConfiguration', () => {
+  test('applies the newly-loaded course default when the directory is already loaded and the current selection is still a default', () => {
+    return expectSaga(languageDirectoryHandlers)
+      .withState({
+        // The session reducer runs before the saga sees this dispatch, so sourceChapter already
+        // reflects the setCourseConfiguration payload below by the time this handler's `select` runs.
+        session: { sourceChapter: 2 },
+        featureFlags: conductorEnabledFlags,
+        languageDirectory: {
+          ...defaultLanguageDirectory,
+          languages,
+          selectedLanguageId: 'python1',
+          isDefaultSelection: true,
+        },
+      })
+      .put(LanguageDirectoryActions.setSelectedLanguage('python2', 'python2Py2js', true))
+      .dispatch(SessionActions.setCourseConfiguration({ sourceChapter: 2 } as any))
+      .silentRun();
+  });
+
+  test('does not clobber a deliberate selection the user already made', () => {
+    return expectSaga(languageDirectoryHandlers)
+      .withState({
+        session: {},
+        featureFlags: conductorEnabledFlags,
+        languageDirectory: {
+          ...defaultLanguageDirectory,
+          languages,
+          selectedLanguageId: 'python3',
+          isDefaultSelection: false,
+        },
+      })
+      .not.put.actionType(LanguageDirectoryActions.setSelectedLanguage.type)
+      .dispatch(SessionActions.setCourseConfiguration({ sourceChapter: 2 } as any))
+      .silentRun();
+  });
+
+  test('does nothing when the directory has not loaded yet (setLanguages will apply the default itself)', () => {
+    return expectSaga(languageDirectoryHandlers)
+      .withState({
+        session: {},
+        featureFlags: conductorEnabledFlags,
+        languageDirectory: defaultLanguageDirectory,
+      })
+      .not.put.actionType(LanguageDirectoryActions.setSelectedLanguage.type)
+      .dispatch(SessionActions.setCourseConfiguration({ sourceChapter: 2 } as any))
+      .silentRun();
+  });
+});

--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -11,8 +11,10 @@ import {
   selectDirectoryLanguageUrl,
 } from 'src/features/directory/flagDirectoryLanguageUrl';
 
+import { deriveLanguageFromChapter } from '../../features/directory/chapterLanguage';
 import LanguageDirectoryActions from '../../features/directory/LanguageDirectoryActions';
 import type { LanguageDirectoryState } from '../../features/directory/LanguageDirectoryTypes';
+import SessionActions from '../application/actions/SessionActions';
 import type { OverallState } from '../application/ApplicationTypes';
 import { defaultEditorValue } from '../application/ApplicationTypes';
 import { combineSagaHandlers } from '../redux/utils';
@@ -43,9 +45,34 @@ export function* getEvaluatorDefinitionSaga() {
   return getEvaluatorDefinition(language, directory.selectedEvaluatorId);
 }
 
-const languageDirectoryHandlers = combineSagaHandlers({
+/**
+ * The language the current course configures as its default, or `undefined` when there is no course
+ * (logged out), the course predates Conductor, or its `sourceChapter` doesn't name a directory entry.
+ *
+ * Course config stores this as `sourceChapter`, which under Conductor is a 1-based index into the
+ * directory rather than a Source chapter — see `deriveLanguageFromChapter`. Admins set it through
+ * Ground Control's "Default language" selector.
+ */
+export function* getCourseDefaultSelectionSaga() {
+  const conductorEnabled: boolean = yield select(selectConductorEnable);
+  if (!conductorEnabled) {
+    // The legacy path drives the language off `playgroundSourceChapter` instead.
+    return undefined;
+  }
+  const languages: ILanguageDefinition[] = yield select(
+    (state: OverallState) => state.languageDirectory.languages,
+  );
+  const sourceChapter: number | undefined = yield select(
+    (state: OverallState) => state.session.sourceChapter,
+  );
+  return deriveLanguageFromChapter(languages, sourceChapter);
+}
+
+export const languageDirectoryHandlers = combineSagaHandlers({
   [LanguageDirectoryActions.setLanguages.type]: function* () {
-    const directory = yield select((state: OverallState) => state.languageDirectory);
+    const directory: LanguageDirectoryState = yield select(
+      (state: OverallState) => state.languageDirectory,
+    );
     if (directory.languages.length === 0) {
       return;
     }
@@ -54,11 +81,48 @@ const languageDirectoryHandlers = combineSagaHandlers({
     // the setSelectedLanguage handler below couldn't resolve it and bailed out early. Re-run
     // that same selection now that the directory is populated, instead of unconditionally
     // overwriting it with the first language.
-    const languageId = directory.selectedLanguageId ?? directory.languages[0].id;
+    if (directory.selectedLanguageId && !directory.isDefaultSelection) {
+      yield put(
+        LanguageDirectoryActions.setSelectedLanguage(
+          directory.selectedLanguageId,
+          directory.selectedEvaluatorId ?? undefined,
+        ),
+      );
+      return;
+    }
+    // No deliberate selection is pending, so (re-)apply the default: the current course's
+    // configured language if one exists and the session has already loaded, otherwise the first
+    // directory entry. If the course config arrives later, its handler below re-applies this -
+    // `isDefaultSelection` stays true until something deliberate overrides it.
+    const courseDefault: { languageId: string; evaluatorId: string } | undefined = yield call(
+      getCourseDefaultSelectionSaga,
+    );
+    const languageId = courseDefault?.languageId ?? directory.languages[0].id;
+    yield put(
+      LanguageDirectoryActions.setSelectedLanguage(languageId, courseDefault?.evaluatorId, true),
+    );
+  },
+  [SessionActions.setCourseConfiguration.type]: function* () {
+    const directory: LanguageDirectoryState = yield select(
+      (state: OverallState) => state.languageDirectory,
+    );
+    // The directory may not have loaded yet (setLanguages will apply the course default itself
+    // once it does), and a deliberate selection - the dropdown, a share link, an assessment - must
+    // never be clobbered by a course config that happens to arrive afterwards.
+    if (directory.languages.length === 0 || !directory.isDefaultSelection) {
+      return;
+    }
+    const courseDefault: { languageId: string; evaluatorId: string } | undefined = yield call(
+      getCourseDefaultSelectionSaga,
+    );
+    if (!courseDefault) {
+      return;
+    }
     yield put(
       LanguageDirectoryActions.setSelectedLanguage(
-        languageId,
-        directory.selectedEvaluatorId ?? undefined,
+        courseDefault.languageId,
+        courseDefault.evaluatorId,
+        true,
       ),
     );
   },

--- a/src/commons/sagas/LanguageDirectorySaga.ts
+++ b/src/commons/sagas/LanguageDirectorySaga.ts
@@ -68,6 +68,24 @@ export function* getCourseDefaultSelectionSaga() {
   return deriveLanguageFromChapter(languages, sourceChapter);
 }
 
+/**
+ * Applies the default selection for `directory`: the course's configured language if one exists,
+ * otherwise the first directory entry. Callers must ensure `directory.languages` is non-empty.
+ *
+ * Always dispatches - including when there's no course default - so that a course whose
+ * `sourceChapter` doesn't resolve to a directory entry (no course, or a stale/out-of-range value)
+ * still lands on a valid selection instead of leaving a previous course's language selected.
+ */
+function* applyDefaultSelectionSaga(directory: Pick<LanguageDirectoryState, 'languages'>) {
+  const courseDefault: { languageId: string; evaluatorId: string } | undefined = yield call(
+    getCourseDefaultSelectionSaga,
+  );
+  const languageId = courseDefault?.languageId ?? directory.languages[0].id;
+  yield put(
+    LanguageDirectoryActions.setSelectedLanguage(languageId, courseDefault?.evaluatorId, true),
+  );
+}
+
 export const languageDirectoryHandlers = combineSagaHandlers({
   [LanguageDirectoryActions.setLanguages.type]: function* () {
     const directory: LanguageDirectoryState = yield select(
@@ -94,13 +112,7 @@ export const languageDirectoryHandlers = combineSagaHandlers({
     // configured language if one exists and the session has already loaded, otherwise the first
     // directory entry. If the course config arrives later, its handler below re-applies this -
     // `isDefaultSelection` stays true until something deliberate overrides it.
-    const courseDefault: { languageId: string; evaluatorId: string } | undefined = yield call(
-      getCourseDefaultSelectionSaga,
-    );
-    const languageId = courseDefault?.languageId ?? directory.languages[0].id;
-    yield put(
-      LanguageDirectoryActions.setSelectedLanguage(languageId, courseDefault?.evaluatorId, true),
-    );
+    yield call(applyDefaultSelectionSaga, directory);
   },
   [SessionActions.setCourseConfiguration.type]: function* () {
     const directory: LanguageDirectoryState = yield select(
@@ -112,19 +124,10 @@ export const languageDirectoryHandlers = combineSagaHandlers({
     if (directory.languages.length === 0 || !directory.isDefaultSelection) {
       return;
     }
-    const courseDefault: { languageId: string; evaluatorId: string } | undefined = yield call(
-      getCourseDefaultSelectionSaga,
-    );
-    if (!courseDefault) {
-      return;
-    }
-    yield put(
-      LanguageDirectoryActions.setSelectedLanguage(
-        courseDefault.languageId,
-        courseDefault.evaluatorId,
-        true,
-      ),
-    );
+    // Re-apply the default even if the new course has no valid configured language (a stale or
+    // out-of-range sourceChapter): otherwise the previous course's language would stay selected,
+    // even though it's still marked as a default rather than something the user chose here.
+    yield call(applyDefaultSelectionSaga, directory);
   },
   [LanguageDirectoryActions.fetchLanguages.type]: function* () {
     const url: string = yield select(selectDirectoryLanguageUrl);

--- a/src/features/directory/LanguageDirectoryActions.ts
+++ b/src/features/directory/LanguageDirectoryActions.ts
@@ -7,8 +7,18 @@ const LanguageDirectoryActions = createActions('directory/languages', {
   fetchLanguages: null,
   /** Set languages list */
   setLanguages: (languages: ILanguageDefinition[]) => ({ languages }),
-  /** Set selected language; evaluatorId optional (defaults to first available) */
-  setSelectedLanguage: (languageId: string, evaluatorId?: string) => ({ languageId, evaluatorId }),
+  /**
+   * Set selected language; evaluatorId optional (defaults to first available).
+   *
+   * `isDefault` marks the selection as a default that a later default may replace (see
+   * `LanguageDirectoryState.isDefaultSelection`). Callers acting on a deliberate choice — the
+   * language dropdown, a share link, a textbook route, an assessment — leave it unset.
+   */
+  setSelectedLanguage: (languageId: string, evaluatorId?: string, isDefault: boolean = false) => ({
+    languageId,
+    evaluatorId,
+    isDefault,
+  }),
   /** Set selected evaluator explicitly */
   setSelectedEvaluator: (evaluatorId: string) => ({ evaluatorId }),
   /** Clear the selected language and evaluator, falling back to js-slang */

--- a/src/features/directory/LanguageDirectoryReducer.ts
+++ b/src/features/directory/LanguageDirectoryReducer.ts
@@ -15,6 +15,7 @@ export const LanguageDirectoryReducer: Reducer<LanguageDirectoryState, SourceAct
       })
       .addCase(Actions.setSelectedLanguage, (state, action) => {
         state.selectedLanguageId = action.payload.languageId;
+        state.isDefaultSelection = action.payload.isDefault;
         if (action.payload.evaluatorId) {
           state.selectedEvaluatorId = action.payload.evaluatorId;
         }
@@ -25,5 +26,6 @@ export const LanguageDirectoryReducer: Reducer<LanguageDirectoryState, SourceAct
       .addCase(Actions.clearSelectedLanguage, state => {
         state.selectedLanguageId = null;
         state.selectedEvaluatorId = null;
+        state.isDefaultSelection = true;
       });
   });

--- a/src/features/directory/LanguageDirectoryTypes.ts
+++ b/src/features/directory/LanguageDirectoryTypes.ts
@@ -3,6 +3,16 @@ import type { ILanguageDefinition } from '@sourceacademy/language-directory/dist
 export type LanguageDirectoryState = {
   readonly selectedLanguageId: string | null;
   readonly selectedEvaluatorId: string | null;
+  /**
+   * Whether the current selection was applied as a *default* (the course's configured language, or
+   * the first directory entry when there is no course) rather than chosen deliberately — by the
+   * language dropdown, a share link, a textbook route, or an assessment.
+   *
+   * Only a default may be replaced by another default. Without this, a course configuration
+   * arriving after the directory has loaded — a slow `fetchUserAndCourse`, or an admin changing the
+   * course default in Ground Control — would overwrite a language the user had just picked.
+   */
+  readonly isDefaultSelection: boolean;
   readonly languages: ILanguageDefinition[];
   readonly languageMap: Record<string, ILanguageDefinition>;
 };

--- a/src/pages/playground/Playground.tsx
+++ b/src/pages/playground/Playground.tsx
@@ -270,6 +270,11 @@ function Playground(props: PlaygroundProps) {
     googleUser: persistenceUser,
     githubOctokitObject,
   } = useAppSelector(state => state.session);
+  // When the Conductor framework is enabled, LanguageDirectorySaga applies the course's configured
+  // default language itself (see setCourseConfiguration/setLanguages handlers), so the legacy
+  // chapter/variant path below must not also apply it - `getLanguageConfig` has no entries for
+  // languages 5+ (Python Full, Scheme) and throws for them.
+  const conductorEnabled = useAppSelector(selectConductorEnable);
 
   const dispatch = useAppDispatch();
   const {
@@ -368,8 +373,13 @@ function Playground(props: PlaygroundProps) {
 
   useEffect(() => {
     if (!hash) {
-      // If not a accessing via shared link, use the Source chapter and variant in the current course
-      if (courseSourceChapter && courseSourceVariant) {
+      // Under Conductor, LanguageDirectorySaga applies the course's configured default language
+      // itself (driven off the same courseSourceChapter, reinterpreted as a directory index - see
+      // getCourseDefaultSelectionSaga), so this legacy path must stand down: courseSourceChapter
+      // values above Source §4 (Python Full, Scheme) have no `getLanguageConfig` match and throw,
+      // and even for §1-4 this would resolve the wrong sublanguage (Source's, not the directory's).
+      if (!conductorEnabled && courseSourceChapter && courseSourceVariant) {
+        // If not a accessing via shared link, use the Source chapter and variant in the current course
         handleChapterSelect(courseSourceChapter, courseSourceVariant);
         // TODO: To migrate the state logic away from playgroundSourceChapter
         //       and playgroundSourceVariant into the language config instead
@@ -388,6 +398,7 @@ function Playground(props: PlaygroundProps) {
     dispatch,
     fileSystem,
     hash,
+    conductorEnabled,
     courseSourceChapter,
     courseSourceVariant,
     workspaceLocation,
@@ -540,9 +551,9 @@ function Playground(props: PlaygroundProps) {
     ],
   );
 
-  // When the Conductor framework is enabled, the stepper (and other tools) are provided by web
-  // plugins loaded dynamically, so the legacy in-frontend tabs are hidden in favour of plugin tabs.
-  const conductorEnabled = useAppSelector(selectConductorEnable);
+  // conductorEnabled is read earlier (see its declaration above) - when true, the stepper (and
+  // other tools) are provided by web plugins loaded dynamically, so the legacy in-frontend tabs
+  // are hidden in favour of plugin tabs.
 
   const clearButton = useMemo(
     () =>


### PR DESCRIPTION
## Summary

- Ground Control's **"Default language"** selector already persisted a course's default sublanguage (`source_chapter`), but nothing under Conductor ever read it back — the Playground always fell back to the first language directory entry, so admins changing the default had no visible effect. Confirmed by hand: setting the course default to Python §2 in Ground Control produced no change in the Playground.
- `LanguageDirectorySaga` now derives the course default from `source_chapter` (via the existing `deriveLanguageFromChapter`) and applies it whenever the directory or the course config load, in whichever order they arrive.
- A new `isDefaultSelection` flag on the `languageDirectory` slice stops a late course config from clobbering a language the user (or a share link, textbook route, or assessment) already picked deliberately.
- `Playground.tsx`'s legacy course-language effect is now gated off when Conductor is enabled — it duplicated this under Conductor and could throw for course chapters above Source §4 (Python Full, Scheme), which have no Source-chapter equivalent.

Closes #4336.

## Out of scope (tracked separately in #4336)

- New courses are still created with `sourceChapter: Chapter.SOURCE_1` (`DropdownCreateCourse.tsx`).
- A logged-out `/playground` has no course config to read, so it still falls back to the first directory entry — a deployment-level default is a separate, larger change (overlaps #4189).

## Test plan

- [x] `LanguageDirectorySaga.test.ts` (new): both load orderings apply the course default; a deliberate selection is never overwritten; Conductor-disabled and no-course cases fall back correctly.
- [x] `yarn tsc -b`, `yarn eslint`, `yarn oxfmt --list-different` all clean on the changed files.
- [x] Full `yarn test` run — 4 pre-existing failures unrelated to this diff (jsdom `localStorage` environment gap in `createStore.test.ts`, `localStorage.test.ts`, `ApplicationWrapper.test.tsx`, `_layout.test.tsx`; none of the touched files).
- [x] Manual verification against the frontend's mock backend (`REACT_APP_USE_BACKEND=FALSE`): confirmed the Playground picks up the course's configured default on load.
- [x] Added a mock handler for `changeSublanguage` (it was previously only wired into the real `BackendSaga`, so Ground Control's selector silently no-op'd under the mock backend) so the whole flow — Ground Control's dropdown through to the Playground — is exercisable locally without a real backend. Re-verification of that end-to-end path through the mock backend after adding the handler is in progress.
- [ ] Manual verification against a real backend - not done, would appreciate a reviewer with one running confirming end-to-end.