### PR TITLE
Update team page for 2026 leadership (Spell)

### DIFF
--- a/src/pages/contributors/subcomponents/ContributorsDetails.tsx
+++ b/src/pages/contributors/subcomponents/ContributorsDetails.tsx
@@ -47,18 +47,6 @@ function ContributorsDetails() {
             <br />
             <strong>(Frontend and Plugins)</strong>
           </p>
-          {dot}
-          <p>
-            Boyd Anderson,
-            <br />
-            Martin Henz,
-            <br />
-            Low Kok Lim,
-            <br />
-            Sanka Rasnayaka
-            <br />
-            <strong>(Coordination)</strong>
-          </p>
         </div>
         <div className={classes['hallOfFame']}>
           <H5>

--- a/src/pages/contributors/subcomponents/ContributorsDetails.tsx
+++ b/src/pages/contributors/subcomponents/ContributorsDetails.tsx
@@ -13,59 +13,45 @@ function ContributorsDetails() {
         <p className={classes['description']}>
           The <i>Source Academy</i> is designed and developed by a team of students, most of whom
           have used the system to learn the fundamentals of computing and enjoyed it. This page
-          includes all developers who contributed to the Source Academy <i>Charm</i> (2025) and its
-          precursors <i>Strange</i> (2024), <i>Merlin</i> (2023), <i>Rook</i> (2022), <i>Knight</i>{' '}
-          (2020) and <i>Cadet</i> (2018). These versions succeeded Source Academy 2 (2017) and
-          ultimately the original Source Academy (2016).
+          includes all developers who contributed to the Source Academy <i>Spell</i> (2026) and its
+          precursors <i>Charm</i> (2025), <i>Strange</i> (2024), <i>Merlin</i> (2023), <i>Rook</i>{' '}
+          (2022), <i>Knight</i> (2020) and <i>Cadet</i> (2018). These versions succeeded Source
+          Academy 2 (2017) and ultimately the original Source Academy (2016).
         </p>
         <div className={classes['leadership']}>
           <H5>
             <strong>
-              <u>2025 Leadership (Charm)</u>
+              <u>2026 Leadership (Spell)</u>
             </strong>
           </H5>
           <p>
-            Richard Dominick
+            Zhang Yao
             <br />
             <strong>(CTO)</strong>
           </p>
           {dot}
           <p>
-            Zhang Yao
-            <br />
-            <strong>(Frontend)</strong>
-          </p>
-          {dot}
-          <p>
-            Gabriel Chang
+            Akshay Vemulapalli
             <br />
             <strong>(Backend)</strong>
           </p>
           {dot}
           <p>
-            Lee Hyung Woon
+            Aarav Malani
             <br />
-            <strong>(Game)</strong>
+            <strong>(Languages and Modules)</strong>
           </p>
           {dot}
           <p>
-            Kyriel Mortel Abad
+            Shrey Jain
             <br />
-            <strong>(Languages)</strong>
-          </p>
-          {dot}
-          <p>
-            Lee Yi
-            <br />
-            <strong>(Modules)</strong>
+            <strong>(Frontend and Plugins)</strong>
           </p>
           {dot}
           <p>
             Boyd Anderson,
             <br />
             Martin Henz,
-            <br />
-            Eldric Liew,
             <br />
             Low Kok Lim,
             <br />
@@ -354,6 +340,63 @@ function ContributorsDetails() {
             Lee Yi
             <br />
             <strong>(Modules)</strong>
+          </p>
+        </div>
+
+        <div className={classes['leadership']}>
+          <p className={classes['evenWider']}>
+            <strong>2025 Leadership (Charm)</strong>
+          </p>
+          <br />
+
+          <p>
+            Richard Dominick
+            <br />
+            <strong>(CTO)</strong>
+          </p>
+          {dot}
+          <p>
+            Zhang Yao
+            <br />
+            <strong>(Frontend)</strong>
+          </p>
+          {dot}
+          <p>
+            Gabriel Chang
+            <br />
+            <strong>(Backend)</strong>
+          </p>
+          {dot}
+          <p>
+            Lee Hyung Woon
+            <br />
+            <strong>(Game)</strong>
+          </p>
+          {dot}
+          <p>
+            Kyriel Mortel Abad
+            <br />
+            <strong>(Languages)</strong>
+          </p>
+          {dot}
+          <p>
+            Lee Yi
+            <br />
+            <strong>(Modules)</strong>
+          </p>
+          {dot}
+          <p>
+            Boyd Anderson,
+            <br />
+            Martin Henz,
+            <br />
+            Eldric Liew,
+            <br />
+            Low Kok Lim,
+            <br />
+            Sanka Rasnayaka
+            <br />
+            <strong>(Coordination)</strong>
           </p>
         </div>
         <div className={classes['contributors']}>

--- a/src/pages/contributors/subcomponents/ContributorsDetails.tsx
+++ b/src/pages/contributors/subcomponents/ContributorsDetails.tsx
@@ -47,6 +47,20 @@ function ContributorsDetails() {
             <br />
             <strong>(Frontend and Plugins)</strong>
           </p>
+          {dot}
+          <p>
+            Boyd Anderson,
+            <br />
+            Martin Henz,
+            <br />
+            Eldric Liew,
+            <br />
+            Low Kok Lim,
+            <br />
+            Sanka Rasnayaka
+            <br />
+            <strong>(Coordination)</strong>
+          </p>
         </div>
         <div className={classes['hallOfFame']}>
           <H5>
@@ -371,20 +385,6 @@ function ContributorsDetails() {
             Lee Yi
             <br />
             <strong>(Modules)</strong>
-          </p>
-          {dot}
-          <p>
-            Boyd Anderson,
-            <br />
-            Martin Henz,
-            <br />
-            Eldric Liew,
-            <br />
-            Low Kok Lim,
-            <br />
-            Sanka Rasnayaka
-            <br />
-            <strong>(Coordination)</strong>
           </p>
         </div>
         <div className={classes['contributors']}>


### PR DESCRIPTION
## Summary

- Replaces the active "2025 Leadership (Charm)" section on the [Team behind the Source Academy](https://sourceacademy.org/contributors) page with "2026 Leadership (Spell)":
  - Zhang Yao (CTO)
  - Akshay Vemulapalli (Backend)
  - Aarav Malani (Languages and Modules)
  - Shrey Jain (Frontend and Plugins)
  - Boyd Anderson, Martin Henz, Low Kok Lim, Sanka Rasnayaka (Coordination)
- No Game lead this year, so that role is dropped from the active section.
- The former 2025 Leadership (Charm) section moves to the end of the historical leadership blocks (after 2024), unchanged, in the same header/format the 2019-2024 blocks already use - mirrors exactly how the 2024→2025 transition was done last year (commit `94d5025a`, "Charm (#3086)").
- Updates the page's top description to name *Spell* (2026) as the current version and add *Charm* (2025) to the list of precursors.

## Test plan

- `yarn format:ci`, `yarn eslint`, and `yarn tsc --noEmit` all pass clean on the changed file.
- Started the dev server locally and confirmed `/contributors` compiles with 0 errors (only pre-existing, unrelated warnings in other files) and serves HTTP 200.
- Structural diff double-checked line-by-line against last year's equivalent commit to make sure the moved section's format (headings, `evenWider` class, role bolding, `{dot}` separators) matches the established convention exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYm9pttcp3nixtDLKiPh2k
